### PR TITLE
feat: G-A19 — Troubleshooting Tooling Engine (symptom-driven diagnostics)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -623,6 +623,7 @@ Use gap IDs in commit messages and conversations.
 | G-A16 | ✅ 2026-06-13 Config drift detection: running vs intended diff with inline remediation — `POST /api/drift/remediate` (`config_drift.generate_remediation`/`build_remediation`, platform-aware Cisco `no`/Junos `set`+`delete`, restore-then-prune) + Day-2 Ops "Inline remediation" UI (per-device command blocks, copy/download); generation-only, no auto-push | P1 |
 | G-A17 | SNMP exporter for the embedded monitoring stack (`prom/snmp-exporter` + generated `snmp.yml`/if_mib modules + Prometheus scrape job) — follow-up split from G-A7 | P2 |
 | G-A18 | ✅ 2026-06-17 LLD (Low-Level Design) diagrams for all 7 use cases — `LLDTopologyDiagram.tsx` pure-SVG component with per-device IP addresses, interface mappings, VLANs, config snippets, port-to-port link labels, physical cabling matrix; 7 builders (DC, Campus, GPU, WAN, Multisite, Multicloud, Aviatrix); integrated as "Low Level Design" tab in Step 4 Network Design | P1 |
+| G-A19 | ✅ 2026-06-18 Troubleshooting Tooling Engine — symptom-driven diagnostic playbooks for 8 categories (bgp_down, ospf_adjacency, interface_flap, high_latency, packet_loss, high_cpu, vxlan_evpn, pfc_rocev2 + generic fallback); platform-specific show commands (NX-OS/IOS-XE/EOS/JunOS), ranked likely causes w/ confidence, remediation steps. `backend/troubleshoot.py` + `POST /api/troubleshoot` (57 pytest) + new "🩺 Troubleshoot" Step 6 sub-tab w/ demo-mode `simulateTroubleshoot()` + `useTroubleshoot` hook | P1 |
 
 ---
 

--- a/CODE_REFERENCE.md
+++ b/CODE_REFERENCE.md
@@ -2002,6 +2002,23 @@ MCP (Model Context Protocol) server exposing NetDesign AI as an AI-native toolse
 
 ---
 
+#### `backend/troubleshoot.py` (G-A19)
+
+**Purpose:** Symptom-driven troubleshooting playbook engine for `POST /api/troubleshoot`. Given a symptom + affected devices + platform, returns an ordered diagnostic playbook (platform-specific show commands), ranked likely causes with confidence, and remediation steps. Pure-Python, no external deps. Distinct from `rca/engine.py` (telemetry-driven hypotheses) and `monitor_engine` (symptom-text fault tree) — this is a guided, vendor-aware diagnostic runbook generator.
+
+**Key exports:**
+- `PLAYBOOKS: dict` — keyed by symptom: `bgp_down`, `ospf_adjacency`, `interface_flap`, `high_latency`, `packet_loss`, `high_cpu`, `vxlan_evpn`, `pfc_rocev2`. Each playbook defines a `category` label, `summary`, ordered `steps` (description + per-platform command + `look_for`), ranked `causes` (confidence 0–1), and `remediation`.
+- `GENERIC_PLAYBOOK` — fallback (category "General") for unknown symptoms.
+- `_cmd(...)` — per-platform command resolver (nxos/iosxe/eos/junos; unknown → nxos).
+- `build_troubleshooting(symptom, affected_devices, platform="nxos") -> dict` — normalizes symptom (lowercase, `-`/space → `_`) + platform, resolves the playbook, assigns sequential step `order`, rounds + sorts causes by confidence desc, echoes affected devices into the summary. Returns `{symptom, category, summary, diagnostic_steps, likely_causes, remediation}`.
+
+**Notes:**
+- Endpoint in `main.py`: `@app.post("/api/troubleshoot", response_model=TroubleshootResponse)` guarded by `require_permission("designs:read")`; Pydantic models `TroubleshootRequest`/`DiagnosticStepModel`/`LikelyCauseModel`/`TroubleshootResponse`.
+- Tests: `tests/test_troubleshoot.py` (57 tests) — contract shape, non-empty sections, cause ranking, category labels, platform-specific command divergence (junos vs nxos), unknown-platform default, unknown/empty-symptom fallback, symptom normalization, affected-device echoing.
+- Frontend mirror: `simulateTroubleshoot(symptom, platform)` exported from `Step6Deploy.tsx` (demo mode), `useTroubleshoot()` hook (live mode → `runTroubleshoot` in `api/client.ts`), and the "🩺 Troubleshoot" Step 6 sub-tab (added to `Sidebar.tsx` `DEPLOY_SUB_ITEMS` + `Step6Deploy.tsx` `Tab` union). Types `DiagnosticStep`/`LikelyCause`/`TroubleshootResult` in `types/index.ts`. Frontend tests: `frontend/src/test/troubleshoot.test.ts` (7 tests).
+
+---
+
 #### `backend/models.py`
 
 **Purpose:** SQLAlchemy 2.0 ORM models (multi-tenant schema) + Pydantic request/response schemas for the FastAPI app.

