### PR TITLE
feat(frontend): migrate AlertsPanel + RcaPanel to TanStack Query v5

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.0.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "zustand": "^4.5.2"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,22 +1,30 @@
 /**
- * App shell — houses the new React components.
+ * App shell — houses the React components.
+ * Wraps everything in QueryClientProvider for TanStack Query.
  * Incremental migration: renders alongside the existing vanilla-JS index.html
  * by mounting into a dedicated <div id="root"> widget when embedded,
  * or as a full SPA when running `npm run dev`.
  */
 import React, { useState } from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { LiveProgressFeed } from './components/LiveProgressFeed'
 import { AlertsPanel } from './components/AlertsPanel'
 import { RcaPanel } from './components/RcaPanel'
 import { useStore } from './store'
 import { isLiveMode } from './api/client'
 
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: { retry: 1, staleTime: 10_000 },
+  },
+})
+
 type Tab = 'deploy' | 'alerts' | 'rca'
 
-export function App() {
+function AppShell() {
   const [tab, setTab] = useState<Tab>('deploy')
-  const deploymentId  = useStore((s) => s.deploymentId)
-  const clearEvents   = useStore((s) => s.clearDeployEvents)
+  const deploymentId = useStore((s) => s.deploymentId)
+  const clearEvents  = useStore((s) => s.clearDeployEvents)
 
   if (!isLiveMode()) {
     return (
@@ -44,12 +52,10 @@ export function App() {
       {tab === 'deploy' && (
         <section className="nd-panel">
           {deploymentId ? (
-            <>
-              <LiveProgressFeed
-                deploymentId={deploymentId}
-                onComplete={() => setTimeout(clearEvents, 5000)}
-              />
-            </>
+            <LiveProgressFeed
+              deploymentId={deploymentId}
+              onComplete={() => setTimeout(clearEvents, 5000)}
+            />
           ) : (
             <div className="nd-placeholder">
               No active deployment. Trigger a deploy from the main panel.
@@ -70,5 +76,13 @@ export function App() {
         </section>
       )}
     </div>
+  )
+}
+
+export function App() {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <AppShell />
+    </QueryClientProvider>
   )
 }

--- a/frontend/src/components/AlertsPanel.tsx
+++ b/frontend/src/components/AlertsPanel.tsx
@@ -1,10 +1,11 @@
 /**
  * AlertsPanel — displays live Prometheus alerts from /api/alerts.
- * Auto-refreshes every 30 s when backend is reachable.
+ * Uses TanStack Query for automatic 30 s polling (replaces useEffect + setInterval).
  */
-import React, { useEffect, useCallback } from 'react'
-import { fetchAlerts } from '@/api/client'
+import React from 'react'
+import { useAlerts } from '@/hooks/useAlerts'
 import { useStore, selectAlerts } from '@/store'
+import { isLiveMode } from '@/api/client'
 
 const SEVERITY_ICON: Record<string, string> = {
   critical: '🔴',
@@ -13,35 +14,53 @@ const SEVERITY_ICON: Record<string, string> = {
 }
 
 export function AlertsPanel() {
-  const alerts    = useStore(selectAlerts)
-  const setAlerts = useStore((s) => s.setAlerts)
+  const cachedAlerts = useStore(selectAlerts)
+  const { isLoading, isError, error, dataUpdatedAt, refetch } = useAlerts()
 
-  const refresh = useCallback(async () => {
-    try { setAlerts(await fetchAlerts()) }
-    catch { /* backend unreachable — keep stale data */ }
-  }, [setAlerts])
+  if (!isLiveMode()) {
+    return (
+      <div className="ap-empty">
+        ⚙️ Backend not configured — enable Live Mode in settings to see alerts.
+      </div>
+    )
+  }
 
-  useEffect(() => {
-    void refresh()
-    const id = setInterval(refresh, 30_000)
-    return () => clearInterval(id)
-  }, [refresh])
+  if (isLoading && cachedAlerts.length === 0) {
+    return <div className="ap-empty">⏳ Loading alerts…</div>
+  }
 
-  if (alerts.length === 0) {
+  if (isError && cachedAlerts.length === 0) {
+    return (
+      <div className="ap-error">
+        ❌ {error?.message ?? 'Failed to load alerts'}
+        {' '}
+        <button onClick={() => refetch()}>Retry</button>
+      </div>
+    )
+  }
+
+  if (cachedAlerts.length === 0) {
     return <div className="ap-empty">✅ No active alerts</div>
   }
 
   return (
-    <ul className="ap-list" role="list">
-      {alerts.map((a, i) => (
-        <li key={i} className={`ap-item ap-item-${a.severity}`}>
-          <span className="ap-icon">{SEVERITY_ICON[a.severity] ?? '⚪'}</span>
-          <span className="ap-host">{a.hostname}</span>
-          <span className="ap-check">{a.check}</span>
-          <span className="ap-msg">{a.message}</span>
-          <span className="ap-val">{a.metric_value.toFixed(2)}</span>
-        </li>
-      ))}
-    </ul>
+    <>
+      {dataUpdatedAt > 0 && (
+        <p className="ap-meta" style={{ fontSize: '0.75rem', opacity: 0.6 }}>
+          Updated {new Date(dataUpdatedAt).toLocaleTimeString()}
+        </p>
+      )}
+      <ul className="ap-list" role="list">
+        {cachedAlerts.map((a, i) => (
+          <li key={i} className={`ap-item ap-item-${a.severity}`}>
+            <span className="ap-icon">{SEVERITY_ICON[a.severity] ?? '⚪'}</span>
+            <span className="ap-host">{a.hostname}</span>
+            <span className="ap-check">{a.check}</span>
+            <span className="ap-msg">{a.message}</span>
+            <span className="ap-val">{a.metric_value.toFixed(2)}</span>
+          </li>
+        ))}
+      </ul>
+    </>
   )
 }

--- a/frontend/src/components/RcaPanel.tsx
+++ b/frontend/src/components/RcaPanel.tsx
@@ -1,9 +1,9 @@
 /**
  * RcaPanel — run hypothesis-based root cause analysis.
- * Submits to /api/rca/analyze and renders ranked hypotheses.
+ * Uses TanStack Query useMutation (replaces useState loading/error + try/catch).
  */
 import React, { useState } from 'react'
-import { runRca } from '@/api/client'
+import { useRunRca } from '@/hooks/useRca'
 import { useStore, selectRca } from '@/store'
 import type { RcaHypothesis } from '@/types'
 
@@ -61,26 +61,16 @@ function HypothesisCard({ h, rank }: { h: RcaHypothesis; rank: number }) {
 }
 
 export function RcaPanel() {
-  const results    = useStore(selectRca)
-  const setResults = useStore((s) => s.setRcaResults)
-  const [symptom, setSymptom]   = useState('')
-  const [devices, setDevices]   = useState('')
-  const [loading, setLoading]   = useState(false)
-  const [error, setError]       = useState<string | null>(null)
+  const results = useStore(selectRca)
+  const [symptom, setSymptom] = useState('')
+  const [devices, setDevices] = useState('')
+  const { mutate: analyze, isPending, isError, error, reset } = useRunRca()
 
-  async function handleSubmit(e: React.FormEvent) {
+  function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
     if (!symptom.trim()) return
-    setLoading(true)
-    setError(null)
-    try {
-      const affected = devices.split(',').map((s) => s.trim()).filter(Boolean)
-      setResults(await runRca(symptom.trim(), affected))
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'RCA failed')
-    } finally {
-      setLoading(false)
-    }
+    const affected = devices.split(',').map((s) => s.trim()).filter(Boolean)
+    analyze({ symptom: symptom.trim(), devices: affected })
   }
 
   return (
@@ -98,17 +88,28 @@ export function RcaPanel() {
           value={devices}
           onChange={(e) => setDevices(e.target.value)}
         />
-        <button className="rca-btn" type="submit" disabled={loading || !symptom.trim()}>
-          {loading ? '🔍 Analyzing…' : '🔍 Analyze'}
-        </button>
+        <div style={{ display: 'flex', gap: '0.5rem' }}>
+          <button className="rca-btn" type="submit" disabled={isPending || !symptom.trim()}>
+            {isPending ? '🔍 Analyzing…' : '🔍 Analyze'}
+          </button>
+          {(results.length > 0 || isError) && (
+            <button type="button" className="rca-btn" onClick={reset}>
+              Clear
+            </button>
+          )}
+        </div>
       </form>
 
-      {error && <div className="rca-error">❌ {error}</div>}
+      {isError && <div className="rca-error">❌ {error?.message ?? 'RCA failed'}</div>}
 
       {results.length > 0 && (
         <div className="rca-results">
-          <p className="rca-count">{results.length} hypothesis{results.length !== 1 ? 'es' : ''} found</p>
-          {results.map((h, i) => <HypothesisCard key={i} h={h} rank={i} />)}
+          <p className="rca-count">
+            {results.length} hypothesis{results.length !== 1 ? 'es' : ''} found
+          </p>
+          {results.map((h, i) => (
+            <HypothesisCard key={i} h={h} rank={i} />
+          ))}
         </div>
       )}
     </div>

--- a/frontend/src/hooks/useAlerts.ts
+++ b/frontend/src/hooks/useAlerts.ts
@@ -1,0 +1,18 @@
+import { useQuery } from '@tanstack/react-query'
+import { fetchAlerts, isLiveMode } from '@/api/client'
+import { useStore } from '@/store'
+
+export function useAlerts(enabled = true) {
+  const setAlerts = useStore((s) => s.setAlerts)
+
+  return useQuery({
+    queryKey: ['alerts'],
+    queryFn: async () => {
+      const data = await fetchAlerts()
+      setAlerts(data) // keep Zustand in sync for components that read the store directly
+      return data
+    },
+    refetchInterval: 30_000,
+    enabled: enabled && isLiveMode(),
+  })
+}

--- a/frontend/src/hooks/useRca.ts
+++ b/frontend/src/hooks/useRca.ts
@@ -1,0 +1,18 @@
+import { useMutation } from '@tanstack/react-query'
+import { runRca } from '@/api/client'
+import { useStore } from '@/store'
+import type { RcaHypothesis } from '@/types'
+
+interface RcaRequest {
+  symptom: string
+  devices: string[]
+}
+
+export function useRunRca() {
+  const setRcaResults = useStore((s) => s.setRcaResults)
+
+  return useMutation<RcaHypothesis[], Error, RcaRequest>({
+    mutationFn: ({ symptom, devices }) => runRca(symptom, devices),
+    onSuccess: (data) => setRcaResults(data),
+  })
+}


### PR DESCRIPTION
Closing — superseded by PR #23 (merged). That PR includes the full TanStack Query migration plus the complete React 19 wizard.