### PR TITLE
feat: F1 — NetBox IPAM CSV export; E2 — fix stale nav label

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -695,7 +695,14 @@ config-gen tests must keep passing; add new tests alongside).
 
 | # | Item | Status | Notes |
 |---|------|--------|-------|
-| E1 | Remove LEGACY/UNUSED wizard pages + nav superseded by Step6Deploy sub-tabs / Sidebar (`Step4ZTP.tsx`, `Step5Checks.tsx`, `Step6Monitor.tsx`, `WizardNav.tsx`) — only referenced by `e2e-features.test.ts`; fix that test to assert the real live page set | [x] | files deleted; `e2e-features.test.ts` "App structure" now lists the 6 live pages (Step1UseCase, Step2Requirements, Step2Design, Step4NetworkDesign, Step3Config, Step6Deploy) + drops WizardNav; CODE_REFERENCE.md LEGACY sections removed; live hooks (`useRunZTP`/`useRunChecks`/`usePollMonitoring`) retained (still used by Step6Deploy) |
+| E1 | Remove LEGACY/UNUSED wizard pages + nav superseded by Step6Deploy sub-tabs / Sidebar (`Step4ZTP.tsx`, `Step5Checks.tsx`, `Step6Monitor.tsx`, `WizardNav.tsx`) — only referenced by `e2e-features.test.ts`; fix that test to assert the real live page set | [x] (`f86ace8`) | files deleted; `e2e-features.test.ts` "App structure" now lists the 6 live pages (Step1UseCase, Step2Requirements, Step2Design, Step4NetworkDesign, Step3Config, Step6Deploy) + drops WizardNav; CODE_REFERENCE.md LEGACY sections removed; live hooks (`useRunZTP`/`useRunChecks`/`usePollMonitoring`) retained (still used by Step6Deploy) |
+| E2 | Fix stale "Next: ZTP →" button label on the Config Gen page (Step3Config, wizard step 5) — actual next step is Step 6 Deploy & Validate | [x] | now "Next: Deploy & Validate →" (matches Sidebar label); CODE_REFERENCE.md note updated |
+
+### F. NetBox / Nautobot parity — IPAM (sourced 2026-06-18)
+
+| # | Item | Status | Notes |
+|---|------|--------|-------|
+| F1 | IPAM source-of-truth export — push the computed IP/VLAN/prefix plan to NetBox/Nautobot as bulk-import CSVs | [x] | new `lib/ipam.ts` (single source of truth): moved `genIPBlocks`/`genIPRows`/`genVLANs`/`genVNIs` out of `Step4NetworkDesign.tsx` + added `toNetBoxPrefixCsv`/`toNetBoxVlanCsv`/`toNetBoxIpAddressCsv`/`buildNetBoxIpamExport` (NetBox 3.x/4.x ipam.prefix/vlan/ipaddress headers, CIDR validation, de-dup, RFC-4180 quoting); 3 export buttons in Step 4 "IP Plan" tab; 13 tests in `test/ipam.test.ts` |
 
 ---
 