--- a/backend/main.py
+++ b/backend/main.py
@@ -1083,6 +1083,55 @@ async def api_rca_analyze(
 
 
 # ---------------------------------------------------------------------------
+# G-A19: Troubleshooting Tooling Engine
+# ---------------------------------------------------------------------------
+
+class TroubleshootRequest(BaseModel):
+    symptom:          str
+    affected_devices: list[str] = []
+    platform:         str = "nxos"
+
+
+class DiagnosticStepModel(BaseModel):
+    order:       int
+    description: str
+    command:     str
+    look_for:    str
+
+
+class LikelyCauseModel(BaseModel):
+    cause:      str
+    confidence: float
+    indicators: list[str]
+
+
+class TroubleshootResponse(BaseModel):
+    symptom:          str
+    category:         str
+    summary:          str
+    diagnostic_steps: list[DiagnosticStepModel]
+    likely_causes:    list[LikelyCauseModel]
+    remediation:      list[str]
+
+
+@app.post("/api/troubleshoot", response_model=TroubleshootResponse)
+async def api_troubleshoot(
+    req: TroubleshootRequest,
+    user: dict = Depends(require_permission("designs:read")),
+):
+    """
+    Return a structured, platform-aware troubleshooting playbook for a symptom.
+    Unknown symptoms fall back to a generic triage workflow.
+    """
+    from troubleshoot import build_troubleshooting
+    return TroubleshootResponse(**build_troubleshooting(
+        symptom=req.symptom,
+        affected_devices=req.affected_devices,
+        platform=req.platform,
+    ))
+
+
+# ---------------------------------------------------------------------------
 # G-A1: Intent NLP parser — free-text → Step 1 form fields (Claude API)
 # ---------------------------------------------------------------------------
 

--- a/backend/tests/test_troubleshoot.py
+++ b/backend/tests/test_troubleshoot.py
@@ -1,0 +1,165 @@
+"""
+Tests for troubleshoot.py — Troubleshooting Tooling Engine (G-A19).
+"""
+import pytest
+from troubleshoot import (
+    build_troubleshooting,
+    PLAYBOOKS,
+    GENERIC_PLAYBOOK,
+    SUPPORTED_PLATFORMS,
+)
+
+KNOWN_SYMPTOMS = [
+    "bgp_down",
+    "ospf_adjacency",
+    "interface_flap",
+    "high_latency",
+    "packet_loss",
+    "high_cpu",
+    "vxlan_evpn",
+    "pfc_rocev2",
+]
+
+
+# ── Shape / contract ────────────────────────────────────────────────────────
+
+class TestContract:
+    @pytest.mark.parametrize("symptom", KNOWN_SYMPTOMS)
+    def test_top_level_keys(self, symptom):
+        r = build_troubleshooting(symptom, ["leaf1"], "nxos")
+        for key in ("symptom", "category", "summary", "diagnostic_steps",
+                    "likely_causes", "remediation"):
+            assert key in r, f"missing key {key}"
+
+    @pytest.mark.parametrize("symptom", KNOWN_SYMPTOMS)
+    def test_non_empty_sections(self, symptom):
+        r = build_troubleshooting(symptom, [], "nxos")
+        assert len(r["diagnostic_steps"]) >= 3
+        assert len(r["likely_causes"]) >= 2
+        assert len(r["remediation"]) >= 2
+
+    @pytest.mark.parametrize("symptom", KNOWN_SYMPTOMS)
+    def test_step_fields(self, symptom):
+        r = build_troubleshooting(symptom, [], "nxos")
+        for i, step in enumerate(r["diagnostic_steps"], start=1):
+            assert step["order"] == i
+            assert step["description"]
+            assert step["command"]
+            assert step["look_for"]
+
+    @pytest.mark.parametrize("symptom", KNOWN_SYMPTOMS)
+    def test_cause_fields(self, symptom):
+        r = build_troubleshooting(symptom, [], "nxos")
+        for c in r["likely_causes"]:
+            assert c["cause"]
+            assert 0.0 <= c["confidence"] <= 1.0
+            assert isinstance(c["indicators"], list)
+
+
+# ── Ranking ─────────────────────────────────────────────────────────────────
+
+class TestRanking:
+    @pytest.mark.parametrize("symptom", KNOWN_SYMPTOMS)
+    def test_causes_sorted_desc(self, symptom):
+        r = build_troubleshooting(symptom, [], "nxos")
+        confs = [c["confidence"] for c in r["likely_causes"]]
+        assert confs == sorted(confs, reverse=True)
+
+
+# ── Category labels ─────────────────────────────────────────────────────────
+
+class TestCategories:
+    def test_known_categories(self):
+        assert build_troubleshooting("bgp_down", [], "nxos")["category"] == "BGP"
+        assert build_troubleshooting("ospf_adjacency", [], "nxos")["category"] == "OSPF"
+        assert build_troubleshooting("interface_flap", [], "nxos")["category"] == "Interface"
+        assert build_troubleshooting("high_latency", [], "nxos")["category"] == "Performance"
+        assert build_troubleshooting("packet_loss", [], "nxos")["category"] == "Performance"
+        assert build_troubleshooting("high_cpu", [], "nxos")["category"] == "Performance"
+        assert build_troubleshooting("vxlan_evpn", [], "nxos")["category"] == "Overlay"
+        assert build_troubleshooting("pfc_rocev2", [], "nxos")["category"] == "QoS/RoCEv2"
+
+
+# ── Platform-specific commands ──────────────────────────────────────────────
+
+class TestPlatformCommands:
+    def test_bgp_junos_differs_from_nxos(self):
+        nxos = build_troubleshooting("bgp_down", [], "nxos")
+        junos = build_troubleshooting("bgp_down", [], "junos")
+        assert nxos["diagnostic_steps"][0]["command"] == "show ip bgp summary"
+        assert junos["diagnostic_steps"][0]["command"] == "show bgp summary"
+        assert nxos["diagnostic_steps"][0]["command"] != junos["diagnostic_steps"][0]["command"]
+
+    def test_bgp_eos_iosxe_match_nxos_summary(self):
+        for plat in ("nxos", "iosxe", "eos"):
+            r = build_troubleshooting("bgp_down", [], plat)
+            assert r["diagnostic_steps"][0]["command"] == "show ip bgp summary"
+
+    def test_ospf_neighbor_differs(self):
+        nxos = build_troubleshooting("ospf_adjacency", [], "nxos")
+        junos = build_troubleshooting("ospf_adjacency", [], "junos")
+        assert nxos["diagnostic_steps"][0]["command"] == "show ip ospf neighbors"
+        assert junos["diagnostic_steps"][0]["command"] == "show ospf neighbor"
+
+    def test_unknown_platform_defaults_to_nxos(self):
+        weird = build_troubleshooting("bgp_down", [], "frobnicator")
+        nxos = build_troubleshooting("bgp_down", [], "nxos")
+        assert weird["diagnostic_steps"][0]["command"] == nxos["diagnostic_steps"][0]["command"]
+
+    @pytest.mark.parametrize("plat", SUPPORTED_PLATFORMS)
+    def test_all_platforms_produce_commands(self, plat):
+        for symptom in KNOWN_SYMPTOMS:
+            r = build_troubleshooting(symptom, [], plat)
+            for step in r["diagnostic_steps"]:
+                assert step["command"], f"empty command for {symptom}/{plat}"
+
+
+# ── Fallback ────────────────────────────────────────────────────────────────
+
+class TestFallback:
+    def test_unknown_symptom_uses_generic(self):
+        r = build_troubleshooting("xyzzy_frobnicator", ["d1"], "nxos")
+        assert r["category"] == "General"
+        assert len(r["diagnostic_steps"]) >= 3
+        assert len(r["likely_causes"]) >= 2
+        assert len(r["remediation"]) >= 2
+
+    def test_empty_symptom_uses_generic(self):
+        r = build_troubleshooting("", [], "nxos")
+        assert r["category"] == "General"
+        assert r["symptom"] == "unknown"
+
+
+# ── Normalization & affected devices ────────────────────────────────────────
+
+class TestNormalization:
+    def test_symptom_case_and_separators_normalized(self):
+        a = build_troubleshooting("BGP-DOWN", [], "nxos")
+        b = build_troubleshooting("bgp down", [], "nxos")
+        c = build_troubleshooting("bgp_down", [], "nxos")
+        assert a["category"] == b["category"] == c["category"] == "BGP"
+
+    def test_affected_devices_echoed_in_summary(self):
+        r = build_troubleshooting("bgp_down", ["leaf1", "leaf2"], "nxos")
+        assert "leaf1" in r["summary"]
+        assert "leaf2" in r["summary"]
+
+    def test_no_affected_devices_summary_clean(self):
+        r = build_troubleshooting("bgp_down", [], "nxos")
+        assert "Affected device" not in r["summary"]
+
+    def test_none_affected_devices_does_not_crash(self):
+        r = build_troubleshooting("bgp_down", None, "nxos")
+        assert isinstance(r["diagnostic_steps"], list)
+
+
+# ── Catalog sanity ──────────────────────────────────────────────────────────
+
+class TestCatalog:
+    def test_all_known_symptoms_present(self):
+        for s in KNOWN_SYMPTOMS:
+            assert s in PLAYBOOKS
+
+    def test_generic_playbook_structure(self):
+        for key in ("category", "summary", "steps", "causes", "remediation"):
+            assert key in GENERIC_PLAYBOOK

--- a/backend/troubleshoot.py
+++ b/backend/troubleshoot.py
@@ -1,0 +1,794 @@
+"""
+Troubleshooting Tooling Engine (gap G-A19).
+
+Given a symptom key, a list of affected devices, and a target platform,
+returns a structured troubleshooting playbook:
+
+  - category          : human-readable category label (BGP, OSPF, ...)
+  - summary           : one-line description of the symptom
+  - diagnostic_steps  : ordered steps with PLATFORM-SPECIFIC show commands
+  - likely_causes     : ranked causes (confidence desc) with indicators
+  - remediation       : concrete remediation steps
+
+This is a pure-Python module with no external dependencies. Show commands
+are resolved per platform (nxos | iosxe | eos | junos) where they differ.
+Style mirrors backend/rca/engine.py.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+SUPPORTED_PLATFORMS = ("nxos", "iosxe", "eos", "junos")
+DEFAULT_PLATFORM = "nxos"
+
+
+# A command spec is either a plain string (same on every platform) or a dict
+# keyed by platform. Use _cmd() to resolve it for a given platform.
+def _cmd(spec: Any, platform: str) -> str:
+    """Resolve a per-platform command spec to a single command string."""
+    if isinstance(spec, dict):
+        return spec.get(platform) or spec.get(DEFAULT_PLATFORM) or next(iter(spec.values()), "")
+    return spec or ""
+
+
+# ── Playbook catalog ───────────────────────────────────────────────────────
+# Each playbook: category, summary, steps[{description, command, look_for}],
+# causes[{cause, confidence, indicators[]}], remediation[].
+# Commands may be per-platform dicts.
+
+PLAYBOOKS: dict[str, dict[str, Any]] = {
+    "bgp_down": {
+        "category": "BGP",
+        "summary": "BGP neighbor session is down or stuck in Idle/Active/Connect.",
+        "steps": [
+            {
+                "description": "Check BGP neighbor session state and uptime",
+                "command": {
+                    "nxos":  "show ip bgp summary",
+                    "iosxe": "show ip bgp summary",
+                    "eos":   "show ip bgp summary",
+                    "junos": "show bgp summary",
+                },
+                "look_for": "State/PfxRcd column — Idle/Active/Connect means session not Established",
+            },
+            {
+                "description": "Inspect neighbor-specific details and last reset reason",
+                "command": {
+                    "nxos":  "show ip bgp neighbors",
+                    "iosxe": "show ip bgp neighbors",
+                    "eos":   "show ip bgp neighbors",
+                    "junos": "show bgp neighbor",
+                },
+                "look_for": "Last reset reason, hold-time expired, peer AS, and configured vs received AS",
+            },
+            {
+                "description": "Verify L3 reachability to the BGP peer address",
+                "command": {
+                    "nxos":  "ping <peer-ip> vrf <vrf>",
+                    "iosxe": "ping <peer-ip>",
+                    "eos":   "ping <peer-ip>",
+                    "junos": "ping <peer-ip>",
+                },
+                "look_for": "Packet loss or unreachable — underlay/IGP problem blocking the TCP/179 session",
+            },
+            {
+                "description": "Check BFD session state for the peer (fast failure detection)",
+                "command": {
+                    "nxos":  "show bfd neighbors",
+                    "iosxe": "show bfd neighbors",
+                    "eos":   "show bfd peers",
+                    "junos": "show bfd session",
+                },
+                "look_for": "BFD Down can tear the BGP session even when the link is physically up",
+            },
+            {
+                "description": "Review route-map / prefix-list policy applied to the neighbor",
+                "command": {
+                    "nxos":  "show route-map",
+                    "iosxe": "show route-map",
+                    "eos":   "show route-map",
+                    "junos": "show policy-options",
+                },
+                "look_for": "Policy that filters all prefixes or a recently changed import/export policy",
+            },
+        ],
+        "causes": [
+            {
+                "cause": "AS number mismatch (configured remote-as != peer local-as)",
+                "confidence": 0.85,
+                "indicators": ["Session stuck in Active/Connect", "Last reset: peer AS mismatch / OpenSent"],
+            },
+            {
+                "cause": "Underlay/IGP reachability lost to peer loopback/P2P address",
+                "confidence": 0.72,
+                "indicators": ["Ping to peer fails", "BGP stuck in Idle", "TCP/179 never establishes"],
+            },
+            {
+                "cause": "BFD session down causing BGP fast-fallover teardown",
+                "confidence": 0.55,
+                "indicators": ["BFD neighbor Down", "BGP flaps coincide with BFD timeouts"],
+            },
+            {
+                "cause": "Hold timer expired / asymmetric timers between peers",
+                "confidence": 0.40,
+                "indicators": ["Last reset: hold timer expired", "Keepalives not received"],
+            },
+        ],
+        "remediation": [
+            "Correct the remote-as on the neighbor statement to match the peer's local ASN.",
+            "Restore underlay reachability (IGP adjacency / static route) to the peer address.",
+            "Re-enable or fix BFD timers; verify both ends use compatible intervals.",
+            "Clear the session after the fix: 'clear ip bgp <peer>' (soft if policy-only change).",
+        ],
+    },
+
+    "ospf_adjacency": {
+        "category": "OSPF",
+        "summary": "OSPF neighbor adjacency is not reaching FULL state (stuck in Init/2-Way/ExStart).",
+        "steps": [
+            {
+                "description": "Check OSPF neighbor state",
+                "command": {
+                    "nxos":  "show ip ospf neighbors",
+                    "iosxe": "show ip ospf neighbor",
+                    "eos":   "show ip ospf neighbor",
+                    "junos": "show ospf neighbor",
+                },
+                "look_for": "Stuck in Init (one-way hellos), 2-Way (DR/BDR), or ExStart/Exchange (MTU)",
+            },
+            {
+                "description": "Verify OSPF interface parameters (area, hello/dead, network type)",
+                "command": {
+                    "nxos":  "show ip ospf interface",
+                    "iosxe": "show ip ospf interface",
+                    "eos":   "show ip ospf interface",
+                    "junos": "show ospf interface detail",
+                },
+                "look_for": "Mismatched area ID, hello/dead timers, or network type between neighbors",
+            },
+            {
+                "description": "Check interface MTU on both ends",
+                "command": {
+                    "nxos":  "show interface",
+                    "iosxe": "show interfaces",
+                    "eos":   "show interfaces",
+                    "junos": "show interfaces extensive",
+                },
+                "look_for": "MTU mismatch — adjacency stuck in ExStart/Exchange is the classic symptom",
+            },
+            {
+                "description": "Confirm OSPF authentication settings match",
+                "command": {
+                    "nxos":  "show ip ospf interface",
+                    "iosxe": "show ip ospf interface",
+                    "eos":   "show ip ospf interface detail",
+                    "junos": "show ospf interface detail",
+                },
+                "look_for": "Authentication type/key mismatch silently drops hellos",
+            },
+        ],
+        "causes": [
+            {
+                "cause": "MTU mismatch between adjacent interfaces",
+                "confidence": 0.80,
+                "indicators": ["Adjacency stuck in ExStart/Exchange", "DBD packets retransmitted"],
+            },
+            {
+                "cause": "Area ID or hello/dead timer mismatch",
+                "confidence": 0.68,
+                "indicators": ["Neighbor stuck in Init", "Hellos seen but no adjacency"],
+            },
+            {
+                "cause": "Authentication type/key mismatch",
+                "confidence": 0.50,
+                "indicators": ["No neighbor entry despite L1/L2 up", "Auth failure log events"],
+            },
+            {
+                "cause": "Network type mismatch (broadcast vs point-to-point) / DR election issue",
+                "confidence": 0.38,
+                "indicators": ["Neighbors stuck in 2-Way", "Unexpected DR/BDR roles"],
+            },
+        ],
+        "remediation": [
+            "Align interface MTU on both ends (or set 'ip ospf mtu-ignore' as a temporary workaround).",
+            "Match OSPF area ID and hello/dead timers on both interfaces.",
+            "Ensure authentication mode and keys are identical on the link.",
+            "Set a consistent OSPF network type; use point-to-point on routed P2P links.",
+        ],
+    },
+
+    "interface_flap": {
+        "category": "Interface",
+        "summary": "Physical interface is flapping (repeated up/down transitions).",
+        "steps": [
+            {
+                "description": "Check interface status and flap/last-change counters",
+                "command": {
+                    "nxos":  "show interface status",
+                    "iosxe": "show interfaces status",
+                    "eos":   "show interfaces status",
+                    "junos": "show interfaces terse",
+                },
+                "look_for": "Recent 'last link flapped' time and number of transitions",
+            },
+            {
+                "description": "Inspect error counters (CRC, input errors, runts/giants)",
+                "command": {
+                    "nxos":  "show interface counters errors",
+                    "iosxe": "show interfaces counters errors",
+                    "eos":   "show interfaces counters errors",
+                    "junos": "show interfaces extensive",
+                },
+                "look_for": "Rising CRC/input errors point to a bad cable, SFP, or dirty fiber",
+            },
+            {
+                "description": "Verify transceiver/optics health (DOM levels)",
+                "command": {
+                    "nxos":  "show interface transceiver details",
+                    "iosxe": "show interfaces transceiver detail",
+                    "eos":   "show interfaces transceiver",
+                    "junos": "show interfaces diagnostics optics",
+                },
+                "look_for": "Rx/Tx power outside thresholds, high-alarm/low-warning flags",
+            },
+            {
+                "description": "Check speed/duplex negotiation",
+                "command": {
+                    "nxos":  "show interface status",
+                    "iosxe": "show interfaces status",
+                    "eos":   "show interfaces status",
+                    "junos": "show interfaces media",
+                },
+                "look_for": "Duplex mismatch (half/full) or auto-neg failure on copper links",
+            },
+        ],
+        "causes": [
+            {
+                "cause": "Faulty cable / dirty or failing optic causing CRC errors",
+                "confidence": 0.78,
+                "indicators": ["Rising CRC and input errors", "DOM Rx power out of range"],
+            },
+            {
+                "cause": "Speed/duplex mismatch on the link",
+                "confidence": 0.55,
+                "indicators": ["Late collisions", "Half-duplex on one end", "Input errors with low throughput"],
+            },
+            {
+                "cause": "Unstable transceiver / loose connector seating",
+                "confidence": 0.45,
+                "indicators": ["Intermittent link-down with no error counters", "Reseat clears it temporarily"],
+            },
+            {
+                "cause": "Far-end device or port-channel member instability",
+                "confidence": 0.30,
+                "indicators": ["Flaps correlate with peer reloads", "LACP member bouncing"],
+            },
+        ],
+        "remediation": [
+            "Replace the cable/optic and clean fiber connectors; re-seat the transceiver.",
+            "Hard-set speed and duplex on both ends to eliminate auto-negotiation issues.",
+            "Move the link to a known-good port to isolate the failing component.",
+            "Enable error-disable recovery / dampening to limit churn while replacing hardware.",
+        ],
+    },
+
+    "high_latency": {
+        "category": "Performance",
+        "summary": "End-to-end latency is elevated above baseline for affected paths.",
+        "steps": [
+            {
+                "description": "Measure hop-by-hop latency to the destination",
+                "command": {
+                    "nxos":  "traceroute <dest-ip>",
+                    "iosxe": "traceroute <dest-ip>",
+                    "eos":   "traceroute <dest-ip>",
+                    "junos": "traceroute <dest-ip>",
+                },
+                "look_for": "The hop where RTT jumps — pinpoints the congested/oversubscribed segment",
+            },
+            {
+                "description": "Check interface utilization and output queue drops",
+                "command": {
+                    "nxos":  "show interface counters detailed",
+                    "iosxe": "show interfaces | include rate|drops",
+                    "eos":   "show interfaces counters rates",
+                    "junos": "show interfaces extensive",
+                },
+                "look_for": "Links near line-rate, output drops, or output-queue depth building up",
+            },
+            {
+                "description": "Inspect QoS queue statistics and buffer occupancy",
+                "command": {
+                    "nxos":  "show queuing interface",
+                    "iosxe": "show policy-map interface",
+                    "eos":   "show qos interfaces",
+                    "junos": "show class-of-service interface",
+                },
+                "look_for": "Tail drops in priority queues and high buffer utilization",
+            },
+            {
+                "description": "Verify control-plane health is not adding processing delay",
+                "command": {
+                    "nxos":  "show system resources",
+                    "iosxe": "show processes cpu sorted",
+                    "eos":   "show processes top once",
+                    "junos": "show chassis routing-engine",
+                },
+                "look_for": "High CPU causing punt/process-switching of latency-sensitive traffic",
+            },
+        ],
+        "causes": [
+            {
+                "cause": "Link congestion / oversubscription on the transit path",
+                "confidence": 0.75,
+                "indicators": ["Utilization near 100%", "Output drops at a specific hop"],
+            },
+            {
+                "cause": "Suboptimal routing / asymmetric or longer path",
+                "confidence": 0.55,
+                "indicators": ["Traceroute takes unexpected hops", "ECMP imbalance"],
+            },
+            {
+                "cause": "QoS buffer/queue tail-drops on latency-sensitive class",
+                "confidence": 0.45,
+                "indicators": ["Priority-queue tail drops", "Jitter spikes under load"],
+            },
+            {
+                "cause": "Control-plane punting due to high CPU",
+                "confidence": 0.30,
+                "indicators": ["High CPU on transit node", "Process-switched flows"],
+            },
+        ],
+        "remediation": [
+            "Add capacity or rebalance ECMP across the congested links.",
+            "Tune routing metrics / fix asymmetric paths to use the shortest route.",
+            "Adjust QoS buffers and priority-queue policing for latency-sensitive traffic.",
+            "Offload control-plane load and ensure hardware (not software) forwarding.",
+        ],
+    },
+
+    "packet_loss": {
+        "category": "Performance",
+        "summary": "Intermittent or sustained packet loss across affected paths.",
+        "steps": [
+            {
+                "description": "Run a sustained ping with size variation to characterize loss",
+                "command": {
+                    "nxos":  "ping <dest-ip> count 1000",
+                    "iosxe": "ping <dest-ip> repeat 1000",
+                    "eos":   "ping <dest-ip> repeat 1000",
+                    "junos": "ping <dest-ip> count 1000 rapid",
+                },
+                "look_for": "Loss percentage and whether large packets fail (MTU/fragmentation)",
+            },
+            {
+                "description": "Check interface drops (input/output, ingress/egress queues)",
+                "command": {
+                    "nxos":  "show interface counters errors",
+                    "iosxe": "show interfaces | include drops|errors",
+                    "eos":   "show interfaces counters discards",
+                    "junos": "show interfaces extensive",
+                },
+                "look_for": "Output drops (egress congestion) vs input errors (L1 problem)",
+            },
+            {
+                "description": "Inspect buffer / microburst statistics on egress ports",
+                "command": {
+                    "nxos":  "show hardware internal buffer info pkt-stats",
+                    "iosxe": "show platform hardware ... buffer",
+                    "eos":   "show interfaces counters queue",
+                    "junos": "show interfaces queue",
+                },
+                "look_for": "Microburst-driven tail drops even when average utilization is low",
+            },
+            {
+                "description": "Verify forwarding/adjacency consistency across the path",
+                "command": {
+                    "nxos":  "show forwarding ipv4 route",
+                    "iosxe": "show ip cef",
+                    "eos":   "show ip route summary",
+                    "junos": "show route forwarding-table",
+                },
+                "look_for": "Blackhole/incomplete adjacency or inconsistent ECMP hashing",
+            },
+        ],
+        "causes": [
+            {
+                "cause": "Egress congestion / microbursts overflowing shallow buffers",
+                "confidence": 0.72,
+                "indicators": ["Output/queue tail drops", "Loss only under bursty load"],
+            },
+            {
+                "cause": "Physical-layer errors (bad cable/optic) causing input errors",
+                "confidence": 0.60,
+                "indicators": ["Rising input/CRC errors", "Loss correlates with one interface"],
+            },
+            {
+                "cause": "MTU mismatch dropping large/fragmented packets",
+                "confidence": 0.45,
+                "indicators": ["Small pings pass, large pings fail", "DF-bit drops"],
+            },
+            {
+                "cause": "Forwarding inconsistency / partial blackhole in ECMP",
+                "confidence": 0.32,
+                "indicators": ["Loss only on certain flows/hashes", "Incomplete adjacency"],
+            },
+        ],
+        "remediation": [
+            "Increase buffer allocation / enable dynamic buffer sharing for bursty egress ports.",
+            "Replace faulty cable/optic and clear physical-layer errors.",
+            "Align MTU end-to-end (including jumbo settings) across the path.",
+            "Verify ECMP hashing and forwarding tables; clear stale adjacencies.",
+        ],
+    },
+
+    "high_cpu": {
+        "category": "Performance",
+        "summary": "Device control-plane CPU utilization is abnormally high.",
+        "steps": [
+            {
+                "description": "Identify top CPU-consuming processes",
+                "command": {
+                    "nxos":  "show processes cpu sort",
+                    "iosxe": "show processes cpu sorted",
+                    "eos":   "show processes top once",
+                    "junos": "show system processes extensive",
+                },
+                "look_for": "The process consuming CPU (BGP, OSPF, ARP/ND, netstack, or a punt handler)",
+            },
+            {
+                "description": "Check control-plane policing (CoPP) drops",
+                "command": {
+                    "nxos":  "show policy-map interface control-plane",
+                    "iosxe": "show policy-map control-plane",
+                    "eos":   "show policy-map interface control-plane copp-system-policy",
+                    "junos": "show ddos-protection protocols statistics",
+                },
+                "look_for": "High CoPP/DDoS-protection drops indicate a punt storm hitting the CPU",
+            },
+            {
+                "description": "Inspect punted traffic to the CPU",
+                "command": {
+                    "nxos":  "show system internal access-list resource utilization",
+                    "iosxe": "show platform software infrastructure punt",
+                    "eos":   "show cpu counters queue",
+                    "junos": "show pfe statistics traffic",
+                },
+                "look_for": "Excessive traffic punted to the CPU (TTL-expiry, glean, ARP floods, ACL logging)",
+            },
+            {
+                "description": "Check for routing churn / flapping driving recomputation",
+                "command": {
+                    "nxos":  "show ip route summary",
+                    "iosxe": "show ip route summary",
+                    "eos":   "show ip route summary",
+                    "junos": "show route summary",
+                },
+                "look_for": "Rapidly changing route counts indicating SPF/BGP recomputation storms",
+            },
+        ],
+        "causes": [
+            {
+                "cause": "Control-plane punt storm (ARP/ND flood, ACL logging, TTL-expiry)",
+                "confidence": 0.78,
+                "indicators": ["High CoPP drops", "Punt queue saturated", "ARP/netstack process high"],
+            },
+            {
+                "cause": "Routing protocol churn driving repeated SPF/best-path recomputation",
+                "confidence": 0.58,
+                "indicators": ["BGP/OSPF process at top of CPU", "Flapping routes/neighbors"],
+            },
+            {
+                "cause": "Software/process bug or memory leak spinning a process",
+                "confidence": 0.40,
+                "indicators": ["One process pinned at ~100%", "Climbing memory usage"],
+            },
+            {
+                "cause": "Excessive SNMP/telemetry polling load",
+                "confidence": 0.28,
+                "indicators": ["SNMP process high", "CPU spikes align with polling intervals"],
+            },
+        ],
+        "remediation": [
+            "Apply/tighten CoPP to rate-limit punted control-plane traffic.",
+            "Suppress the source of the punt storm (fix ARP flood, disable noisy ACL logging).",
+            "Stabilize routing (dampening, BFD timer tuning) to stop recomputation churn.",
+            "Reduce SNMP/telemetry polling rate or upgrade software to fix a known CPU bug.",
+        ],
+    },
+
+    "vxlan_evpn": {
+        "category": "Overlay",
+        "summary": "VXLAN/EVPN overlay fault — VTEP unreachable or hosts not learned across the fabric.",
+        "steps": [
+            {
+                "description": "Check EVPN BGP address-family neighbor state",
+                "command": {
+                    "nxos":  "show bgp l2vpn evpn summary",
+                    "iosxe": "show bgp l2vpn evpn summary",
+                    "eos":   "show bgp evpn summary",
+                    "junos": "show bgp summary",
+                },
+                "look_for": "EVPN AF Established and PfxRcd > 0 toward spines/route-reflectors",
+            },
+            {
+                "description": "Verify NVE/VTEP interface and peer reachability",
+                "command": {
+                    "nxos":  "show nve peers",
+                    "iosxe": "show nve peers",
+                    "eos":   "show vxlan vtep",
+                    "junos": "show interfaces vtep",
+                },
+                "look_for": "VTEP peers present and Up; source loopback reachable in the underlay",
+            },
+            {
+                "description": "Check VNI-to-VLAN bindings and VNI state",
+                "command": {
+                    "nxos":  "show nve vni",
+                    "iosxe": "show nve vni",
+                    "eos":   "show vxlan vni",
+                    "junos": "show ethernet-switching vxlan-tunnel-end-point remote",
+                },
+                "look_for": "VNI Up and mapped to the correct VLAN/bridge-domain on all leaves",
+            },
+            {
+                "description": "Inspect EVPN route-targets (import/export) for the L2/L3 VNI",
+                "command": {
+                    "nxos":  "show bgp l2vpn evpn",
+                    "iosxe": "show bgp l2vpn evpn",
+                    "eos":   "show bgp evpn route-type mac-ip",
+                    "junos": "show route table bgp.evpn.0",
+                },
+                "look_for": "Route-target mismatch — type-2/type-5 routes received but not imported",
+            },
+            {
+                "description": "Validate learned MAC/host (type-2) routes for the VNI",
+                "command": {
+                    "nxos":  "show l2route evpn mac all",
+                    "iosxe": "show l2route evpn mac all",
+                    "eos":   "show bgp evpn route-type mac-ip",
+                    "junos": "show evpn database",
+                },
+                "look_for": "Remote MACs/hosts present; missing entries mean type-2 routes not propagated",
+            },
+        ],
+        "causes": [
+            {
+                "cause": "Route-target import/export mismatch between leaves (VNI not stitched)",
+                "confidence": 0.82,
+                "indicators": ["EVPN routes received but not imported", "Hosts local-only, not learned remotely"],
+            },
+            {
+                "cause": "VTEP source loopback unreachable in the underlay",
+                "confidence": 0.68,
+                "indicators": ["NVE peer Down", "Ping to remote VTEP loopback fails"],
+            },
+            {
+                "cause": "EVPN BGP session down to spine / route-reflector",
+                "confidence": 0.55,
+                "indicators": ["l2vpn evpn AF not Established", "PfxRcd = 0 on EVPN AF"],
+            },
+            {
+                "cause": "VNI-to-VLAN mapping mismatch or VNI down on a leaf",
+                "confidence": 0.40,
+                "indicators": ["VNI Down state", "Inconsistent VLAN/VNI map across leaves"],
+            },
+        ],
+        "remediation": [
+            "Align EVPN route-targets (or use 'route-target both auto') consistently across all leaves.",
+            "Restore underlay reachability to the VTEP source loopback (IGP/BGP underlay).",
+            "Fix the EVPN BGP session to the spine/route-reflector and confirm AF activation.",
+            "Correct VNI-to-VLAN bindings and ensure the VNI is up on every participating leaf.",
+        ],
+    },
+
+    "pfc_rocev2": {
+        "category": "QoS/RoCEv2",
+        "summary": "RoCEv2 / RDMA fabric impairment — PFC storms, watchdog drops, or ECN/DCQCN misconfiguration.",
+        "steps": [
+            {
+                "description": "Check PFC counters and per-priority pause frames",
+                "command": {
+                    "nxos":  "show interface priority-flow-control",
+                    "iosxe": "show interface priority-flow-control",
+                    "eos":   "show interfaces priority-flow-control",
+                    "junos": "show interfaces priority-flow-control",
+                },
+                "look_for": "Pause frames TX/RX on the lossless priority (typically priority 3 for RoCEv2)",
+            },
+            {
+                "description": "Inspect PFC watchdog status for stuck/deadlocked queues",
+                "command": {
+                    "nxos":  "show queuing pfc-queue interface",
+                    "iosxe": "show platform hardware ... pfc-watchdog",
+                    "eos":   "show qos interface counters",
+                    "junos": "show class-of-service interface detail",
+                },
+                "look_for": "Watchdog-triggered queue drops indicating a PFC deadlock/storm",
+            },
+            {
+                "description": "Verify ECN marking and DCQCN configuration on lossless queues",
+                "command": {
+                    "nxos":  "show policy-map interface type queuing",
+                    "iosxe": "show policy-map interface",
+                    "eos":   "show qos interface random-detect",
+                    "junos": "show class-of-service interface detail",
+                },
+                "look_for": "ECN/WRED thresholds and that no-drop is set on the RoCEv2 priority",
+            },
+            {
+                "description": "Confirm consistent QoS / no-drop class mapping fabric-wide",
+                "command": {
+                    "nxos":  "show policy-map system type network-qos",
+                    "iosxe": "show policy-map",
+                    "eos":   "show qos maps",
+                    "junos": "show class-of-service",
+                },
+                "look_for": "Mismatched DSCP/CoS-to-queue maps or no-drop class between leaf and spine",
+            },
+        ],
+        "causes": [
+            {
+                "cause": "PFC priority / no-drop class misconfigured or inconsistent across the fabric",
+                "confidence": 0.83,
+                "indicators": ["Pause frames on wrong priority", "no-drop not applied to RoCEv2 queue"],
+            },
+            {
+                "cause": "PFC deadlock / storm tripping the watchdog (cyclic buffer dependency)",
+                "confidence": 0.66,
+                "indicators": ["PFC watchdog drops climbing", "Lossless queue stuck, traffic stalls"],
+            },
+            {
+                "cause": "ECN/DCQCN misconfiguration causing congestion not to be signaled",
+                "confidence": 0.52,
+                "indicators": ["No CNP/ECN marks under congestion", "Tail drops on lossless queue"],
+            },
+            {
+                "cause": "Headroom/buffer too small for the link distance/MTU",
+                "confidence": 0.35,
+                "indicators": ["Drops on lossless queue despite PFC", "Long-distance/jumbo links affected"],
+            },
+        ],
+        "remediation": [
+            "Apply PFC no-drop consistently on the RoCEv2 priority (priority 3) across every device.",
+            "Tune/clear the PFC watchdog and resolve the cyclic dependency causing the deadlock.",
+            "Configure ECN/WRED thresholds and DCQCN so congestion is marked, not dropped.",
+            "Increase ingress buffer headroom to match link length and MTU for lossless transport.",
+        ],
+    },
+}
+
+
+GENERIC_PLAYBOOK: dict[str, Any] = {
+    "category": "General",
+    "summary": "Unrecognized symptom — running a generic network triage workflow.",
+    "steps": [
+        {
+            "description": "Confirm device reachability and management access",
+            "command": {
+                "nxos":  "ping <device-ip>",
+                "iosxe": "ping <device-ip>",
+                "eos":   "ping <device-ip>",
+                "junos": "ping <device-ip>",
+            },
+            "look_for": "Whether the affected device is reachable on the management plane at all",
+        },
+        {
+            "description": "Review recent log messages for errors/events",
+            "command": {
+                "nxos":  "show logging last 100",
+                "iosxe": "show logging",
+                "eos":   "show logging last 100",
+                "junos": "show log messages",
+            },
+            "look_for": "Interface flaps, protocol resets, hardware faults, or syslog errors",
+        },
+        {
+            "description": "Check interface status across the device",
+            "command": {
+                "nxos":  "show interface status",
+                "iosxe": "show interfaces status",
+                "eos":   "show interfaces status",
+                "junos": "show interfaces terse",
+            },
+            "look_for": "Down/err-disabled interfaces and high error counters",
+        },
+        {
+            "description": "Check overall control-plane / system health",
+            "command": {
+                "nxos":  "show system resources",
+                "iosxe": "show processes cpu sorted",
+                "eos":   "show processes top once",
+                "junos": "show chassis routing-engine",
+            },
+            "look_for": "High CPU/memory, environmental alarms, or process crashes",
+        },
+    ],
+    "causes": [
+        {
+            "cause": "Configuration or recent change introduced the fault",
+            "confidence": 0.40,
+            "indicators": ["Issue started after a change window", "Diff vs last-good config"],
+        },
+        {
+            "cause": "Physical-layer or hardware fault",
+            "confidence": 0.35,
+            "indicators": ["Interface errors", "Environmental/PSU/fan alarms in logs"],
+        },
+        {
+            "cause": "Transient / load-related condition",
+            "confidence": 0.25,
+            "indicators": ["Intermittent symptoms", "Correlates with traffic peaks"],
+        },
+    ],
+    "remediation": [
+        "Capture the current state and compare against the last-known-good baseline.",
+        "Isolate the failing layer (physical → L2 → L3 → application) methodically.",
+        "Roll back the most recent change if the issue began after a deployment.",
+        "Escalate with collected show outputs if the root cause remains unconfirmed.",
+    ],
+}
+
+
+def _normalize_platform(platform: str | None) -> str:
+    p = (platform or "").strip().lower()
+    return p if p in SUPPORTED_PLATFORMS else DEFAULT_PLATFORM
+
+
+def _normalize_symptom(symptom: str | None) -> str:
+    return (symptom or "").strip().lower().replace("-", "_").replace(" ", "_")
+
+
+def _render_steps(raw_steps: list[dict[str, Any]], platform: str) -> list[dict[str, Any]]:
+    steps: list[dict[str, Any]] = []
+    for idx, step in enumerate(raw_steps, start=1):
+        steps.append({
+            "order": idx,
+            "description": step["description"],
+            "command": _cmd(step.get("command", ""), platform),
+            "look_for": step.get("look_for", ""),
+        })
+    return steps
+
+
+def _render_causes(raw_causes: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    causes = [
+        {
+            "cause": c["cause"],
+            "confidence": round(float(c.get("confidence", 0.0)), 2),
+            "indicators": list(c.get("indicators", [])),
+        }
+        for c in raw_causes
+    ]
+    return sorted(causes, key=lambda c: c["confidence"], reverse=True)
+
+
+def build_troubleshooting(
+    symptom: str,
+    affected_devices: list[str] | None = None,
+    platform: str = "nxos",
+) -> dict[str, Any]:
+    """
+    Build a structured troubleshooting playbook for a symptom on a platform.
+
+    Unknown symptoms fall back to the generic ("General") playbook.
+    Platform defaults to nxos if unknown/unspecified.
+    """
+    affected = list(affected_devices or [])
+    plat = _normalize_platform(platform)
+    key = _normalize_symptom(symptom)
+
+    playbook = PLAYBOOKS.get(key, GENERIC_PLAYBOOK)
+
+    summary = playbook["summary"]
+    if affected:
+        summary = f"{summary} Affected device(s): {', '.join(affected)}."
+
+    return {
+        "symptom": key or "unknown",
+        "category": playbook["category"],
+        "summary": summary,
+        "diagnostic_steps": _render_steps(playbook["steps"], plat),
+        "likely_causes": _render_causes(playbook["causes"]),
+        "remediation": list(playbook["remediation"]),
+    }

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -85,6 +85,13 @@ export const runRca = (
   design_id: designId,
 })
 
+// ── Troubleshooting Tooling Engine (G-A19) ────────────────────────────────────
+
+import type { TroubleshootResult } from '@/types'
+
+export const runTroubleshoot = (symptom: string, affectedDevices: string[], platform: string) =>
+  post<TroubleshootResult>('/api/troubleshoot', { symptom, affected_devices: affectedDevices, platform })
+
 // ── Intent NLP parser (G-A1) ──────────────────────────────────────────────────
 
 import type { IntentParseResult } from '@/types'

--- a/frontend/src/components/wizard/Sidebar.tsx
+++ b/frontend/src/components/wizard/Sidebar.tsx
@@ -37,6 +37,7 @@ const DEPLOY_SUB_ITEMS = [
   { tab: 'netconf',  icon: '🖧', label: 'NETCONF'          },
   { tab: 'monitor',  icon: '📊', label: 'Monitoring'       },
   { tab: 'day2ops',  icon: '⚙️', label: 'Day-2 Ops'       },
+  { tab: 'troubleshoot', icon: '🩺', label: 'Troubleshoot' },
   { tab: 'batfish',  icon: '🦟', label: 'Batfish Validate' },
 ]
 

--- a/frontend/src/hooks/useTroubleshoot.ts
+++ b/frontend/src/hooks/useTroubleshoot.ts
@@ -1,0 +1,16 @@
+import { useMutation } from '@tanstack/react-query'
+import { runTroubleshoot } from '@/api/client'
+import type { TroubleshootResult } from '@/types'
+
+interface TroubleshootRequest {
+  symptom: string
+  devices: string[]
+  platform: string
+}
+
+export function useTroubleshoot() {
+  return useMutation<TroubleshootResult, Error, TroubleshootRequest>({
+    mutationFn: ({ symptom, devices, platform }) =>
+      runTroubleshoot(symptom, devices, platform),
+  })
+}

--- a/frontend/src/pages/Step6Deploy.tsx
+++ b/frontend/src/pages/Step6Deploy.tsx
@@ -14,13 +14,14 @@ import { TopologyDiagram } from '@/components/TopologyDiagram'
 import { formatUptime } from '@/lib/utils'
 import { cn } from '@/lib/utils'
 import { genGNMICCollectorConfig, genTelegrafGNMIConfig, genPrometheusAlertRules, genGrafanaDashboardJSON } from '@/lib/telemetry-gen'
-import type { ZTPEvent, BOMDevice, CheckResult, MonitoringResult, ZTPResult, ChecksResult, DeviceMetrics, MetricsSummary, ConfigDriftResponse, ConfigDriftDevice, ConfigRemediationResponse, RemediationDeviceInput } from '@/types'
+import { useTroubleshoot } from '@/hooks/useTroubleshoot'
+import type { ZTPEvent, BOMDevice, CheckResult, MonitoringResult, ZTPResult, ChecksResult, DeviceMetrics, MetricsSummary, ConfigDriftResponse, ConfigDriftDevice, ConfigRemediationResponse, RemediationDeviceInput, TroubleshootResult } from '@/types'
 
 const STATUS_BADGE: Record<string, 'pass' | 'warn' | 'fail' | 'neutral'> = {
   healthy: 'pass', degraded: 'warn', down: 'fail', unknown: 'neutral',
 }
 
-type Tab = 'deploy' | 'ztp' | 'checks' | 'monitor' | 'netconf' | 'day2ops' | 'batfish'
+type Tab = 'deploy' | 'ztp' | 'checks' | 'monitor' | 'netconf' | 'day2ops' | 'troubleshoot' | 'batfish'
 
 type PipelineStage = 'precheck' | 'backup' | 'push' | 'verify' | 'postcheck'
 type StageStatus = 'pending' | 'running' | 'done' | 'failed'
@@ -1136,6 +1137,378 @@ export function simulateRemediation(devices: RemediationDeviceInput[]): ConfigRe
   }
 }
 
+// ── Troubleshooting Tooling Engine (G-A19 demo mode) ──────────────────────────
+// Mirrors the backend POST /api/troubleshoot playbooks: per-symptom diagnostic
+// steps, ranked likely causes, and remediation, with platform-specific CLI.
+// Platforms: nxos | iosxe | eos | junos.
+
+type TPlat = 'nxos' | 'iosxe' | 'eos' | 'junos'
+
+function normTPlat(platform: string): TPlat {
+  const p = platform.toLowerCase()
+  if (/jun/.test(p)) return 'junos'
+  if (/eos|arista/.test(p)) return 'eos'
+  if (/nx|nexus/.test(p)) return 'nxos'
+  return 'iosxe'
+}
+
+// Pick a platform-specific command from a per-platform map.
+function tcmd(platform: string, map: Record<TPlat, string>): string {
+  return map[normTPlat(platform)]
+}
+
+// Human-readable labels for the 8 supported symptom keys (drives the <select>).
+const TROUBLESHOOT_SYMPTOMS: Array<{ key: string; label: string }> = [
+  { key: 'bgp_down',        label: 'BGP session down' },
+  { key: 'ospf_adjacency',  label: 'OSPF adjacency stuck' },
+  { key: 'interface_flap',  label: 'Interface flapping' },
+  { key: 'high_latency',    label: 'High latency' },
+  { key: 'packet_loss',     label: 'Packet loss' },
+  { key: 'high_cpu',        label: 'High CPU' },
+  { key: 'vxlan_evpn',      label: 'VXLAN / EVPN reachability' },
+  { key: 'pfc_rocev2',      label: 'PFC / RoCEv2 (GPU fabric)' },
+]
+
+interface TPlaybook {
+  category: string
+  summary: string
+  steps: (p: string) => DiagnosticStep[]
+  causes: LikelyCause[]
+  remediation: string[]
+}
+
+// (DiagnosticStep / LikelyCause come from @/types via the file-level import.)
+type DiagnosticStep = TroubleshootResult['diagnostic_steps'][number]
+type LikelyCause = TroubleshootResult['likely_causes'][number]
+
+const TROUBLESHOOT_PLAYBOOKS: Record<string, TPlaybook> = {
+  bgp_down: {
+    category: 'Routing',
+    summary: 'A BGP session is stuck in Idle/Active/Connect and not reaching Established. Verify reachability, the TCP/179 session, and that AS numbers, timers, and MTU agree on both ends.',
+    steps: (p) => [
+      { order: 1, description: 'Check the BGP neighbor summary and session state',
+        command: tcmd(p, { nxos: 'show ip bgp summary', iosxe: 'show ip bgp summary', eos: 'show ip bgp summary', junos: 'show bgp summary' }),
+        look_for: 'Neighbor stuck in Idle/Active/Connect rather than Established; check the State/PfxRcd column' },
+      { order: 2, description: 'Verify L3 reachability to the neighbor address',
+        command: tcmd(p, { nxos: 'ping <neighbor-ip>', iosxe: 'ping <neighbor-ip>', eos: 'ping <neighbor-ip>', junos: 'ping <neighbor-ip>' }),
+        look_for: 'Packet loss or unreachable — a routing/underlay problem prevents the TCP session' },
+      { order: 3, description: 'Inspect detailed neighbor state, configured vs received AS, and timers',
+        command: tcmd(p, { nxos: 'show ip bgp neighbors <neighbor-ip>', iosxe: 'show ip bgp neighbors <neighbor-ip>', eos: 'show ip bgp neighbors <neighbor-ip>', junos: 'show bgp neighbor <neighbor-ip>' }),
+        look_for: 'AS mismatch ("remote AS" vs configured), hold-time mismatch, or "Connection refused"' },
+      { order: 4, description: 'Check for MTU / path-MTU issues that break large BGP updates',
+        command: tcmd(p, { nxos: 'ping <neighbor-ip> df-bit packet-size 8972', iosxe: 'ping <neighbor-ip> df-bit size 8972', eos: 'ping <neighbor-ip> df-bit size 8972', junos: 'ping <neighbor-ip> do-not-fragment size 8972' }),
+        look_for: 'Fragmentation-needed / drops — an MTU mismatch can wedge the session in OpenSent/OpenConfirm' },
+    ],
+    causes: [
+      { cause: 'TCP/179 session never forms — underlay/L3 unreachability', confidence: 0.85,
+        indicators: ['Neighbor stuck in Active/Connect', 'Ping to neighbor fails', 'No route to neighbor in RIB'] },
+      { cause: 'AS number mismatch (remote-as misconfigured)', confidence: 0.7,
+        indicators: ['"remote AS x, configured AS y"', 'Session flaps in OpenSent', 'Notification: Bad Peer AS'] },
+      { cause: 'MTU / path-MTU mismatch wedging large updates', confidence: 0.5,
+        indicators: ['Session reaches OpenConfirm then drops', 'df-bit ping fails at 9000', 'Inconsistent on jumbo links'] },
+      { cause: 'BFD session down tearing BGP down', confidence: 0.4,
+        indicators: ['BFD admin-down/Down', 'BGP flaps in lockstep with BFD', 'Recent link errors'] },
+    ],
+    remediation: [
+      'Restore L3 reachability to the neighbor (fix underlay route / interface)',
+      'Align remote-as on both peers and confirm router-id uniqueness',
+      'Match MTU on the path and enable path-MTU discovery where supported',
+      'If BFD is enabled, confirm BFD timers/echo are consistent before clearing the session',
+      'As a last resort, soft-clear the neighbor (clear ip bgp <ip> soft) rather than a hard reset',
+    ],
+  },
+
+  ospf_adjacency: {
+    category: 'Routing',
+    summary: 'OSPF neighbors are not reaching FULL (often stuck in INIT/EXSTART/2-WAY). Mismatched timers, area IDs, network types, or MTU are the usual culprits.',
+    steps: (p) => [
+      { order: 1, description: 'Check OSPF neighbor adjacency state',
+        command: tcmd(p, { nxos: 'show ip ospf neighbor', iosxe: 'show ip ospf neighbor', eos: 'show ip ospf neighbor', junos: 'show ospf neighbor' }),
+        look_for: 'State stuck in INIT (no hellos back), 2-WAY (DR/BDR), or EXSTART (MTU mismatch)' },
+      { order: 2, description: 'Compare interface OSPF parameters (hello/dead, area, network type)',
+        command: tcmd(p, { nxos: 'show ip ospf interface <intf>', iosxe: 'show ip ospf interface <intf>', eos: 'show ip ospf interface <intf>', junos: 'show ospf interface <intf> detail' }),
+        look_for: 'Hello/Dead timer mismatch, area ID mismatch, or network-type mismatch (p2p vs broadcast)' },
+      { order: 3, description: 'Verify interface MTU on both ends',
+        command: tcmd(p, { nxos: 'show interface <intf>', iosxe: 'show ip interface <intf>', eos: 'show interfaces <intf>', junos: 'show interfaces <intf>' }),
+        look_for: 'MTU mismatch — adjacency stuck in EXSTART/EXCHANGE is the classic symptom' },
+      { order: 4, description: 'Confirm OSPF authentication matches',
+        command: tcmd(p, { nxos: 'show ip ospf interface <intf>', iosxe: 'show ip ospf interface <intf>', eos: 'show ip ospf interface <intf>', junos: 'show ospf interface <intf> detail' }),
+        look_for: 'Authentication type/key mismatch — hellos are silently dropped' },
+    ],
+    causes: [
+      { cause: 'Hello/Dead timer or area-ID mismatch', confidence: 0.8,
+        indicators: ['Neighbor stuck in INIT', 'Timers differ on the two ends', 'Area mismatch logged'] },
+      { cause: 'MTU mismatch (adjacency hangs in EXSTART/EXCHANGE)', confidence: 0.7,
+        indicators: ['EXSTART/EXCHANGE state', 'Different MTU on the link', 'DBD retransmits'] },
+      { cause: 'OSPF authentication mismatch', confidence: 0.5,
+        indicators: ['No neighbor at all', 'Auth-type/key differs', '%OSPF auth mismatch logs'] },
+      { cause: 'Network-type mismatch (broadcast vs point-to-point)', confidence: 0.4,
+        indicators: ['Stuck in 2-WAY', 'No DR/BDR election expected on p2p', 'Mismatched ip ospf network'] },
+    ],
+    remediation: [
+      'Align hello/dead intervals and area IDs on both interfaces',
+      'Set identical MTU (or use "ip ospf mtu-ignore" only as a temporary workaround)',
+      'Match OSPF authentication type and key',
+      'Set a consistent OSPF network type on both ends',
+    ],
+  },
+
+  interface_flap: {
+    category: 'Physical',
+    summary: 'An interface is repeatedly going up/down. Inspect error counters, optics/light levels, speed/duplex, and cabling before suspecting protocol issues.',
+    steps: (p) => [
+      { order: 1, description: 'Check interface status and last flap time',
+        command: tcmd(p, { nxos: 'show interface <intf>', iosxe: 'show interfaces <intf>', eos: 'show interfaces <intf>', junos: 'show interfaces <intf> extensive' }),
+        look_for: '"last link flapped" timestamp, line-protocol bouncing, reset counts' },
+      { order: 2, description: 'Examine error counters (CRC, input errors, runts)',
+        command: tcmd(p, { nxos: 'show interface <intf> counters errors', iosxe: 'show interfaces <intf> | include error|CRC', eos: 'show interfaces <intf> counters errors', junos: 'show interfaces <intf> extensive | match error' }),
+        look_for: 'Rising CRC / input errors / runts — points to a bad cable, dirty fiber, or duplex mismatch' },
+      { order: 3, description: 'Verify speed/duplex negotiation',
+        command: tcmd(p, { nxos: 'show interface <intf> status', iosxe: 'show interfaces <intf> status', eos: 'show interfaces <intf> status', junos: 'show interfaces <intf> media' }),
+        look_for: 'Half-duplex on one side / speed mismatch — a frequent late-collision and flap source' },
+      { order: 4, description: 'Read optical transceiver light levels (for fiber)',
+        command: tcmd(p, { nxos: 'show interface <intf> transceiver details', iosxe: 'show interfaces <intf> transceiver detail', eos: 'show interfaces <intf> transceiver', junos: 'show interfaces diagnostics optics <intf>' }),
+        look_for: 'Rx/Tx power outside the optic\'s range, or low light — dirty/failing optic or fiber' },
+    ],
+    causes: [
+      { cause: 'Bad cable / dirty or failing optic (CRC errors)', confidence: 0.8,
+        indicators: ['Rising CRC and input errors', 'Rx power out of range', 'Flaps stop when cable swapped'] },
+      { cause: 'Speed/duplex mismatch', confidence: 0.6,
+        indicators: ['Half-duplex on one end', 'Late collisions', 'Auto-neg disagreement'] },
+      { cause: 'Failing transceiver / SFP not fully seated', confidence: 0.5,
+        indicators: ['Tx power abnormal', 'Errors only on one optic', 'DOM thresholds exceeded'] },
+      { cause: 'STP topology change / port-security shut', confidence: 0.35,
+        indicators: ['err-disabled state', 'STP TCN bursts', 'Recovers after err-disable timeout'] },
+    ],
+    remediation: [
+      'Replace the cable or clean/replace the optic and re-seat the SFP',
+      'Hard-set matching speed/duplex on both ends if auto-neg is unreliable',
+      'Confirm transceiver DOM levels are within spec; swap suspect optics',
+      'If err-disabled, fix the trigger (BPDU/port-security) then re-enable',
+    ],
+  },
+
+  high_latency: {
+    category: 'Performance',
+    summary: 'End-to-end latency is elevated. Localize the hop adding delay, then check for congestion/queuing, suboptimal routing, or a control-plane-punted path.',
+    steps: (p) => [
+      { order: 1, description: 'Trace the path hop-by-hop to localize the latency',
+        command: tcmd(p, { nxos: 'traceroute <dest>', iosxe: 'traceroute <dest>', eos: 'traceroute <dest>', junos: 'traceroute <dest>' }),
+        look_for: 'The hop where RTT jumps — that device/link is the contributor' },
+      { order: 2, description: 'Check interface utilization and output drops/queue depth',
+        command: tcmd(p, { nxos: 'show interface <intf> | include rate|drop', iosxe: 'show interfaces <intf> | include rate|drops', eos: 'show interfaces <intf> | include rate|drops', junos: 'show interfaces <intf> extensive | match "rate|drop"' }),
+        look_for: 'High utilization with output drops / deep queues — congestion adds queuing delay' },
+      { order: 3, description: 'Verify the forwarding path is optimal (no scenic route)',
+        command: tcmd(p, { nxos: 'show ip route <dest>', iosxe: 'show ip cef <dest>', eos: 'show ip route <dest>', junos: 'show route <dest>' }),
+        look_for: 'Suboptimal next-hop / asymmetric path adding extra hops' },
+      { order: 4, description: 'Rule out control-plane punting (process-switched path)',
+        command: tcmd(p, { nxos: 'show processes cpu sort', iosxe: 'show processes cpu sorted', eos: 'show processes top once', junos: 'show chassis routing-engine' }),
+        look_for: 'High CPU correlating with latency — traffic punted to CPU instead of hardware' },
+    ],
+    causes: [
+      { cause: 'Link congestion / queuing delay on a hot interface', confidence: 0.75,
+        indicators: ['High utilization', 'Output drops/queue depth rising', 'Latency tracks load'] },
+      { cause: 'Suboptimal or asymmetric routing path', confidence: 0.55,
+        indicators: ['Traceroute takes extra hops', 'Recent route change', 'Asymmetric RTT'] },
+      { cause: 'Control-plane punting (process-switched traffic)', confidence: 0.45,
+        indicators: ['High CPU', 'Latency only for certain flows', 'CoPP / punt path active'] },
+      { cause: 'Buffer/QoS misconfiguration', confidence: 0.35,
+        indicators: ['Tail drops in priority queue', 'Microbursts', 'Shaper too aggressive'] },
+    ],
+    remediation: [
+      'Relieve congestion: add capacity/ECMP or tune QoS on the hot link',
+      'Correct routing metrics/policy to restore the optimal path',
+      'Ensure traffic is hardware-switched (fix CoPP/punt cause)',
+      'Right-size buffers and queue thresholds for the traffic profile',
+    ],
+  },
+
+  packet_loss: {
+    category: 'Performance',
+    summary: 'Traffic is experiencing drops. Distinguish interface errors (physical) from output drops (congestion/microbursts) and policy drops (ACL/QoS).',
+    steps: (p) => [
+      { order: 1, description: 'Check interface drop and error counters',
+        command: tcmd(p, { nxos: 'show interface <intf> counters errors', iosxe: 'show interfaces <intf> | include drops|errors', eos: 'show interfaces <intf> counters errors', junos: 'show interfaces <intf> extensive | match "drop|error"' }),
+        look_for: 'Output drops (congestion) vs input errors/CRC (physical) vs no-buffer drops' },
+      { order: 2, description: 'Look for queue drops / microburst tail-drops',
+        command: tcmd(p, { nxos: 'show queuing interface <intf>', iosxe: 'show policy-map interface <intf>', eos: 'show interfaces <intf> counters queue', junos: 'show interfaces queue <intf>' }),
+        look_for: 'Tail-drops on a specific queue — microbursts overrun shallow buffers' },
+      { order: 3, description: 'Verify no ACL / policy is dropping the flow',
+        command: tcmd(p, { nxos: 'show access-lists', iosxe: 'show access-lists', eos: 'show ip access-lists', junos: 'show firewall' }),
+        look_for: 'ACL deny hit-counts incrementing for the affected flow' },
+      { order: 4, description: 'Test reachability and loss rate to the destination',
+        command: tcmd(p, { nxos: 'ping <dest> count 100', iosxe: 'ping <dest> repeat 100', eos: 'ping <dest> repeat 100', junos: 'ping <dest> count 100' }),
+        look_for: 'Consistent loss % to quantify and confirm the drop point' },
+    ],
+    causes: [
+      { cause: 'Microbursts overrunning buffers (output/tail drops)', confidence: 0.7,
+        indicators: ['Output/queue tail-drops', 'Low average but bursty load', 'Drops on shallow-buffer ports'] },
+      { cause: 'Physical-layer errors (CRC/input errors)', confidence: 0.6,
+        indicators: ['Rising CRC/input errors', 'Bad cable/optic', 'Errors localized to one port'] },
+      { cause: 'ACL / QoS policy dropping the flow', confidence: 0.45,
+        indicators: ['ACL deny hits incrementing', 'Policer/exceed drops', 'Loss only for specific 5-tuple'] },
+      { cause: 'Oversubscription / sustained congestion', confidence: 0.4,
+        indicators: ['Link at 100%', 'WRED drops', 'Loss tracks peak hours'] },
+    ],
+    remediation: [
+      'Increase buffer allocation or enable WRED/ECN to absorb microbursts',
+      'Fix the physical layer (cable/optic) if CRC/input errors are present',
+      'Adjust or remove the ACL/QoS policy dropping legitimate traffic',
+      'Add capacity / ECMP to relieve sustained oversubscription',
+    ],
+  },
+
+  high_cpu: {
+    category: 'Device Health',
+    summary: 'Control-plane CPU is high. Identify the top process, check whether traffic is being punted to the CPU, and verify CoPP is protecting the control plane.',
+    steps: (p) => [
+      { order: 1, description: 'Identify the top CPU process',
+        command: tcmd(p, { nxos: 'show processes cpu sort', iosxe: 'show processes cpu sorted', eos: 'show processes top once', junos: 'show system processes extensive' }),
+        look_for: 'A single process dominating, or high interrupt/IP-input (punted traffic)' },
+      { order: 2, description: 'Check the CoPP / control-plane policy for drops',
+        command: tcmd(p, { nxos: 'show policy-map interface control-plane', iosxe: 'show policy-map control-plane', eos: 'show policy-map interface control-plane', junos: 'show ddos-protection statistics' }),
+        look_for: 'CoPP class exceed/drop counters climbing — control plane under attack/overload' },
+      { order: 3, description: 'Look for traffic punted to CPU (software-switched)',
+        command: tcmd(p, { nxos: 'show hardware rate-limiter', iosxe: 'show platform punt-statistics', eos: 'show cpu counters queue', junos: 'show pfe statistics traffic' }),
+        look_for: 'High punt rate — TTL-expiry, ARP storms, or no-route punts hammering the CPU' },
+      { order: 4, description: 'Check for routing/protocol churn driving CPU',
+        command: tcmd(p, { nxos: 'show ip bgp summary', iosxe: 'show ip route summary', eos: 'show ip route summary', junos: 'show route summary' }),
+        look_for: 'Route/SPF churn or constant BGP updates keeping the CPU busy' },
+    ],
+    causes: [
+      { cause: 'Traffic punted to CPU (process-switched / no CoPP protection)', confidence: 0.75,
+        indicators: ['High IP-input / interrupt CPU', 'Punt-statistics climbing', 'CoPP exceed drops'] },
+      { cause: 'Control-plane storm (ARP/BPDU/protocol flood)', confidence: 0.6,
+        indicators: ['One CoPP class saturated', 'Broadcast storm', 'CPU tracks a noisy port'] },
+      { cause: 'Routing/SPF churn from instability', confidence: 0.5,
+        indicators: ['Flapping routes', 'Constant BGP updates', 'OSPF SPF runs frequent'] },
+      { cause: 'Runaway / buggy process', confidence: 0.35,
+        indicators: ['Single process pinned high', 'Resolves after process restart', 'Known bug / memory leak'] },
+    ],
+    remediation: [
+      'Apply or tighten CoPP to rate-limit control-plane traffic',
+      'Identify and stop the punt source (TTL-expiry, ARP storm, missing route)',
+      'Stabilize routing (dampening, fix flapping link) to stop churn',
+      'If a process is buggy, restart it and check for a software fix/upgrade',
+    ],
+  },
+
+  vxlan_evpn: {
+    category: 'Overlay',
+    summary: 'VXLAN/EVPN endpoints cannot reach each other across the fabric. Check the NVE peer state, EVPN route exchange, and that route-targets / VNI-to-VLAN mappings agree.',
+    steps: (p) => [
+      { order: 1, description: 'Check NVE interface and VTEP peer state',
+        command: tcmd(p, { nxos: 'show nve peers', iosxe: 'show nve peers', eos: 'show vxlan vtep', junos: 'show interfaces vtep' }),
+        look_for: 'Expected remote VTEPs present and Up; missing peer = no overlay path' },
+      { order: 2, description: 'Verify L2VPN EVPN routes are being learned',
+        command: tcmd(p, { nxos: 'show bgp l2vpn evpn summary', iosxe: 'show bgp l2vpn evpn summary', eos: 'show bgp evpn summary', junos: 'show bgp summary' }),
+        look_for: 'EVPN address-family Established and prefixes received (>0)' },
+      { order: 3, description: 'Confirm Type-2 (MAC/IP) routes for the host',
+        command: tcmd(p, { nxos: 'show bgp l2vpn evpn', iosxe: 'show bgp l2vpn evpn', eos: 'show bgp evpn route-type mac-ip', junos: 'show route table bgp.evpn.0' }),
+        look_for: 'Missing Type-2 routes for the affected MAC/IP — host not advertised or RT-filtered' },
+      { order: 4, description: 'Check VNI status and VLAN-to-VNI mapping',
+        command: tcmd(p, { nxos: 'show nve vni', iosxe: 'show nve vni', eos: 'show vxlan vni', junos: 'show ethernet-switching vxlan-tunnel-end-point remote' }),
+        look_for: 'VNI Up and mapped to the correct VLAN; route-target import/export mismatch' },
+    ],
+    causes: [
+      { cause: 'Route-target import/export mismatch (routes not imported)', confidence: 0.8,
+        indicators: ['EVPN routes present in BGP but not in the VRF/MAC-VRF', 'RT differs between leaves', 'Type-2 not imported'] },
+      { cause: 'VTEP/NVE peer not established (underlay or source-loopback issue)', confidence: 0.65,
+        indicators: ['Remote VTEP missing from "show nve peers"', 'Source loopback not advertised', 'Underlay route missing'] },
+      { cause: 'VLAN-to-VNI mapping inconsistent between leaves', confidence: 0.55,
+        indicators: ['Same VLAN maps to different VNIs', 'VNI down', 'L2VNI vs L3VNI confusion'] },
+      { cause: 'EVPN address-family not negotiated with spines', confidence: 0.45,
+        indicators: ['l2vpn evpn AF Idle', 'send-community extended missing', 'No EVPN prefixes received'] },
+    ],
+    remediation: [
+      'Align route-target import/export (use "route-target both auto" consistently)',
+      'Restore VTEP reachability: advertise the source loopback in the underlay',
+      'Make VLAN-to-VNI mappings identical on all leaves in the segment',
+      'Enable the l2vpn evpn address-family with extended communities to the spines',
+    ],
+  },
+
+  pfc_rocev2: {
+    category: 'GPU Fabric',
+    summary: 'RoCEv2 traffic is suffering drops/poor RDMA performance. Verify PFC is enabled no-drop on the correct priority end-to-end and that ECN/DCQCN are marking, not dropping.',
+    steps: (p) => [
+      { order: 1, description: 'Verify PFC is enabled and watch for PFC pause frames',
+        command: tcmd(p, { nxos: 'show interface priority-flow-control', iosxe: 'show interface <intf> priority-flow-control', eos: 'show priority-flow-control', junos: 'show interfaces <intf> extensive | match pfc' }),
+        look_for: 'PFC On for the RoCE priority and Rx/Tx pause counters incrementing as expected' },
+      { order: 2, description: 'Confirm the no-drop class maps to the correct CoS/priority',
+        command: tcmd(p, { nxos: 'show queuing interface <intf>', iosxe: 'show policy-map interface <intf>', eos: 'show qos interface <intf>', junos: 'show class-of-service interface <intf>' }),
+        look_for: 'RoCE priority (typically 3) in a no-drop queue; mismatched priority = drops' },
+      { order: 3, description: 'Check ECN marking and DCQCN behavior',
+        command: tcmd(p, { nxos: 'show queuing interface <intf> | include ECN|WRED', iosxe: 'show policy-map interface <intf> | include ECN|wred', eos: 'show qos interface <intf> | include ecn', junos: 'show class-of-service interface <intf> detail | match ecn' }),
+        look_for: 'ECN marking (not tail-drop) on the lossy threshold; CNP generation present' },
+      { order: 4, description: 'Look for PFC watchdog / deadlock events',
+        command: tcmd(p, { nxos: 'show interface priority-flow-control watchdog', iosxe: 'show interface <intf> priority-flow-control', eos: 'show priority-flow-control watchdog', junos: 'show interfaces <intf> extensive | match watchdog' }),
+        look_for: 'PFC watchdog shutting queues — PFC storm / deadlock on the no-drop class' },
+    ],
+    causes: [
+      { cause: 'PFC not enabled (or on the wrong priority) end-to-end', confidence: 0.8,
+        indicators: ['PFC Off on a transit hop', 'RoCE priority not no-drop', 'Drops on priority 3 queue'] },
+      { cause: 'CoS/DSCP-to-priority mapping mismatch across hops', confidence: 0.65,
+        indicators: ['Pause frames absent where expected', 'Traffic lands in drop queue', 'Inconsistent qos-group mapping'] },
+      { cause: 'ECN/DCQCN misconfigured (tail-drop instead of mark)', confidence: 0.55,
+        indicators: ['No CNP generation', 'WRED min/max wrong', 'High retransmits despite no-drop'] },
+      { cause: 'PFC watchdog / deadlock disabling queues', confidence: 0.4,
+        indicators: ['PFC watchdog events', 'Queue auto-shut/restored', 'Pause storm on one priority'] },
+    ],
+    remediation: [
+      'Enable PFC no-drop on the RoCE priority (e.g. priority 3) on every hop',
+      'Ensure consistent DSCP/CoS-to-qos-group mapping across the fabric',
+      'Tune ECN/WRED thresholds to mark (not drop) and confirm DCQCN/CNP generation',
+      'Enable PFC watchdog to break deadlocks and investigate the pause-storm source',
+    ],
+  },
+}
+
+const TROUBLESHOOT_FALLBACK: TPlaybook = {
+  category: 'General',
+  summary: 'No specific playbook matched this symptom. Start with a top-down health check: physical/interface state, IP reachability, protocol adjacencies, then control-plane health.',
+  steps: (p) => [
+    { order: 1, description: 'Check overall interface status',
+      command: tcmd(p, { nxos: 'show interface status', iosxe: 'show ip interface brief', eos: 'show interfaces status', junos: 'show interfaces terse' }),
+      look_for: 'Down/err-disabled interfaces or unexpected state changes' },
+    { order: 2, description: 'Verify basic reachability to the affected destination',
+      command: tcmd(p, { nxos: 'ping <dest>', iosxe: 'ping <dest>', eos: 'ping <dest>', junos: 'ping <dest>' }),
+      look_for: 'Loss or unreachable indicating where to focus next' },
+    { order: 3, description: 'Review the system log for recent errors',
+      command: tcmd(p, { nxos: 'show logging last 100', iosxe: 'show logging | last 100', eos: 'show logging last 100', junos: 'show log messages | last 100' }),
+      look_for: 'Recent error/warning events correlating with the problem time' },
+    { order: 4, description: 'Check device CPU and memory health',
+      command: tcmd(p, { nxos: 'show system resources', iosxe: 'show processes cpu sorted', eos: 'show processes top once', junos: 'show chassis routing-engine' }),
+      look_for: 'Resource exhaustion that could explain broad symptoms' },
+  ],
+  causes: [
+    { cause: 'Physical / interface-level issue', confidence: 0.5,
+      indicators: ['Interface down/err-disabled', 'Error counters rising', 'Recent flap'] },
+    { cause: 'Reachability / routing problem', confidence: 0.4,
+      indicators: ['Ping fails', 'Missing route', 'Asymmetric path'] },
+    { cause: 'Control-plane / resource pressure', confidence: 0.3,
+      indicators: ['High CPU/memory', 'Process churn', 'Log warnings'] },
+  ],
+  remediation: [
+    'Triage from the bottom up: physical → IP → protocol → control plane',
+    'Correlate the system log timestamps with when the issue began',
+    'Isolate to a single device/link, then drill in with a targeted command set',
+  ],
+}
+
+export function simulateTroubleshoot(symptom: string, platform: string): TroubleshootResult {
+  const pb = TROUBLESHOOT_PLAYBOOKS[symptom] ?? TROUBLESHOOT_FALLBACK
+  const causes = [...pb.causes].sort((a, b) => b.confidence - a.confidence)
+  return {
+    symptom,
+    category: pb.category,
+    summary: pb.summary,
+    diagnostic_steps: pb.steps(platform),
+    likely_causes: causes,
+    remediation: [...pb.remediation],
+  }
+}
+
 // ── NETCONF XML helpers ───────────────────────────────────────────────────────
 
 function buildNetconfXMLForOp(op: string, datastore: string, vendor: string): string {
@@ -1683,6 +2056,25 @@ export function Step6Deploy() {
     }
     setBatfishRunning(false)
     setBatfishDone(true)
+  }
+
+  // ── Troubleshooting Tooling Engine state (G-A19) ──────────────────────────
+  const [tsSymptom, setTsSymptom] = useState('bgp_down')
+  const [tsPlatform, setTsPlatform] = useState('nxos')
+  const [tsDevicesNote, setTsDevicesNote] = useState('')
+  const [tsResult, setTsResult] = useState<TroubleshootResult | null>(null)
+  const { mutate: runTs, isPending: tsRunning } = useTroubleshoot()
+
+  function handleRunTroubleshoot() {
+    const devices = tsDevicesNote.split(/[\s,]+/).map(s => s.trim()).filter(Boolean)
+    if (!isLive) {
+      setTsResult(simulateTroubleshoot(tsSymptom, tsPlatform))
+      return
+    }
+    runTs({ symptom: tsSymptom, devices, platform: tsPlatform }, {
+      onSuccess: setTsResult,
+      onError(e) { showToast('Diagnostics failed: ' + e.message, 'error') },
+    })
   }
 
   // ── Policy Gate state ─────────────────────────────────────────────────────
@@ -3351,6 +3743,167 @@ export function Step6Deploy() {
               ))}
             </div>
           </Card>
+        </div>
+      )}
+
+      {/* ── Troubleshooting Tooling Engine tab (G-A19) ─────────────────── */}
+      {tab === 'troubleshoot' && (
+        <div className="space-y-6">
+          <Card>
+            <CardHeader><CardTitle>Troubleshooting Tooling Engine</CardTitle></CardHeader>
+            <p className="text-xs text-gray-500 mb-4">
+              Pick a symptom and a target platform to get a guided diagnostic
+              playbook — ordered show/ping commands with what to look for, ranked
+              likely causes, and a remediation checklist. Nothing is pushed to any
+              device.
+            </p>
+
+            <div className="flex flex-wrap gap-4 items-end">
+              <div>
+                <label className="text-xs text-gray-400 block mb-1">Symptom</label>
+                <select
+                  value={tsSymptom}
+                  onChange={e => setTsSymptom(e.target.value)}
+                  className="bg-white/5 border border-white/10 rounded px-3 py-2 text-sm text-gray-200
+                             focus:outline-none focus:border-blue-500"
+                >
+                  {TROUBLESHOOT_SYMPTOMS.map(s => (
+                    <option key={s.key} value={s.key}>{s.label}</option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label className="text-xs text-gray-400 block mb-1">Platform</label>
+                <select
+                  value={tsPlatform}
+                  onChange={e => setTsPlatform(e.target.value)}
+                  className="bg-white/5 border border-white/10 rounded px-3 py-2 text-sm text-gray-200
+                             focus:outline-none focus:border-blue-500"
+                >
+                  <option value="nxos">NX-OS</option>
+                  <option value="iosxe">IOS-XE</option>
+                  <option value="eos">Arista EOS</option>
+                  <option value="junos">Juniper JunOS</option>
+                </select>
+              </div>
+              <div className="flex-1 min-w-[180px]">
+                <label className="text-xs text-gray-400 block mb-1">Affected devices (optional)</label>
+                <input
+                  value={tsDevicesNote}
+                  onChange={e => setTsDevicesNote(e.target.value)}
+                  placeholder="e.g. leaf-1, spine-2"
+                  className="w-full bg-white/5 border border-white/10 rounded px-3 py-2 text-sm text-gray-200
+                             focus:outline-none focus:border-blue-500"
+                />
+              </div>
+              <Button onClick={handleRunTroubleshoot} disabled={tsRunning}>
+                {tsRunning ? (
+                  <span className="flex items-center gap-2">
+                    <span className="inline-block w-3 h-3 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+                    Running…
+                  </span>
+                ) : '🩺 Run Diagnostics'}
+              </Button>
+            </div>
+          </Card>
+
+          {tsResult && (
+            <>
+              {/* Summary banner */}
+              <Card>
+                <div className="flex items-start gap-3">
+                  <Badge variant="neutral" className="text-xs shrink-0">{tsResult.category}</Badge>
+                  <div>
+                    <div className="text-sm font-semibold text-gray-200 mb-1">
+                      {TROUBLESHOOT_SYMPTOMS.find(s => s.key === tsResult.symptom)?.label ?? tsResult.symptom}
+                    </div>
+                    <p className="text-sm text-gray-400">{tsResult.summary}</p>
+                  </div>
+                </div>
+              </Card>
+
+              {/* Diagnostic steps */}
+              <Card>
+                <CardHeader><CardTitle>Diagnostic Steps</CardTitle></CardHeader>
+                <div className="space-y-3">
+                  {tsResult.diagnostic_steps.map(step => (
+                    <div key={step.order} className="rounded-lg border border-white/10 bg-white/[0.02] p-4">
+                      <div className="flex items-start gap-3">
+                        <span className="shrink-0 w-6 h-6 rounded-full bg-blue-500/20 text-blue-300 text-xs
+                                         font-semibold flex items-center justify-center">
+                          {step.order}
+                        </span>
+                        <div className="flex-1 min-w-0">
+                          <div className="text-sm text-gray-200 mb-2">{step.description}</div>
+                          <pre className="text-xs font-mono whitespace-pre-wrap overflow-x-auto rounded bg-black/40
+                                          border border-white/10 px-3 py-2 text-green-300">
+                            {step.command}
+                          </pre>
+                          <div className="mt-2 text-xs text-gray-400">
+                            <span className="text-yellow-400 font-semibold">look for: </span>
+                            {step.look_for}
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </Card>
+
+              {/* Likely causes (ranked, confidence bar) */}
+              <Card>
+                <CardHeader><CardTitle>Likely Causes</CardTitle></CardHeader>
+                <div className="space-y-3">
+                  {tsResult.likely_causes.map((c, i) => {
+                    const pct = Math.round(c.confidence * 100)
+                    const color = pct >= 75 ? 'bg-red-500' : pct >= 50 ? 'bg-yellow-500' : 'bg-blue-500'
+                    return (
+                      <div key={i} className="rounded-lg border border-white/10 bg-white/[0.02] p-4 space-y-2">
+                        <div className="flex items-start justify-between gap-3">
+                          <div className="flex items-center gap-2 min-w-0">
+                            <Badge variant="neutral" className="text-xs shrink-0">#{i + 1}</Badge>
+                            <span className="text-sm font-semibold text-gray-200">{c.cause}</span>
+                          </div>
+                          <div className="flex items-center gap-2 w-32 shrink-0">
+                            <div className="flex-1 h-1.5 rounded-full bg-white/10 overflow-hidden">
+                              <div className={`h-full rounded-full ${color}`} style={{ width: `${pct}%` }} />
+                            </div>
+                            <span className="text-xs text-gray-400 w-8 text-right">{pct}%</span>
+                          </div>
+                        </div>
+                        {c.indicators.length > 0 && (
+                          <ul className="space-y-1">
+                            {c.indicators.map((ind, j) => (
+                              <li key={j} className="text-xs text-gray-400 flex items-start gap-1.5">
+                                <span className="text-gray-600 shrink-0">·</span>
+                                {ind}
+                              </li>
+                            ))}
+                          </ul>
+                        )}
+                      </div>
+                    )
+                  })}
+                </div>
+              </Card>
+
+              {/* Remediation checklist */}
+              <Card>
+                <CardHeader><CardTitle>Remediation</CardTitle></CardHeader>
+                <div className="space-y-2">
+                  {tsResult.remediation.map((r, i) => (
+                    <div
+                      key={i}
+                      className="flex items-start gap-2 px-4 py-2.5 rounded-lg border border-white/10 bg-white/[0.02]"
+                    >
+                      <span className="text-green-400 shrink-0 mt-0.5">☐</span>
+                      <span className="text-sm text-gray-300">{r}</span>
+                    </div>
+                  ))}
+                </div>
+              </Card>
+            </>
+          )}
         </div>
       )}
 

--- a/frontend/src/test/troubleshoot.test.ts
+++ b/frontend/src/test/troubleshoot.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest'
+import { simulateTroubleshoot } from '@/pages/Step6Deploy'
+
+const SYMPTOMS = [
+  'bgp_down',
+  'ospf_adjacency',
+  'interface_flap',
+  'high_latency',
+  'packet_loss',
+  'high_cpu',
+  'vxlan_evpn',
+  'pfc_rocev2',
+]
+
+describe('simulateTroubleshoot (G-A19 demo mode)', () => {
+  it('returns non-empty steps/causes/remediation for every known symptom', () => {
+    for (const sym of SYMPTOMS) {
+      const r = simulateTroubleshoot(sym, 'nxos')
+      expect(r.symptom).toBe(sym)
+      expect(r.category).not.toBe('General')
+      expect(r.summary.length).toBeGreaterThan(0)
+      expect(r.diagnostic_steps.length).toBeGreaterThan(0)
+      expect(r.likely_causes.length).toBeGreaterThan(0)
+      expect(r.remediation.length).toBeGreaterThan(0)
+      // every step is well-formed
+      for (const step of r.diagnostic_steps) {
+        expect(step.command.length).toBeGreaterThan(0)
+        expect(step.description.length).toBeGreaterThan(0)
+        expect(step.look_for.length).toBeGreaterThan(0)
+      }
+    }
+  })
+
+  it('orders diagnostic steps sequentially from 1', () => {
+    const r = simulateTroubleshoot('bgp_down', 'iosxe')
+    r.diagnostic_steps.forEach((s, i) => expect(s.order).toBe(i + 1))
+  })
+
+  it('ranks likely causes by confidence descending', () => {
+    for (const sym of SYMPTOMS) {
+      const causes = simulateTroubleshoot(sym, 'eos').likely_causes
+      for (let i = 1; i < causes.length; i++) {
+        expect(causes[i - 1].confidence).toBeGreaterThanOrEqual(causes[i].confidence)
+      }
+    }
+  })
+
+  it('emits platform-specific commands (junos differs from nxos for bgp_down)', () => {
+    const nxos = simulateTroubleshoot('bgp_down', 'nxos').diagnostic_steps[0].command
+    const junos = simulateTroubleshoot('bgp_down', 'junos').diagnostic_steps[0].command
+    expect(nxos).not.toBe(junos)
+    expect(nxos).toContain('show ip bgp summary')
+    expect(junos).toContain('show bgp summary')
+  })
+
+  it('uses no-drop / PFC concepts for pfc_rocev2 remediation', () => {
+    const r = simulateTroubleshoot('pfc_rocev2', 'nxos')
+    const text = r.remediation.join(' ').toLowerCase()
+    expect(text).toContain('pfc')
+    expect(text).toContain('no-drop')
+  })
+
+  it('flags route-target mismatch as the top cause for vxlan_evpn', () => {
+    const r = simulateTroubleshoot('vxlan_evpn', 'nxos')
+    expect(r.likely_causes[0].cause.toLowerCase()).toContain('route-target')
+  })
+
+  it('falls back to a generic playbook for an unknown symptom', () => {
+    const r = simulateTroubleshoot('something_unknown', 'iosxe')
+    expect(r.category).toBe('General')
+    expect(r.diagnostic_steps.length).toBeGreaterThan(0)
+    expect(r.likely_causes.length).toBeGreaterThan(0)
+    expect(r.remediation.length).toBeGreaterThan(0)
+  })
+})

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -272,6 +272,15 @@ export interface RcaHypothesis {
   remediation: string
 }
 
+// ── Troubleshooting Tooling Engine (G-A19) ──────────────────────────────────────
+
+export interface DiagnosticStep { order: number; description: string; command: string; look_for: string }
+export interface LikelyCause { cause: string; confidence: number; indicators: string[] }
+export interface TroubleshootResult {
+  symptom: string; category: string; summary: string
+  diagnostic_steps: DiagnosticStep[]; likely_causes: LikelyCause[]; remediation: string[]
+}
+
 // ── Intent NLP parser (G-A1) ────────────────────────────────────────────────────
 
 export interface IntentParseResult {


### PR DESCRIPTION
## G-A19 — Troubleshooting Tooling Engine

A guided, vendor-aware troubleshooting engine. Given a symptom + platform, it returns an ordered diagnostic playbook (platform-specific `show` commands + what to look for), ranked likely causes with confidence, and remediation steps.

### Backend
- `backend/troubleshoot.py` — `PLAYBOOKS` for 8 symptom categories: `bgp_down`, `ospf_adjacency`, `interface_flap`, `high_latency`, `packet_loss`, `high_cpu`, `vxlan_evpn`, `pfc_rocev2` (+ generic fallback). Per-platform command resolver (NX-OS / IOS-XE / EOS / JunOS). `build_troubleshooting()` normalizes input, ranks causes, echoes affected devices.
- `POST /api/troubleshoot` (guarded by `require_permission("designs:read")`)
- `backend/tests/test_troubleshoot.py` — **57 tests**

### Frontend
- New **🩺 Troubleshoot** Step 6 sub-tab (Sidebar + Step6Deploy): symptom/platform selectors, ordered diagnostic steps with monospace commands + "look for" hints, ranked causes with confidence bars, remediation checklist.
- Demo-mode `simulateTroubleshoot()` mirroring the backend playbooks; `useTroubleshoot` hook + `runTroubleshoot` client for live mode; `TroubleshootResult` types.
- `frontend/src/test/troubleshoot.test.ts` — **7 tests**

### Verification
- Frontend: **279 tests pass**, `tsc` clean, `npm run build` OK
- Backend: **57 troubleshoot tests pass**

First item of the continuous enterprise-improvement loop (focus: design / config / ZTP / monitoring / troubleshooting).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DiH1v2ufYHuupbP4xn6pPb)_