### PR TITLE
feat: light/dark theme toggle

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import { Sidebar } from '@/components/wizard/Sidebar'
 import { TroubleshootingEngine } from '@/components/TroubleshootingEngine'
 import { LandingPage } from '@/components/LandingPage'
 import { BackendToggle, BackendToggleProvider } from '@/components/BackendToggle'
+import { ThemeToggle } from '@/components/ui/ThemeToggle'
 import { useAppStore } from '@/store/useAppStore'
 import { Step1UseCase } from '@/pages/Step1UseCase'
 import { Step2Requirements } from '@/pages/Step2Requirements'
@@ -75,6 +76,12 @@ export default function App() {
   const [backendUrl, setBackendUrl] = useState('http://localhost:8000')
   const setStep = useAppStore(s => s.setStep)
   const step = useAppStore(s => s.step)
+  const theme = useAppStore(s => s.theme)
+
+  // Apply the light/dark theme to <html> so the CSS variable overrides kick in.
+  useEffect(() => {
+    document.documentElement.classList.toggle('light', theme === 'light')
+  }, [theme])
 
   // M-57: on mount, check for ?design= param and restore state
   useEffect(() => {
@@ -135,7 +142,8 @@ export default function App() {
                     <img src="/favicon.svg" alt="" className="w-5 h-5" />
                     <span className="font-bold text-white text-sm">NetDesign <span className="text-blue-400">AI</span></span>
                   </button>
-                  <div className="ml-auto">
+                  <div className="ml-auto flex items-center gap-2">
+                    <ThemeToggle compact />
                     <BackendToggle
                       isLive={isLive}
                       baseUrl={backendUrl}
@@ -148,7 +156,8 @@ export default function App() {
                 {/* Page content */}
                 <div className="flex-1 px-4 sm:px-6 py-4 sm:py-8">
                   {/* Desktop backend toggle — floating top-right, hidden on mobile */}
-                  <div className="hidden lg:block absolute top-4 right-6 z-40">
+                  <div className="hidden lg:flex items-center gap-2 absolute top-4 right-6 z-40">
+                    <ThemeToggle compact />
                     <BackendToggle
                       isLive={isLive}
                       baseUrl={backendUrl}

--- a/frontend/src/components/LandingPage.tsx
+++ b/frontend/src/components/LandingPage.tsx
@@ -1,4 +1,5 @@
 import { useAppStore } from '@/store/useAppStore'
+import { ThemeToggle } from '@/components/ui/ThemeToggle'
 
 interface Props {
   onStart: () => void
@@ -80,6 +81,7 @@ export function LandingPage({ onStart }: Props) {
             </div>
           </div>
           <div className="flex items-center gap-2">
+            <ThemeToggle compact />
             <button
               type="button"
               onClick={onStart}

--- a/frontend/src/components/ui/ThemeToggle.tsx
+++ b/frontend/src/components/ui/ThemeToggle.tsx
@@ -1,0 +1,46 @@
+import { useAppStore } from '@/store/useAppStore'
+
+interface Props {
+  /** Compact icon-only button (for tight headers). */
+  compact?: boolean
+  className?: string
+}
+
+/**
+ * Light / dark theme toggle. Flips useAppStore().theme; App applies the
+ * `light` class on <html>, which remaps the Tailwind color variables.
+ */
+export function ThemeToggle({ compact = false, className = '' }: Props) {
+  const theme = useAppStore(s => s.theme)
+  const toggleTheme = useAppStore(s => s.toggleTheme)
+  const isDark = theme === 'dark'
+
+  return (
+    <button
+      type="button"
+      onClick={toggleTheme}
+      aria-label={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
+      title={isDark ? 'Light mode' : 'Dark mode'}
+      className={[
+        'inline-flex items-center justify-center rounded-lg border transition-colors cursor-pointer',
+        'border-white/15 bg-white/5 text-gray-300 hover:text-blue-300 hover:border-blue-500/40 hover:bg-blue-500/10',
+        compact ? 'w-8 h-8' : 'gap-2 px-3 h-9 text-sm font-medium',
+        className,
+      ].join(' ')}
+    >
+      {isDark ? (
+        // Sun — click to go light
+        <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <circle cx="12" cy="12" r="4" />
+          <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41" />
+        </svg>
+      ) : (
+        // Moon — click to go dark
+        <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+        </svg>
+      )}
+      {!compact && <span>{isDark ? 'Light' : 'Dark'}</span>}
+    </button>
+  )
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -13,3 +13,92 @@ body {
 #root {
   min-height: 100vh;
 }
+
+/* ── Light mode overrides ────────────────────────────────────────────────────
+   Tailwind v4 solid utilities reference var(--color-*) so remapping them here
+   flips all bg-gray-*, text-gray-*, border-gray-* automatically.
+   Opacity utilities (bg-white/10 etc.) compile to literal hex — those need
+   explicit class overrides further below.
+──────────────────────────────────────────────────────────────────────────── */
+html.light {
+  color-scheme: light;
+
+  /* Invert the gray ramp (dark → light surface, light → dark text) */
+  --color-gray-950: #f8fafc;
+  --color-gray-900: #f1f5f9;
+  --color-gray-800: #e2e8f0;
+  --color-gray-700: #cbd5e1;
+  --color-gray-600: #94a3b8;
+  --color-gray-500: #64748b;
+  --color-gray-400: #475569;
+  --color-gray-300: #334155;
+  --color-gray-200: #1e293b;
+  --color-gray-100: #0f172a;
+  --color-gray-50:  #0a1628;
+
+  /* Remap white/black so text-white → near-black and bg-white → near-white */
+  --color-white: #0f172a;
+  --color-black: #ffffff;
+}
+
+html.light body {
+  background: #f8fafc;
+  color: #1e293b;
+}
+
+/* ── White-opacity utility overrides ────────────────────────────────────────
+   These compile to literal rgba(255,255,255,…) in the stylesheet so the CSS
+   variable remap above won't affect them. Override each class explicitly.
+──────────────────────────────────────────────────────────────────────────── */
+
+/* Backgrounds */
+html.light .bg-white\/\[0\.02\] { background-color: rgba(15,23,42,0.02); }
+html.light .bg-white\/\[0\.03\] { background-color: rgba(15,23,42,0.03); }
+html.light .bg-white\/5         { background-color: rgba(15,23,42,0.05); }
+html.light .bg-white\/8         { background-color: rgba(15,23,42,0.08); }
+html.light .bg-white\/10        { background-color: rgba(15,23,42,0.10); }
+html.light .bg-white\/15        { background-color: rgba(15,23,42,0.15); }
+html.light .bg-white\/20        { background-color: rgba(15,23,42,0.20); }
+
+/* Semi-transparent dark surface overlays */
+html.light .bg-gray-950\/95     { background-color: rgba(248,250,252,0.95); }
+html.light .bg-gray-950\/60     { background-color: rgba(248,250,252,0.60); }
+html.light .bg-gray-900\/95     { background-color: rgba(241,245,249,0.95); }
+html.light .bg-gray-900\/80     { background-color: rgba(241,245,249,0.80); }
+html.light .bg-gray-900\/60     { background-color: rgba(241,245,249,0.60); }
+html.light .bg-gray-800\/60     { background-color: rgba(226,232,240,0.60); }
+
+/* Borders */
+html.light .border-white\/5     { border-color: rgba(15,23,42,0.05); }
+html.light .border-white\/8     { border-color: rgba(15,23,42,0.08); }
+html.light .border-white\/10    { border-color: rgba(15,23,42,0.10); }
+html.light .border-white\/15    { border-color: rgba(15,23,42,0.15); }
+html.light .border-white\/20    { border-color: rgba(15,23,42,0.20); }
+html.light .border-white\/25    { border-color: rgba(15,23,42,0.25); }
+html.light .border-white\/30    { border-color: rgba(15,23,42,0.30); }
+
+/* Dividers */
+html.light .divide-white\/5 > :not([hidden]) ~ :not([hidden]) {
+  border-color: rgba(15,23,42,0.05);
+}
+
+/* Ring */
+html.light .ring-white\/10 { --tw-ring-color: rgba(15,23,42,0.10); }
+
+/* ── Blue accent — keep text legible on blue filled buttons in light mode ──── */
+html.light .bg-blue-600         { background-color: #2563eb; }
+html.light .bg-blue-500         { background-color: #3b82f6; }
+html.light .hover\:bg-blue-500:hover { background-color: #3b82f6; }
+html.light .text-blue-400       { color: #2563eb; }
+html.light .text-blue-300       { color: #1d4ed8; }
+
+/* Ensure white text stays on filled blue / green / red buttons */
+html.light .bg-blue-600.text-white,
+html.light .bg-blue-500.text-white,
+html.light .bg-green-600.text-white,
+html.light .bg-red-600.text-white    { color: #ffffff; }
+
+/* ── Scrollbar styling for light mode ──────────────────────────────────────── */
+html.light ::-webkit-scrollbar-track  { background: #f1f5f9; }
+html.light ::-webkit-scrollbar-thumb  { background: #cbd5e1; border-radius: 4px; }
+html.light ::-webkit-scrollbar-thumb:hover { background: #94a3b8; }

--- a/frontend/src/store/useAppStore.ts
+++ b/frontend/src/store/useAppStore.ts
@@ -30,6 +30,8 @@ interface AppStore extends AppState {
   // M-55
   setCustomPolicyRules: (rules: string) => void
   setActiveDeployTab: (tab: string) => void
+  setTheme: (theme: 'dark' | 'light') => void
+  toggleTheme: () => void
 
   // Step 2 setters — requirements
   setTrafficPattern: (p: TrafficPattern) => void
@@ -110,6 +112,7 @@ const DEFAULT_STATE: AppState = {
   primaryContact: '',
   customPolicyRules: '',
   activeDeployTab: 'deploy',
+  theme: 'dark',
   // Step 2 — Network Requirements
   trafficPattern: 'ew',
   totalEndpoints: 500,
@@ -164,6 +167,8 @@ export const useAppStore = create<AppStore>()(
       setPrimaryContact: primaryContact => set({ primaryContact }),
       setCustomPolicyRules: customPolicyRules => set({ customPolicyRules }),
       setActiveDeployTab: activeDeployTab => set({ activeDeployTab }),
+      setTheme: theme => set({ theme }),
+      toggleTheme: () => set(s => ({ theme: s.theme === 'dark' ? 'light' : 'dark' })),
 
       setTrafficPattern: trafficPattern => set({ trafficPattern }),
       setTotalEndpoints: totalEndpoints => set({ totalEndpoints }),

--- a/frontend/src/test/theme-toggle.test.tsx
+++ b/frontend/src/test/theme-toggle.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render, fireEvent, screen, cleanup } from '@testing-library/react'
+import { useEffect } from 'react'
+import { useAppStore } from '@/store/useAppStore'
+import { ThemeToggle } from '@/components/ui/ThemeToggle'
+
+// Mirror of the effect that App.tsx runs so we can assert the DOM side-effect
+// that actually drives the light-mode CSS variable overrides.
+function ThemeHost() {
+  const theme = useAppStore(s => s.theme)
+  useEffect(() => {
+    document.documentElement.classList.toggle('light', theme === 'light')
+  }, [theme])
+  return <ThemeToggle />
+}
+
+beforeEach(() => {
+  useAppStore.getState().reset()
+  document.documentElement.classList.remove('light')
+})
+
+afterEach(() => {
+  cleanup()
+  document.documentElement.classList.remove('light')
+})
+
+describe('ThemeToggle', () => {
+  it('defaults to dark theme with no light class on <html>', () => {
+    render(<ThemeHost />)
+    expect(useAppStore.getState().theme).toBe('dark')
+    expect(document.documentElement.classList.contains('light')).toBe(false)
+  })
+
+  it('shows "Switch to light mode" affordance while dark', () => {
+    render(<ThemeHost />)
+    expect(screen.getByRole('button', { name: /switch to light mode/i })).toBeInTheDocument()
+  })
+
+  it('clicking the toggle flips store theme to light and adds html.light', () => {
+    render(<ThemeHost />)
+    fireEvent.click(screen.getByRole('button'))
+    expect(useAppStore.getState().theme).toBe('light')
+    expect(document.documentElement.classList.contains('light')).toBe(true)
+  })
+
+  it('clicking again flips back to dark and removes html.light', () => {
+    render(<ThemeHost />)
+    const btn = screen.getByRole('button')
+    fireEvent.click(btn) // → light
+    fireEvent.click(btn) // → dark
+    expect(useAppStore.getState().theme).toBe('dark')
+    expect(document.documentElement.classList.contains('light')).toBe(false)
+  })
+
+  it('toggleTheme store action alternates deterministically', () => {
+    const { toggleTheme } = useAppStore.getState()
+    toggleTheme()
+    expect(useAppStore.getState().theme).toBe('light')
+    toggleTheme()
+    expect(useAppStore.getState().theme).toBe('dark')
+  })
+})

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -133,6 +133,8 @@ export interface AppState {
   customPolicyRules: string
   // Active deploy sub-tab
   activeDeployTab: string
+  // UI theme — light / dark mode
+  theme: 'dark' | 'light'
   // Step 2 — Network Requirements
   trafficPattern: TrafficPattern
   totalEndpoints: number


### PR DESCRIPTION
## Summary

- Adds a `ThemeToggle` button (sun/moon icon) to the landing page header and the app's mobile + desktop headers
- Zustand store tracks `theme: 'dark' | 'light'` (persisted), with `toggleTheme()` action
- `App.tsx` applies/removes the `html.light` class on `<html>` whenever the theme changes
- `index.css` contains the full `html.light` block: inverts the Tailwind gray ramp via CSS variable overrides, remaps `--color-white` → near-black and `--color-black` → near-white, and adds explicit overrides for all opacity utilities (`bg-white/5`, `border-white/10`, `bg-gray-950/95`, etc.) that compile to literal hex and therefore bypass the variable remap

## Test plan

- [ ] Toggle button visible in landing page header (compact icon-only)
- [ ] Toggle button visible in app desktop header (top-right, alongside BackendToggle)
- [ ] Toggle button visible in app mobile top bar
- [ ] Clicking sun icon → light mode: page background becomes light gray, text becomes dark
- [ ] Clicking moon icon → dark mode: reverts to original dark theme
- [ ] Theme preference persists on page reload (Zustand persist)
- [ ] Blue filled buttons (Start Designing, Launch App) remain readable in both modes
- [ ] `npm test -- --run` → 166 tests pass
- [ ] `npm run build` → clean Vite build

https://claude.ai/code/session_01JMitmtXvRKuygjN3CGERCV

---
_Generated by [Claude Code](https://claude.ai/code/session_01JMitmtXvRKuygjN3CGERCV)_