--- a/CODE_REFERENCE.md
+++ b/CODE_REFERENCE.md
@@ -742,6 +742,37 @@ interface Product {
 
 ---
 
+## Frontend — `lib/ipam.ts` (IPAM plan + NetBox export — F1)
+
+**Purpose:** Single source of truth for IP / VLAN / prefix / VNI planning,
+plus NetBox/Nautobot-importable CSV export. The `gen*` functions were moved
+here from `Step4NetworkDesign.tsx` (2026-06-18) so the page and the export
+share one implementation; the page imports them for its "IP Plan" / "VLAN &
+VNI" tabs.
+
+**Key exports:**
+- Interfaces: `IPBlock`, `IPRow`, `VLANRow`, `VNIRow`.
+- `genIPBlocks(useCase, totalEndpoints, numSites, devices): IPBlock[]` —
+  aggregate prefix plan (OOB, loopbacks, P2P, corp/voice/server/IoT; +DC
+  underlay/overlay for dc/multisite; +GPU/storage fabric for gpu).
+- `genIPRows(useCase, devices): IPRow[]` — per-device loopback/interface
+  allocations (firewall/spine/leaf/dist/access), with "… +N more" summary
+  rows when a layer exceeds the display cap.
+- `genVLANs(useCase): VLANRow[]` / `genVNIs(): VNIRow[]`.
+- `toNetBoxPrefixCsv(blocks, vlans)` — `ipam.prefix` CSV (`prefix,status,
+  role,vlan_vid,description`); aggregate blocks → `container`, VLAN subnets
+  → `active`; de-duped by CIDR.
+- `toNetBoxVlanCsv(vlans)` — `ipam.vlan` CSV (`vid,name,status,description`).
+- `toNetBoxIpAddressCsv(rows)` — `ipam.ipaddress` CSV (`address,status,
+  dns_name,description`); skips range/summary rows, appends prefix length,
+  uses lowercase hostname as `dns_name`.
+- `buildNetBoxIpamExport(useCase, totalEndpoints, numSites, devices):
+  NetBoxIpamExport` — `{ prefixesCsv, vlansCsv, ipAddressesCsv }`.
+- Internal: RFC-4180 `csvCell`/`csvRow` quoting, `isCidr` validation.
+- **UI**: Step 4 "IP Plan" tab has 3 download buttons (Prefixes / VLANs /
+  IP Addresses CSV) via `downloadCsv()` in `Step4NetworkDesign.tsx`.
+- **Tests**: 13 in `test/ipam.test.ts`.
+
 ## Frontend — `lib/netbox.ts` (NetBox/Nautobot import — Enterprise Upgrade B1)
 
 **Purpose:** Reads existing inventory from a NetBox or Nautobot instance
@@ -1146,7 +1177,7 @@ These four files appear to be retained purely so `e2e-features.test.ts` can smok
 
 **Notes:**
 - CodeMirror 6 (`@codemirror/view`, `@codemirror/state`, `oneDark` theme) mounted/destroyed in a `useEffect` keyed on `[selectedId, configs]`.
-- "Next: ZTP →" button label is stale/legacy text (actual next step is Step 6 Deploy & Validate, not a ZTP-specific step).
+- "Next →" button label reads "Next: Deploy & Validate →" (matches the Step 6 Sidebar label; E2).
 
 ---
 

--- a/frontend/src/lib/ipam.ts
+++ b/frontend/src/lib/ipam.ts
@@ -1,0 +1,210 @@
+import type { BOMDevice } from '@/types'
+
+// ── IPAM data model ──────────────────────────────────────────────────────────
+// Canonical IP / VLAN / VNI planning, derived from the BOM + intent. This is
+// the single source of truth for the Step 4 "IP Plan" / "VLAN & VNI" tabs and
+// for the NetBox-importable CSV export below (NetBox/Nautobot parity, IPAM).
+
+export interface IPBlock { label: string; subnet: string; detail: string; range: string }
+export interface IPRow { device: string; layer: string; iface: string; ip: string; prefix: string; purpose: string }
+export interface VLANRow { id: number; name: string; subnet: string; gw: string; dhcp: string; purpose: string; layer: string }
+export interface VNIRow { vni: number; vlan: string; type: string; vrf: string; irb: string; rt: string }
+
+// ── Aggregate prefix plan ────────────────────────────────────────────────────
+
+export function genIPBlocks(useCase: string, totalEndpoints: number, numSites: number, devices: BOMDevice[]): IPBlock[] {
+  const isDC    = useCase === 'dc' || useCase === 'multisite'
+  const isGPU   = useCase === 'gpu'
+  const nSpines = devices.filter(d => d.subLayer === 'spine').length
+  const nLeaves = devices.filter(d => d.subLayer === 'leaf').length
+  const nDist   = devices.filter(d => d.subLayer === 'distribution').length
+  const nAccess = devices.filter(d => d.subLayer === 'access').length
+  const totalInfra = devices.length
+
+  const p2pTotal = isDC ? nLeaves * nSpines : nAccess + nDist
+  const p2pPrefix = p2pTotal <= 256 ? '/23' : '/21'
+
+  const blocks: IPBlock[] = [
+    { label: 'MANAGEMENT OOB',   subnet: '10.0.0.0/24',  detail: `VLAN 10 · ${totalInfra} network devices across ${numSites} site(s)`, range: `10.0.0.1 – 10.0.0.${Math.min(totalInfra + 1, 254)}` },
+    { label: 'LOOPBACKS',        subnet: '10.255.0.0/24',detail: `/32 per device · ${totalInfra} addresses needed`, range: `10.255.0.1 – 10.255.0.${Math.min(totalInfra, 254)}` },
+    { label: 'P2P FABRIC LINKS', subnet: `10.100.0.0${p2pPrefix}`, detail: `/31 per link · ${p2pTotal} links`, range: `10.100.0.0 – covers ${p2pTotal} /31 pairs` },
+    { label: 'CORPORATE DATA',   subnet: '10.10.0.0/22', detail: `VLAN 20 · ${totalEndpoints || 0} endpoints`, range: '10.10.0.1 – 10.10.3.254 (1022 hosts)' },
+    { label: 'VOICE / UC',       subnet: '10.20.0.0/23', detail: 'VLAN 30 · IP Phones, UC', range: '10.20.0.1 – 10.20.1.254 (510 hosts)' },
+    { label: 'SERVER / DMZ',     subnet: '10.50.0.0/22', detail: 'VLAN 50/60 · Physical & VM servers', range: '10.50.0.1 – 10.50.3.254 (1022 hosts)' },
+    { label: 'IoT / GUEST',      subnet: '10.60.0.0/23', detail: 'VLAN 61/21 · Isolated · internet-only ACL', range: '10.60.0.1 – 10.60.1.254 (510 hosts)' },
+  ]
+
+  if (isDC) {
+    blocks.push({ label: `DC UNDERLAY /31 (${nLeaves} leaf × ${nSpines} spine = ${nLeaves * nSpines} links)`, subnet: '10.1.0.0/20', detail: `P2P /31 links · ECMP · BFD`, range: `10.1.0.0 – covers ${nLeaves * nSpines} /31 pairs` })
+    blocks.push({ label: 'DC OVERLAY — VXLAN tenant subnets', subnet: '10.200.0.0/14', detail: `VXLAN VNI space · PROD/STOR/DEV tenants · ${nLeaves} VTEPs`, range: '10.200.0.0 – 10.203.255.255 (262K hosts)' })
+  }
+  if (isGPU) {
+    blocks.push({ label: `GPU COMPUTE fabric`, subnet: '192.168.100.0/22', detail: `RoCEv2 RDMA fabric · lossless · PFC priority 3`, range: '192.168.100.1 – 192.168.103.254' })
+    blocks.push({ label: 'STORAGE — NVMe-oF / GPUDirect', subnet: '192.168.200.0/23', detail: 'NVMe-oF storage fabric · GPUDirect RDMA', range: '192.168.200.1 – 192.168.201.254' })
+  }
+  return blocks
+}
+
+// ── Per-device IP allocations ────────────────────────────────────────────────
+
+export function genIPRows(_useCase: string, devices: BOMDevice[]): IPRow[] {
+  const rows: IPRow[] = []
+  const spines = devices.filter(d => d.subLayer === 'spine')
+  const leaves = devices.filter(d => d.subLayer === 'leaf')
+  const dists  = devices.filter(d => d.subLayer === 'distribution')
+  const access = devices.filter(d => d.subLayer === 'access')
+  const fws    = devices.filter(d => d.subLayer === 'firewall')
+
+  fws.forEach((d, i) => {
+    rows.push({ device: d.hostname, layer: 'Firewall', iface: 'Loopback0', ip: `10.255.0.${i + 1}`, prefix: '/32', purpose: 'Router-ID / BGP peering' })
+    rows.push({ device: d.hostname, layer: 'Firewall', iface: 'Gi0/0', ip: `10.0.0.${i + 1}`, prefix: '/30', purpose: 'Outside / Internet uplink' })
+  })
+
+  spines.forEach((d, i) => {
+    rows.push({ device: d.hostname, layer: 'Spine', iface: 'Loopback0', ip: `10.255.1.${i + 1}`, prefix: '/32', purpose: `BGP Router-ID · spine ${i + 1} of ${spines.length}` })
+  })
+
+  const showLeaves = leaves.slice(0, 10)
+  showLeaves.forEach((d, i) => {
+    rows.push({ device: d.hostname, layer: 'Leaf', iface: 'Loopback0', ip: `10.255.2.${i + 1}`, prefix: '/32', purpose: `BGP Router-ID · leaf ${i + 1} of ${leaves.length}` })
+    rows.push({ device: d.hostname, layer: 'Leaf', iface: 'Loopback1 (VTEP)', ip: `10.255.3.${i + 1}`, prefix: '/32', purpose: 'VXLAN NVE source (anycast)' })
+  })
+  if (leaves.length > 10) {
+    rows.push({ device: `… +${leaves.length - 10} more`, layer: 'Leaf', iface: '—', ip: `10.255.2.11 – 10.255.2.${leaves.length}`, prefix: '/32', purpose: 'Same scheme continues' })
+  }
+
+  dists.forEach((d, i) => {
+    rows.push({ device: d.hostname, layer: 'Distribution', iface: 'Loopback0', ip: `10.255.0.${20 + i}`, prefix: '/32', purpose: `Router-ID · device ${i + 1} of ${dists.length}` })
+  })
+
+  const showAccess = access.slice(0, 8)
+  showAccess.forEach((d, i) => {
+    rows.push({ device: d.hostname, layer: 'Access', iface: 'Vlan10', ip: `10.0.0.${31 + i}`, prefix: '/24', purpose: 'OOB management' })
+  })
+  if (access.length > 8) {
+    rows.push({ device: `… +${access.length - 8} more`, layer: 'Access', iface: 'Vlan10', ip: `10.0.0.${31 + 8} – .${Math.min(30 + access.length, 254)}`, prefix: '/24', purpose: 'OOB management — same scheme' })
+  }
+
+  return rows
+}
+
+// ── VLAN / VNI plan ──────────────────────────────────────────────────────────
+
+export function genVLANs(useCase: string): VLANRow[] {
+  const isDC = useCase === 'dc' || useCase === 'multisite' || useCase === 'gpu'
+  const base: VLANRow[] = [
+    { id: 10,  name: 'MGMT',          subnet: '10.0.0.0/24',   gw: '10.0.0.1',   dhcp: '10.0.0.10–250',   purpose: 'Network device OOB management',  layer: 'mgmt'  },
+    { id: 20,  name: 'CORP-DATA',     subnet: '10.10.0.0/22',  gw: '10.10.0.1',  dhcp: '10.10.0.10–1000', purpose: 'Corporate user endpoints',        layer: 'access'},
+    { id: 21,  name: 'GUEST',         subnet: '10.11.0.0/23',  gw: '10.11.0.1',  dhcp: '10.11.0.10–500',  purpose: 'Guest / BYOD (internet only)',    layer: 'access'},
+    { id: 30,  name: 'VOICE',         subnet: '10.20.0.0/23',  gw: '10.20.0.1',  dhcp: '10.20.0.10–500',  purpose: 'IP Telephony / UC',               layer: 'dist'  },
+    { id: 40,  name: 'WIRELESS-CORP', subnet: '10.30.0.0/22',  gw: '10.30.0.1',  dhcp: '10.30.0.10–1000', purpose: 'Corporate SSID (802.1X)',         layer: 'access'},
+    { id: 50,  name: 'SERVER-FARM',   subnet: '10.50.0.0/22',  gw: '10.50.0.1',  dhcp: 'Static only',     purpose: 'Physical & VM servers',          layer: 'dist'  },
+    { id: 60,  name: 'DMZ',           subnet: '10.60.0.0/24',  gw: '10.60.0.1',  dhcp: 'Static only',     purpose: 'Internet-facing / public SVC',   layer: 'fw'    },
+    { id: 99,  name: 'NATIVE-TRUNK',  subnet: '—',             gw: '—',          dhcp: '—',               purpose: 'Native VLAN on trunk links',     layer: 'mgmt'  },
+  ]
+  if (isDC) {
+    base.push({ id: 100, name: 'DC-TENANT-A', subnet: '10.200.0.0/22', gw: '10.200.0.1', dhcp: 'Dynamic', purpose: 'DC tenant A (VNI 100000)', layer: 'leaf' })
+    base.push({ id: 101, name: 'DC-TENANT-B', subnet: '10.200.4.0/22', gw: '10.200.4.1', dhcp: 'Dynamic', purpose: 'DC tenant B (VNI 100001)', layer: 'leaf' })
+    base.push({ id: 200, name: 'DC-STORAGE',  subnet: '10.201.0.0/22', gw: '10.201.0.1', dhcp: 'Static',  purpose: 'Storage network (iSCSI/NFS)', layer: 'dist' })
+  }
+  return base
+}
+
+export function genVNIs(): VNIRow[] {
+  return [
+    { vni: 100000, vlan: '100', type: 'L2',       vrf: 'TENANT-A', irb: '10.200.0.1/22',   rt: '65000:100'  },
+    { vni: 100001, vlan: '101', type: 'L2',       vrf: 'TENANT-B', irb: '10.200.4.1/22',   rt: '65000:101'  },
+    { vni: 100050, vlan: '50',  type: 'L2',       vrf: 'DEFAULT',  irb: '10.50.0.1/22',    rt: '65000:50'   },
+    { vni: 999000, vlan: '—',   type: 'L3 IP-VRF',vrf: 'TENANT-A', irb: 'Anycast 10.200.0.1', rt: '65000:9000' },
+    { vni: 999001, vlan: '—',   type: 'L3 IP-VRF',vrf: 'TENANT-B', irb: 'Anycast 10.200.4.1', rt: '65000:9001' },
+  ]
+}
+
+// ── NetBox-importable CSV export (IPAM source-of-truth sync) ──────────────────
+// NetBox bulk CSV import uses headers matching model field names. These match
+// NetBox 3.x / 4.x ipam.prefix, ipam.vlan and ipam.ipaddress importers.
+
+/** Quote a CSV cell when it contains a comma, quote or newline (RFC 4180). */
+function csvCell(value: string): string {
+  const v = value ?? ''
+  return /[",\n]/.test(v) ? `"${v.replace(/"/g, '""')}"` : v
+}
+
+function csvRow(cells: string[]): string {
+  return cells.map(csvCell).join(',')
+}
+
+/** True when a string is a single, importable CIDR (not a range or placeholder). */
+function isCidr(s: string): boolean {
+  return /^\d{1,3}(\.\d{1,3}){3}\/\d{1,2}$/.test(s.trim())
+}
+
+/**
+ * NetBox `ipam.prefix` import CSV. Aggregate plan blocks become `container`
+ * prefixes (they're parent supernets carved into smaller subnets); per-VLAN
+ * subnets become `active` prefixes carrying their VLAN id. Prefixes are
+ * de-duplicated by CIDR (first occurrence wins).
+ */
+export function toNetBoxPrefixCsv(blocks: IPBlock[], vlans: VLANRow[]): string {
+  const header = 'prefix,status,role,vlan_vid,description'
+  const seen = new Set<string>()
+  const lines: string[] = []
+
+  for (const b of blocks) {
+    if (!isCidr(b.subnet) || seen.has(b.subnet)) continue
+    seen.add(b.subnet)
+    lines.push(csvRow([b.subnet, 'container', 'infrastructure', '', b.label]))
+  }
+  for (const v of vlans) {
+    if (!isCidr(v.subnet) || seen.has(v.subnet)) continue
+    seen.add(v.subnet)
+    lines.push(csvRow([v.subnet, 'active', v.layer, String(v.id), `${v.name} — ${v.purpose}`]))
+  }
+  return [header, ...lines].join('\n') + '\n'
+}
+
+/** NetBox `ipam.vlan` import CSV. */
+export function toNetBoxVlanCsv(vlans: VLANRow[]): string {
+  const header = 'vid,name,status,description'
+  const lines = vlans.map(v => csvRow([String(v.id), v.name, 'active', v.purpose]))
+  return [header, ...lines].join('\n') + '\n'
+}
+
+/**
+ * NetBox `ipam.ipaddress` import CSV. Summary rows (ranges / "… +N more")
+ * are skipped — only concrete per-device host/loopback addresses are emitted.
+ */
+export function toNetBoxIpAddressCsv(rows: IPRow[]): string {
+  const header = 'address,status,dns_name,description'
+  const lines: string[] = []
+  for (const r of rows) {
+    if (r.device.startsWith('…') || /[–-]\s/.test(r.ip) || !/^\d{1,3}(\.\d{1,3}){3}$/.test(r.ip.trim())) continue
+    const address = `${r.ip}${r.prefix}`
+    const dns = r.device.toLowerCase()
+    lines.push(csvRow([address, 'active', dns, `${r.layer} ${r.iface} — ${r.purpose}`]))
+  }
+  return [header, ...lines].join('\n') + '\n'
+}
+
+export interface NetBoxIpamExport {
+  prefixesCsv: string
+  vlansCsv: string
+  ipAddressesCsv: string
+}
+
+/** Build all three NetBox IPAM CSVs from the computed design. */
+export function buildNetBoxIpamExport(
+  useCase: string,
+  totalEndpoints: number,
+  numSites: number,
+  devices: BOMDevice[],
+): NetBoxIpamExport {
+  const blocks = genIPBlocks(useCase, totalEndpoints, numSites, devices)
+  const vlans  = genVLANs(useCase)
+  const rows   = genIPRows(useCase, devices)
+  return {
+    prefixesCsv: toNetBoxPrefixCsv(blocks, vlans),
+    vlansCsv: toNetBoxVlanCsv(vlans),
+    ipAddressesCsv: toNetBoxIpAddressCsv(rows),
+  }
+}

--- a/frontend/src/pages/Step3Config.tsx
+++ b/frontend/src/pages/Step3Config.tsx
@@ -451,7 +451,7 @@ export function Step3Config() {
 
       <div className="flex justify-between">
         <Button variant="secondary" onClick={prevStep}>&#8592; Back</Button>
-        <Button onClick={nextStep}>Next: ZTP &#8594;</Button>
+        <Button onClick={nextStep}>Next: Deploy &amp; Validate &#8594;</Button>
       </div>
     </div>
   )

--- a/frontend/src/pages/Step4NetworkDesign.tsx
+++ b/frontend/src/pages/Step4NetworkDesign.tsx
@@ -8,6 +8,7 @@ import { LLDTopologyDiagram } from '@/components/LLDTopologyDiagram'
 import { RackElevation } from '@/components/RackElevation'
 import { formatUSD, cn } from '@/lib/utils'
 import { haPairInfo, DCI_RT_ASN } from '@/lib/configgen'
+import { genIPBlocks, genIPRows, genVLANs, genVNIs, buildNetBoxIpamExport } from '@/lib/ipam'
 import type { BOMDevice, AppType } from '@/types'
 
 // ── Tab types ────────────────────────────────────────────────────
@@ -87,119 +88,6 @@ const VENDOR_BADGE_COLORS: Record<string, string> = {
   Juniper:  'bg-orange-900/60 text-orange-300 border border-orange-700/30',
   Arista:   'bg-teal-900/60 text-teal-300 border border-teal-700/30',
   Aviatrix: 'bg-purple-900/60 text-purple-300 border border-purple-700/30',
-}
-
-// ── IP Plan data generator ───────────────────────────────────────
-interface IPBlock { label: string; subnet: string; detail: string; range: string }
-
-function genIPBlocks(useCase: string, totalEndpoints: number, numSites: number, devices: BOMDevice[]): IPBlock[] {
-  const isDC    = useCase === 'dc' || useCase === 'multisite'
-  const isGPU   = useCase === 'gpu'
-  const nSpines = devices.filter(d => d.subLayer === 'spine').length
-  const nLeaves = devices.filter(d => d.subLayer === 'leaf').length
-  const nDist   = devices.filter(d => d.subLayer === 'distribution').length
-  const nAccess = devices.filter(d => d.subLayer === 'access').length
-  const totalInfra = devices.length
-
-  const p2pTotal = isDC ? nLeaves * nSpines : nAccess + nDist
-  const p2pPrefix = p2pTotal <= 256 ? '/23' : '/21'
-
-  const blocks: IPBlock[] = [
-    { label: 'MANAGEMENT OOB',   subnet: '10.0.0.0/24',  detail: `VLAN 10 · ${totalInfra} network devices across ${numSites} site(s)`, range: `10.0.0.1 – 10.0.0.${Math.min(totalInfra + 1, 254)}` },
-    { label: 'LOOPBACKS',        subnet: '10.255.0.0/24',detail: `/32 per device · ${totalInfra} addresses needed`, range: `10.255.0.1 – 10.255.0.${Math.min(totalInfra, 254)}` },
-    { label: 'P2P FABRIC LINKS', subnet: `10.100.0.0${p2pPrefix}`, detail: `/31 per link · ${p2pTotal} links`, range: `10.100.0.0 – covers ${p2pTotal} /31 pairs` },
-    { label: 'CORPORATE DATA',   subnet: '10.10.0.0/22', detail: `VLAN 20 · ${totalEndpoints || 0} endpoints`, range: '10.10.0.1 – 10.10.3.254 (1022 hosts)' },
-    { label: 'VOICE / UC',       subnet: '10.20.0.0/23', detail: 'VLAN 30 · IP Phones, UC', range: '10.20.0.1 – 10.20.1.254 (510 hosts)' },
-    { label: 'SERVER / DMZ',     subnet: '10.50.0.0/22', detail: 'VLAN 50/60 · Physical & VM servers', range: '10.50.0.1 – 10.50.3.254 (1022 hosts)' },
-    { label: 'IoT / GUEST',      subnet: '10.60.0.0/23', detail: 'VLAN 61/21 · Isolated · internet-only ACL', range: '10.60.0.1 – 10.60.1.254 (510 hosts)' },
-  ]
-
-  if (isDC) {
-    blocks.push({ label: `DC UNDERLAY /31 (${nLeaves} leaf × ${nSpines} spine = ${nLeaves * nSpines} links)`, subnet: '10.1.0.0/20', detail: `P2P /31 links · ECMP · BFD`, range: `10.1.0.0 – covers ${nLeaves * nSpines} /31 pairs` })
-    blocks.push({ label: 'DC OVERLAY — VXLAN tenant subnets', subnet: '10.200.0.0/14', detail: `VXLAN VNI space · PROD/STOR/DEV tenants · ${nLeaves} VTEPs`, range: '10.200.0.0 – 10.203.255.255 (262K hosts)' })
-  }
-  if (isGPU) {
-    blocks.push({ label: `GPU COMPUTE fabric`, subnet: '192.168.100.0/22', detail: `RoCEv2 RDMA fabric · lossless · PFC priority 3`, range: '192.168.100.1 – 192.168.103.254' })
-    blocks.push({ label: 'STORAGE — NVMe-oF / GPUDirect', subnet: '192.168.200.0/23', detail: 'NVMe-oF storage fabric · GPUDirect RDMA', range: '192.168.200.1 – 192.168.201.254' })
-  }
-  return blocks
-}
-
-interface IPRow { device: string; layer: string; iface: string; ip: string; prefix: string; purpose: string }
-
-function genIPRows(_useCase: string, devices: BOMDevice[]): IPRow[] {
-  const rows: IPRow[] = []
-  const spines = devices.filter(d => d.subLayer === 'spine')
-  const leaves = devices.filter(d => d.subLayer === 'leaf')
-  const dists  = devices.filter(d => d.subLayer === 'distribution')
-  const access = devices.filter(d => d.subLayer === 'access')
-  const fws    = devices.filter(d => d.subLayer === 'firewall')
-
-  fws.forEach((d, i) => {
-    rows.push({ device: d.hostname, layer: 'Firewall', iface: 'Loopback0', ip: `10.255.0.${i + 1}`, prefix: '/32', purpose: 'Router-ID / BGP peering' })
-    rows.push({ device: d.hostname, layer: 'Firewall', iface: 'Gi0/0', ip: `10.0.0.${i + 1}`, prefix: '/30', purpose: 'Outside / Internet uplink' })
-  })
-
-  spines.forEach((d, i) => {
-    rows.push({ device: d.hostname, layer: 'Spine', iface: 'Loopback0', ip: `10.255.1.${i + 1}`, prefix: '/32', purpose: `BGP Router-ID · spine ${i + 1} of ${spines.length}` })
-  })
-
-  const showLeaves = leaves.slice(0, 10)
-  showLeaves.forEach((d, i) => {
-    rows.push({ device: d.hostname, layer: 'Leaf', iface: 'Loopback0', ip: `10.255.2.${i + 1}`, prefix: '/32', purpose: `BGP Router-ID · leaf ${i + 1} of ${leaves.length}` })
-    rows.push({ device: d.hostname, layer: 'Leaf', iface: 'Loopback1 (VTEP)', ip: `10.255.3.${i + 1}`, prefix: '/32', purpose: 'VXLAN NVE source (anycast)' })
-  })
-  if (leaves.length > 10) {
-    rows.push({ device: `… +${leaves.length - 10} more`, layer: 'Leaf', iface: '—', ip: `10.255.2.11 – 10.255.2.${leaves.length}`, prefix: '/32', purpose: 'Same scheme continues' })
-  }
-
-  dists.forEach((d, i) => {
-    rows.push({ device: d.hostname, layer: 'Distribution', iface: 'Loopback0', ip: `10.255.0.${20 + i}`, prefix: '/32', purpose: `Router-ID · device ${i + 1} of ${dists.length}` })
-  })
-
-  const showAccess = access.slice(0, 8)
-  showAccess.forEach((d, i) => {
-    rows.push({ device: d.hostname, layer: 'Access', iface: 'Vlan10', ip: `10.0.0.${31 + i}`, prefix: '/24', purpose: 'OOB management' })
-  })
-  if (access.length > 8) {
-    rows.push({ device: `… +${access.length - 8} more`, layer: 'Access', iface: 'Vlan10', ip: `10.0.0.${31 + 8} – .${Math.min(30 + access.length, 254)}`, prefix: '/24', purpose: 'OOB management — same scheme' })
-  }
-
-  return rows
-}
-
-// ── VLAN data generator ──────────────────────────────────────────
-interface VLANRow { id: number; name: string; subnet: string; gw: string; dhcp: string; purpose: string; layer: string }
-interface VNIRow  { vni: number; vlan: string; type: string; vrf: string; irb: string; rt: string }
-
-function genVLANs(useCase: string): VLANRow[] {
-  const isDC = useCase === 'dc' || useCase === 'multisite' || useCase === 'gpu'
-  const base: VLANRow[] = [
-    { id: 10,  name: 'MGMT',          subnet: '10.0.0.0/24',   gw: '10.0.0.1',   dhcp: '10.0.0.10–250',   purpose: 'Network device OOB management',  layer: 'mgmt'  },
-    { id: 20,  name: 'CORP-DATA',     subnet: '10.10.0.0/22',  gw: '10.10.0.1',  dhcp: '10.10.0.10–1000', purpose: 'Corporate user endpoints',        layer: 'access'},
-    { id: 21,  name: 'GUEST',         subnet: '10.11.0.0/23',  gw: '10.11.0.1',  dhcp: '10.11.0.10–500',  purpose: 'Guest / BYOD (internet only)',    layer: 'access'},
-    { id: 30,  name: 'VOICE',         subnet: '10.20.0.0/23',  gw: '10.20.0.1',  dhcp: '10.20.0.10–500',  purpose: 'IP Telephony / UC',               layer: 'dist'  },
-    { id: 40,  name: 'WIRELESS-CORP', subnet: '10.30.0.0/22',  gw: '10.30.0.1',  dhcp: '10.30.0.10–1000', purpose: 'Corporate SSID (802.1X)',         layer: 'access'},
-    { id: 50,  name: 'SERVER-FARM',   subnet: '10.50.0.0/22',  gw: '10.50.0.1',  dhcp: 'Static only',     purpose: 'Physical & VM servers',          layer: 'dist'  },
-    { id: 60,  name: 'DMZ',           subnet: '10.60.0.0/24',  gw: '10.60.0.1',  dhcp: 'Static only',     purpose: 'Internet-facing / public SVC',   layer: 'fw'    },
-    { id: 99,  name: 'NATIVE-TRUNK',  subnet: '—',             gw: '—',          dhcp: '—',               purpose: 'Native VLAN on trunk links',     layer: 'mgmt'  },
-  ]
-  if (isDC) {
-    base.push({ id: 100, name: 'DC-TENANT-A', subnet: '10.200.0.0/22', gw: '10.200.0.1', dhcp: 'Dynamic', purpose: 'DC tenant A (VNI 100000)', layer: 'leaf' })
-    base.push({ id: 101, name: 'DC-TENANT-B', subnet: '10.200.4.0/22', gw: '10.200.4.1', dhcp: 'Dynamic', purpose: 'DC tenant B (VNI 100001)', layer: 'leaf' })
-    base.push({ id: 200, name: 'DC-STORAGE',  subnet: '10.201.0.0/22', gw: '10.201.0.1', dhcp: 'Static',  purpose: 'Storage network (iSCSI/NFS)', layer: 'dist' })
-  }
-  return base
-}
-
-function genVNIs(): VNIRow[] {
-  return [
-    { vni: 100000, vlan: '100', type: 'L2',       vrf: 'TENANT-A', irb: '10.200.0.1/22',   rt: '65000:100'  },
-    { vni: 100001, vlan: '101', type: 'L2',       vrf: 'TENANT-B', irb: '10.200.4.1/22',   rt: '65000:101'  },
-    { vni: 100050, vlan: '50',  type: 'L2',       vrf: 'DEFAULT',  irb: '10.50.0.1/22',    rt: '65000:50'   },
-    { vni: 999000, vlan: '—',   type: 'L3 IP-VRF',vrf: 'TENANT-A', irb: 'Anycast 10.200.0.1', rt: '65000:9000' },
-    { vni: 999001, vlan: '—',   type: 'L3 IP-VRF',vrf: 'TENANT-B', irb: 'Anycast 10.200.4.1', rt: '65000:9001' },
-  ]
 }
 
 // ── Routing data generator ───────────────────────────────────────
@@ -331,6 +219,16 @@ export function genComputedTopology(useCase: string, devices: BOMDevice[], appTy
 }
 
 // ── CSV export helpers ───────────────────────────────────────────
+function downloadCsv(content: string, baseName: string) {
+  const blob = new Blob([content], { type: 'text/csv' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = `${baseName}-${new Date().toISOString().slice(0, 10)}.csv`
+  a.click()
+  URL.revokeObjectURL(url)
+}
+
 function exportLLDCSV(useCase: string, devices: BOMDevice[], totalEndpoints: number, numSites: number, underlayProtocol: string, overlayProtocols: string[]) {
   const sections: string[] = []
 
@@ -981,6 +879,31 @@ export function Step4NetworkDesign() {
       {/* ── IP Plan tab ──────────────────────────────────────────────── */}
       {activeTab === 'ipplan' && (
         <div className="space-y-4">
+          {/* NetBox IPAM export */}
+          <Card>
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <div>
+                <h3 className="text-sm font-semibold text-gray-300">NetBox / Nautobot IPAM Export</h3>
+                <p className="text-xs text-gray-500 mt-0.5">
+                  Bulk-import CSVs for IPAM source-of-truth sync (prefixes, VLANs, IP addresses).
+                </p>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <Button variant="secondary" onClick={() => {
+                  const x = buildNetBoxIpamExport(useCase, totalEndpoints, numSites, generatedDevices)
+                  downloadCsv(x.prefixesCsv, `netbox-prefixes-${useCase || 'network'}`)
+                }}>↓ Prefixes CSV</Button>
+                <Button variant="secondary" onClick={() => {
+                  const x = buildNetBoxIpamExport(useCase, totalEndpoints, numSites, generatedDevices)
+                  downloadCsv(x.vlansCsv, `netbox-vlans-${useCase || 'network'}`)
+                }}>↓ VLANs CSV</Button>
+                <Button variant="secondary" onClick={() => {
+                  const x = buildNetBoxIpamExport(useCase, totalEndpoints, numSites, generatedDevices)
+                  downloadCsv(x.ipAddressesCsv, `netbox-ip-addresses-${useCase || 'network'}`)
+                }}>↓ IP Addresses CSV</Button>
+              </div>
+            </div>
+          </Card>
           {/* IP block cards */}
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
             {ipBlocks.map(b => (

--- a/frontend/src/test/ipam.test.ts
+++ b/frontend/src/test/ipam.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest'
+import {
+  genIPBlocks, genIPRows, genVLANs, genVNIs,
+  toNetBoxPrefixCsv, toNetBoxVlanCsv, toNetBoxIpAddressCsv, buildNetBoxIpamExport,
+} from '../lib/ipam'
+import type { BOMDevice } from '@/types'
+
+function dev(subLayer: string, hostname: string, idx: number): BOMDevice {
+  return {
+    id: `${subLayer}-${idx}`, hostname, vendor: 'Cisco', model: 'Test',
+    role: 'Switch', subLayer, count: 1, ports: 48, speed: '25G',
+    features: [], unitPrice: 1000, totalPrice: 1000,
+  }
+}
+
+const dcDevices: BOMDevice[] = [
+  dev('spine', 'IAD-SPINE-A01', 0),
+  dev('spine', 'IAD-SPINE-A02', 1),
+  dev('leaf', 'IAD-LEAF-A01', 0),
+  dev('leaf', 'IAD-LEAF-A02', 1),
+  dev('firewall', 'IAD-FW-A01', 0),
+]
+
+describe('lib/ipam — data generators', () => {
+  it('genIPBlocks returns DC-specific overlay/underlay blocks for dc', () => {
+    const blocks = genIPBlocks('dc', 500, 1, dcDevices)
+    const labels = blocks.map(b => b.label).join(' | ')
+    expect(labels).toContain('MANAGEMENT OOB')
+    expect(labels).toContain('DC UNDERLAY')
+    expect(labels).toContain('DC OVERLAY')
+  })
+
+  it('genIPBlocks adds GPU/storage blocks for gpu', () => {
+    const blocks = genIPBlocks('gpu', 64, 1, dcDevices)
+    const labels = blocks.map(b => b.label).join(' | ')
+    expect(labels).toContain('GPU COMPUTE')
+    expect(labels).toContain('STORAGE')
+  })
+
+  it('genIPRows emits loopbacks for spine/leaf/firewall', () => {
+    const rows = genIPRows('dc', dcDevices)
+    expect(rows.some(r => r.layer === 'Spine' && r.iface === 'Loopback0')).toBe(true)
+    expect(rows.some(r => r.layer === 'Leaf' && r.iface.includes('VTEP'))).toBe(true)
+    expect(rows.some(r => r.layer === 'Firewall')).toBe(true)
+  })
+
+  it('genVLANs includes DC tenant VLANs only for fabric use cases', () => {
+    expect(genVLANs('dc').some(v => v.name === 'DC-TENANT-A')).toBe(true)
+    expect(genVLANs('campus').some(v => v.name === 'DC-TENANT-A')).toBe(false)
+  })
+
+  it('genVNIs returns L2 and L3 VNI rows', () => {
+    const vnis = genVNIs()
+    expect(vnis.some(v => v.type === 'L2')).toBe(true)
+    expect(vnis.some(v => v.type.includes('L3'))).toBe(true)
+  })
+})
+
+describe('lib/ipam — NetBox CSV export', () => {
+  const blocks = genIPBlocks('dc', 500, 1, dcDevices)
+  const vlans = genVLANs('dc')
+  const rows = genIPRows('dc', dcDevices)
+
+  it('prefix CSV has NetBox header and only valid CIDRs', () => {
+    const csv = toNetBoxPrefixCsv(blocks, vlans)
+    const lines = csv.trim().split('\n')
+    expect(lines[0]).toBe('prefix,status,role,vlan_vid,description')
+    for (const line of lines.slice(1)) {
+      const cidr = line.split(',')[0]
+      expect(cidr).toMatch(/^\d{1,3}(\.\d{1,3}){3}\/\d{1,2}$/)
+    }
+  })
+
+  it('prefix CSV marks aggregate blocks as container and VLAN subnets as active', () => {
+    const csv = toNetBoxPrefixCsv(blocks, vlans)
+    expect(csv).toContain(',container,infrastructure,')
+    expect(csv).toContain(',active,')
+  })
+
+  it('prefix CSV de-duplicates by CIDR', () => {
+    const csv = toNetBoxPrefixCsv(blocks, vlans)
+    const cidrs = csv.trim().split('\n').slice(1).map(l => l.split(',')[0])
+    expect(new Set(cidrs).size).toBe(cidrs.length)
+  })
+
+  it('VLAN CSV emits one row per VLAN with active status', () => {
+    const csv = toNetBoxVlanCsv(vlans)
+    const lines = csv.trim().split('\n')
+    expect(lines[0]).toBe('vid,name,status,description')
+    expect(lines.length - 1).toBe(vlans.length)
+    expect(lines[1]).toContain(',active,')
+  })
+
+  it('IP address CSV skips summary/range rows and appends prefix length', () => {
+    const csv = toNetBoxIpAddressCsv(rows)
+    const lines = csv.trim().split('\n')
+    expect(lines[0]).toBe('address,status,dns_name,description')
+    for (const line of lines.slice(1)) {
+      const addr = line.split(',')[0]
+      expect(addr).toMatch(/^\d{1,3}(\.\d{1,3}){3}\/\d{1,2}$/)
+    }
+    expect(csv).not.toContain('…')
+    expect(csv).not.toContain(' – ')
+  })
+
+  it('IP address CSV uses lowercase hostname as dns_name', () => {
+    const csv = toNetBoxIpAddressCsv(rows)
+    expect(csv).toContain('iad-spine-a01')
+  })
+
+  it('buildNetBoxIpamExport returns all three CSVs', () => {
+    const x = buildNetBoxIpamExport('dc', 500, 1, dcDevices)
+    expect(x.prefixesCsv).toContain('prefix,status,role,vlan_vid,description')
+    expect(x.vlansCsv).toContain('vid,name,status,description')
+    expect(x.ipAddressesCsv).toContain('address,status,dns_name,description')
+  })
+
+  it('CSV cells with commas are quoted', () => {
+    const csv = toNetBoxVlanCsv(genVLANs('dc'))
+    // purpose strings contain no commas in defaults, but quoting must be safe:
+    // craft a row by checking the escape helper indirectly via a comma value
+    const withComma = toNetBoxPrefixCsv(
+      [{ label: 'A, B', subnet: '10.9.0.0/24', detail: '', range: '' }],
+      [],
+    )
+    expect(withComma).toContain('"A, B"')
+    expect(csv).toBeTruthy()
+  })
+})


### PR DESCRIPTION
## Summary

Two improvements sourced from §23 (cleanup + NetBox parity) now that the §20/§22 A–D backlog is complete.

### F1 — NetBox / Nautobot IPAM CSV export (NetBox parity, IPAM)
- New **`lib/ipam.ts`** as the single source of truth for IP / VLAN / prefix / VNI planning. The `genIPBlocks` / `genIPRows` / `genVLANs` / `genVNIs` generators were **moved out of `Step4NetworkDesign.tsx`** (which previously held them inline with no tests) so the page and the new export share one implementation.
- NetBox-importable CSV exporters matching NetBox 3.x/4.x importers:
  - `toNetBoxPrefixCsv` → `ipam.prefix` (aggregate blocks as `container`, VLAN subnets as `active`, de-duped by CIDR)
  - `toNetBoxVlanCsv` → `ipam.vlan`
  - `toNetBoxIpAddressCsv` → `ipam.ipaddress` (skips range/summary rows, appends prefix length, lowercase hostname as `dns_name`)
  - `buildNetBoxIpamExport` → all three
  - CIDR validation + RFC-4180 quoting helpers
- 3 download buttons in the Step 4 **"IP Plan"** tab.
- 13 tests in `test/ipam.test.ts`.

### E2 — consistency cleanup
- The Config Gen page (wizard step 5) button said "Next: ZTP →" but actually advances to step 6 "Deploy & Validate". It now reads **"Next: Deploy & Validate →"**, matching the Sidebar label.

## Test plan
- [x] 413 tests pass (`npm test`) — 13 new
- [x] TypeScript clean (`tsc --noEmit`)
- [x] Production build succeeds (`npm run build`)
- [x] Refactor is behavior-preserving — page imports the moved generators; no UI logic change beyond the new export buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DiH1v2ufYHuupbP4xn6pPb

---
_Generated by [Claude Code](https://claude.ai/code/session_01DiH1v2ufYHuupbP4xn6pPb)_