### PR TITLE
feat: G1 — ToR + GPU compute server rack model

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -705,6 +705,12 @@ config-gen tests must keep passing; add new tests alongside).
 |---|------|--------|-------|
 | F1 | IPAM source-of-truth export — push the computed IP/VLAN/prefix plan to NetBox/Nautobot as bulk-import CSVs | [x] | new `lib/ipam.ts` (single source of truth): moved `genIPBlocks`/`genIPRows`/`genVLANs`/`genVNIs` out of `Step4NetworkDesign.tsx` + added `toNetBoxPrefixCsv`/`toNetBoxVlanCsv`/`toNetBoxIpAddressCsv`/`buildNetBoxIpamExport` (NetBox 3.x/4.x ipam.prefix/vlan/ipaddress headers, CIDR validation, de-dup, RFC-4180 quoting); 3 export buttons in Step 4 "IP Plan" tab; 13 tests in `test/ipam.test.ts` |
 
+### G. Rack model — ToR + GPU compute (sourced 2026-06-18)
+
+| # | Item | Status | Notes |
+|---|------|--------|-------|
+| G1 | ToR + GPU compute server rack model — derive compute servers from endpoint count (2048 GPUs → 256 servers), ToR-based rack placement (leaf MLAG pair + N servers per rack), spines in dedicated network rack(s) | [x] | new `gpu-server-4u` product (4U, 8×H100, 6.5kW, $150k); `GPUS_PER_SERVER=8` constant; GPU compute injection in `buildDeviceList`; sequential hostnames (`GPU-001`); `computeToRLayout` in `RackElevation.tsx` (10 servers/rack); SVG capped at 12 racks; 13 new tests |
+
 ---
 
 ## 23. Autonomous "Start Improving" Mode (2026-06-11 →)

--- a/CODE_REFERENCE.md
+++ b/CODE_REFERENCE.md
@@ -130,7 +130,8 @@ cabling, and optics. **Never hardcode device counts — always go through
   Fortinet, Dell EMC, HPE Aruba, NVIDIA, Extreme.
 - `ROLE_CODE: Record<subLayer, hostnameCode>` — `spine→SPINE, leaf→LEAF,
   distribution→DIST, access→ACC, wan-edge→WAN, firewall→FW, cloud-gw→CGW,
-  cloud-transit→CTGW, core→CORE`.
+  cloud-transit→CTGW, core→CORE, gpu-compute→GPU`.
+- `GPUS_PER_SERVER = 8` — exported constant for GPU-to-server ratio.
 
 ### Functions
 - **`resolvePrefs(useCase, vendorPrefs): Record<role, productId>`** — starts
@@ -148,6 +149,9 @@ cabling, and optics. **Never hardcode device counts — always go through
   the next pair, etc.** This pairing convention is what `configgen.ts`'s
   `haPairInfo()` relies on (see below) to derive vPC/MLAG/HSRP pairing
   without needing extra state.
+  - **Exception:** `SEQUENTIAL_ROLES` set (`gpu-compute`) uses sequential
+    numbering instead of HA pairing: `IAD-GPU-001, IAD-GPU-002, ...`
+    (3-digit zero-padded).
 - **`buildDeviceList(state): BOMDevice[]`** — the core port-math engine:
   - Resolves `prefs` via `resolvePrefs()` (or Cisco defaults if no
     `vendorPrefs`).
@@ -174,6 +178,11 @@ cabling, and optics. **Never hardcode device counts — always go through
     useCases.includes(useCase)`), and pushes `qty` `BOMDevice` entries
     (`id = ${product.id}-${globalIdx}`, `hostname: ''` — filled in by
     `generateHostnames()` at the end).
+  - **GPU compute injection** *(2026-06-18)*: when `useCase === 'gpu'` and
+    `totalEndpoints > 0`, appends `ceil(totalEndpoints / GPUS_PER_SERVER)`
+    GPU compute server devices (`subLayer: 'gpu-compute'`, product
+    `gpu-server-4u`). These appear in the BOM summary and enable the ToR
+    rack layout in `RackElevation.tsx`.
   - **Note**: the intermediate `leafCount/spineCount/uplinksNeeded` numbers
     are computed but NOT attached to the returned `BOMDevice[]` — this is
     why `configgen.ts` re-derives uplink/pairing info from `idx`/`hostname`
@@ -702,9 +711,9 @@ rules:
 ## Frontend — `lib/products.ts` / `lib/utils.ts`
 
 ### `lib/products.ts`
-**Purpose:** Static hardware product catalog (31 SKUs) used by `lib/bom.ts` for BOM generation and Step 3 product selection.
+**Purpose:** Static hardware product catalog (32 SKUs) used by `lib/bom.ts` for BOM generation and Step 3 product selection.
 
-**Structure:** `PRODUCTS: Product[]` — 31 entries using the `Product` interface from `types/index.ts`:
+**Structure:** `PRODUCTS: Product[]` — 32 entries using the `Product` interface from `types/index.ts`:
 ```ts
 interface Product {
   id: string; model: string; vendor: string; subLayer: string
@@ -718,6 +727,7 @@ interface Product {
 - Spine/Core: Cisco Nexus 9336C-FX2 / 9364C-GX, Arista 7800R3, Juniper QFX10002-72Q, Dell Z9332F, Aruba CX 10000, NVIDIA Spectrum SN5600, Extreme 8720
 - Leaf/ToR: Cisco Nexus 93180YC-FX / 9332C, Arista 7050CX3-32S, Juniper QFX5120-48Y, Dell S5248F, NVIDIA Spectrum SN4600C, Extreme 8520
 - Distribution/Access (campus): Catalyst 9500-48Y4C, 9300L-48T-4G, 9200-48P, FortiSwitch T1024E/148F-POE, Aruba CX 6400/6300M, Extreme 5720/5420
+- GPU Compute: GPU Server 4U (8x H100) — `subLayer: 'gpu-compute'`, 4U, 6.5kW, $150k
 - WAN/Edge: ASR 1002-HX, Catalyst SD-WAN vEdge 2000, Catalyst 8300 Edge (cEdge)
 - SD-WAN Controllers: vManage, vSmart Controller, vBond Orchestrator
 - IOS-XR SP/WAN: ASR 9904, NCS 540
@@ -1397,16 +1407,22 @@ These four files appear to be retained purely so `e2e-features.test.ts` can smok
   - Rack assignment schedule table (device → rack position/RU/power/ports)
   - Role-color legend
 - `computeRackLayout(devices): RackAssignment[]` — assigns devices to racks:
-  - Sorts by role priority (sdwan-controller → firewall → wan-edge → core → spine → dist → leaf → access)
-  - 2U for spine/core/wan-edge/sdwan-controller, 1U for leaf/access/firewall/distribution
+  - **ToR mode** (when `gpu-compute` devices present): creates Compute racks
+    (leaf MLAG pair as ToR at top + 10× 4U GPU servers filling 40U), plus
+    Network racks for spines/firewalls. Labels: "Compute A/B/C…",
+    "Network Rack 1/2…".
+  - **Dense mode** (no compute): sorts by role priority and packs into racks
+    (sdwan-controller → firewall → wan-edge → core → spine → dist → leaf → access)
+  - 4U for gpu-compute, 2U for spine/core/wan-edge/sdwan-controller,
+    1U for leaf/access/firewall/distribution
   - 0U for cloud-gw/cloud-transit (excluded from physical rack)
-  - Auto-overflow to next rack when capacity exceeded
+  - SVG display capped at 12 racks; full schedule always in table below
 - `buildCableSchedule(devices, cabling): CableRun[]` — expands aggregate CableLink entries
   into per-device-pair cable runs with hostname/port/type/speed/length
 
 **Types:** `RackSlot`, `RackAssignment`, `CableRun` (locally defined)
 
-**Integration:** Step 4 "Rack & Cabling" tab. Tests: 11 in `test/rack.test.ts`.
+**Integration:** Step 4 "Rack & Cabling" tab. Tests: 18 in `test/rack.test.ts`.
 
 #### `frontend/src/components/LLDTopologyDiagram.tsx`
 **Purpose:** Renders pure-SVG, use-case-aware Low-Level Design (LLD) topology diagrams with per-device IP addresses, interface mappings, VLANs, config snippets, port-to-port link labels, and a companion Physical Cabling Matrix table. Provides deeper implementation detail than the HLD diagram.

--- a/frontend/src/components/RackElevation.tsx
+++ b/frontend/src/components/RackElevation.tsx
@@ -44,7 +44,7 @@ const RACK_TOTAL_H = RACK_U * U_HEIGHT + MARGIN_TOP + MARGIN_BOTTOM
 
 const ROLE_ORDER = [
   'sdwan-controller', 'firewall', 'wan-edge', 'core', 'spine',
-  'distribution', 'leaf', 'access', 'cloud-gw', 'cloud-transit',
+  'distribution', 'leaf', 'access', 'gpu-compute', 'cloud-gw', 'cloud-transit',
 ]
 
 const ROLE_COLORS: Record<string, { bg: string; border: string; text: string }> = {
@@ -56,6 +56,7 @@ const ROLE_COLORS: Record<string, { bg: string; border: string; text: string }> 
   'wan-edge':         { bg: '#4A2A0A', border: '#F59E0B', text: '#FDE68A' },
   'sdwan-controller': { bg: '#4A0A2A', border: '#F472B6', text: '#FBCFE8' },
   firewall:           { bg: '#5C1010', border: '#EF4444', text: '#FECACA' },
+  'gpu-compute':      { bg: '#4A0E4E', border: '#E879F9', text: '#F5D0FE' },
   'cloud-gw':         { bg: '#0A3A4A', border: '#22D3EE', text: '#CFFAFE' },
   'cloud-transit':    { bg: '#0A3A4A', border: '#22D3EE', text: '#CFFAFE' },
 }
@@ -68,6 +69,8 @@ function ruForRole(subLayer: string): number {
   switch (subLayer) {
     case 'spine': case 'core': case 'wan-edge': case 'sdwan-controller':
       return 2
+    case 'gpu-compute':
+      return 4
     case 'firewall':
       return 1
     case 'cloud-gw': case 'cloud-transit':
@@ -80,7 +83,7 @@ function ruForRole(subLayer: string): number {
 const ROLE_POWER: Record<string, number> = {
   spine: 800, core: 800, leaf: 480, distribution: 600, access: 400,
   'wan-edge': 300, 'sdwan-controller': 300, firewall: 800,
-  'cloud-gw': 0, 'cloud-transit': 0,
+  'gpu-compute': 6500, 'cloud-gw': 0, 'cloud-transit': 0,
 }
 
 function devicePower(d: BOMDevice): number {
@@ -90,6 +93,11 @@ function devicePower(d: BOMDevice): number {
 // ── Rack layout computation ──────────────────────────────────────────────────
 
 export function computeRackLayout(devices: BOMDevice[]): RackAssignment[] {
+  const hasCompute = devices.some(d => d.subLayer === 'gpu-compute')
+  return hasCompute ? computeToRLayout(devices) : computeDenseLayout(devices)
+}
+
+function computeDenseLayout(devices: BOMDevice[]): RackAssignment[] {
   const physical = devices.filter(d => ruForRole(d.subLayer) > 0)
 
   const sorted = [...physical].sort((a, b) => {
@@ -123,6 +131,113 @@ export function computeRackLayout(devices: BOMDevice[]): RackAssignment[] {
     currentU += h
   }
   if (currentRack.slots.length > 0) racks.push(currentRack)
+  if (racks.length === 0) {
+    racks.push({ rackId: 'R1', label: 'Rack A', slots: [], totalU: RACK_U, usedU: 0, totalPowerW: 0 })
+  }
+  return racks
+}
+
+function addSlot(rack: RackAssignment, startU: number, dev: BOMDevice): number {
+  const h = ruForRole(dev.subLayer)
+  const pw = devicePower(dev)
+  rack.slots.push({ startU, heightU: h, device: dev, powerW: pw })
+  rack.usedU += h
+  rack.totalPowerW += pw
+  return startU + h
+}
+
+function computeToRLayout(devices: BOMDevice[]): RackAssignment[] {
+  const leaves = devices.filter(d => d.subLayer === 'leaf')
+  const compute = devices.filter(d => d.subLayer === 'gpu-compute')
+  const network = devices.filter(d =>
+    d.subLayer !== 'leaf' && d.subLayer !== 'gpu-compute' && ruForRole(d.subLayer) > 0,
+  )
+
+  const leafPairs: BOMDevice[][] = []
+  for (let i = 0; i < leaves.length; i += 2) {
+    leafPairs.push(leaves.slice(i, Math.min(i + 2, leaves.length)))
+  }
+
+  const computeRU = ruForRole('gpu-compute')
+  const leafRU = ruForRole('leaf')
+  const torU = leafRU * 2
+  const serversPerRack = Math.floor((RACK_U - torU) / computeRU)
+
+  const racks: RackAssignment[] = []
+  let computeIdx = 0
+  let pairIdx = 0
+
+  while (computeIdx < compute.length) {
+    const rn = racks.length + 1
+    const rack: RackAssignment = {
+      rackId: `CR${rn}`, label: `Compute ${alphaLabel(rn - 1)}`,
+      slots: [], totalU: RACK_U, usedU: 0, totalPowerW: 0,
+    }
+    let currentU = 1
+
+    if (pairIdx < leafPairs.length) {
+      for (const leaf of leafPairs[pairIdx]) {
+        currentU = addSlot(rack, currentU, leaf)
+      }
+      pairIdx++
+    }
+
+    let placed = 0
+    while (computeIdx < compute.length && placed < serversPerRack && currentU + computeRU - 1 <= RACK_U) {
+      currentU = addSlot(rack, currentU, compute[computeIdx])
+      computeIdx++
+      placed++
+    }
+
+    racks.push(rack)
+  }
+
+  // Remaining leaf pairs without compute servers
+  while (pairIdx < leafPairs.length) {
+    const rn = racks.length + 1
+    const rack: RackAssignment = {
+      rackId: `LR${rn}`, label: `Leaf Rack ${alphaLabel(rn - 1)}`,
+      slots: [], totalU: RACK_U, usedU: 0, totalPowerW: 0,
+    }
+    let currentU = 1
+    for (const leaf of leafPairs[pairIdx]) {
+      currentU = addSlot(rack, currentU, leaf)
+    }
+    pairIdx++
+    racks.push(rack)
+  }
+
+  // Network rack(s) for spines, firewalls
+  if (network.length > 0) {
+    const sortedNet = [...network].sort((a, b) => {
+      const ai = ROLE_ORDER.indexOf(a.subLayer)
+      const bi = ROLE_ORDER.indexOf(b.subLayer)
+      return (ai < 0 ? 99 : ai) - (bi < 0 ? 99 : bi)
+    })
+
+    let netNum = 1
+    let netRack: RackAssignment = {
+      rackId: `NW${netNum}`, label: `Network Rack ${netNum}`,
+      slots: [], totalU: RACK_U, usedU: 0, totalPowerW: 0,
+    }
+    let currentU = 1
+
+    for (const dev of sortedNet) {
+      const h = ruForRole(dev.subLayer)
+      if (currentU + h - 1 > RACK_U) {
+        racks.push(netRack)
+        netNum++
+        netRack = {
+          rackId: `NW${netNum}`, label: `Network Rack ${netNum}`,
+          slots: [], totalU: RACK_U, usedU: 0, totalPowerW: 0,
+        }
+        currentU = 1
+      }
+      currentU = addSlot(netRack, currentU, dev)
+    }
+    if (netRack.slots.length > 0) racks.push(netRack)
+  }
+
   if (racks.length === 0) {
     racks.push({ rackId: 'R1', label: 'Rack A', slots: [], totalU: RACK_U, usedU: 0, totalPowerW: 0 })
   }
@@ -291,6 +406,7 @@ function RackLegend() {
   const items = [
     { label: 'Spine / Core', subLayer: 'spine' },
     { label: 'Leaf / Access', subLayer: 'leaf' },
+    { label: 'GPU Compute', subLayer: 'gpu-compute' },
     { label: 'Distribution', subLayer: 'distribution' },
     { label: 'WAN Edge', subLayer: 'wan-edge' },
     { label: 'SD-WAN Controller', subLayer: 'sdwan-controller' },
@@ -342,13 +458,27 @@ export function RackElevation({ devices, cabling, siteCode }: Props) {
       </div>
 
       {/* Rack SVGs */}
-      <div className="grid gap-6" style={{ gridTemplateColumns: `repeat(${Math.min(racks.length, 3)}, minmax(0, 1fr))` }}>
-        {racks.map(rack => (
-          <div key={rack.rackId} className="bg-black/40 border border-white/10 rounded-xl p-3">
-            <RackSVG rack={rack} />
-          </div>
-        ))}
-      </div>
+      {(() => {
+        const MAX_SVG = 12
+        const display = racks.length <= MAX_SVG ? racks : racks.slice(0, MAX_SVG)
+        const cols = Math.min(display.length, racks.length > 6 ? 4 : 3)
+        return (
+          <>
+            <div className="grid gap-6" style={{ gridTemplateColumns: `repeat(${cols}, minmax(0, 1fr))` }}>
+              {display.map(rack => (
+                <div key={rack.rackId} className="bg-black/40 border border-white/10 rounded-xl p-3">
+                  <RackSVG rack={rack} />
+                </div>
+              ))}
+            </div>
+            {racks.length > MAX_SVG && (
+              <p className="text-xs text-gray-500 text-center mt-2">
+                Showing {MAX_SVG} of {racks.length} racks — see table below for full schedule
+              </p>
+            )}
+          </>
+        )
+      })()}
 
       {/* Cable Schedule Table */}
       {cableRuns.length > 0 && (

--- a/frontend/src/lib/bom.ts
+++ b/frontend/src/lib/bom.ts
@@ -130,7 +130,10 @@ const ROLE_CODE: Record<string, string> = {
   'oran-midhaul':     'OMH',
   'oran-core':        'OC5G',
   'oran-timing':      'OPTM',
+  'gpu-compute':      'GPU',
 }
+
+export const GPUS_PER_SERVER = 8
 
 /** Bijective base-26 column label: 0→A … 25→Z, 26→AA, 27→AB … (no overflow). */
 export function alphaLabel(n: number): string {
@@ -148,6 +151,8 @@ function rackLabel(idx: number): string {
   return alphaLabel(Math.floor(idx / 2))
 }
 
+const SEQUENTIAL_ROLES = new Set(['gpu-compute'])
+
 export function generateHostnames(devices: BOMDevice[], siteCode: string): BOMDevice[] {
   const site = (siteCode || 'SITE').toUpperCase().slice(0, 5)
   const counters: Record<string, number> = {}
@@ -156,6 +161,10 @@ export function generateHostnames(devices: BOMDevice[], siteCode: string): BOMDe
     const code = ROLE_CODE[dev.subLayer] ?? dev.subLayer.toUpperCase().slice(0, 4)
     if (!counters[code]) counters[code] = 0
     const idx = counters[code]++
+    if (SEQUENTIAL_ROLES.has(dev.subLayer)) {
+      const num = String(idx + 1).padStart(3, '0')
+      return { ...dev, hostname: `${site}-${code}-${num}` }
+    }
     const rack = rackLabel(idx)
     const num = String((idx % 2) + 1).padStart(2, '0')
     return { ...dev, hostname: `${site}-${code}-${rack}${num}` }
@@ -271,6 +280,31 @@ export function buildDeviceList(state: Pick<AppState, 'useCase' | 'scale' | 'sit
         uplinks: product.uplinks,
         features: product.features,
       })
+    }
+  }
+
+  // GPU compute server injection: derive server count from GPU endpoint count
+  if (useCase === 'gpu' && endpointCount > 0) {
+    const gpuServerProd = PRODUCTS.find(p => p.id === 'gpu-server-4u')
+    if (gpuServerProd) {
+      const numServers = Math.ceil(endpointCount / GPUS_PER_SERVER)
+      for (let i = 0; i < numServers; i++) {
+        devices.push({
+          id: `gpu-server-4u-${++globalIdx}`,
+          hostname: '',
+          role: 'gpu-compute',
+          subLayer: gpuServerProd.subLayer,
+          model: gpuServerProd.model,
+          vendor: gpuServerProd.vendor,
+          count: 1,
+          unitPrice: gpuServerProd.priceUSD,
+          totalPrice: gpuServerProd.priceUSD,
+          speed: gpuServerProd.speed,
+          ports: gpuServerProd.ports,
+          uplinks: gpuServerProd.uplinks,
+          features: gpuServerProd.features,
+        })
+      }
     }
   }
 
@@ -442,6 +476,7 @@ const ROLE_DEFAULT_POWER_W: Record<string, number> = {
   'oran-midhaul': 600,
   'oran-core': 1000,
   'oran-timing': 50,
+  'gpu-compute': 6500,
 }
 
 /** Rack units consumed by a device, derived from its sub-layer role. */
@@ -466,6 +501,8 @@ function rackUnitsFor(subLayer: string): number {
       return 0 // field-mounted — no rack RU
     case 'oran-midhaul':
       return 2
+    case 'gpu-compute':
+      return 4
     default:
       return 1 // leaf / distribution / access — 1RU ToR/fixed
   }

--- a/frontend/src/lib/products.ts
+++ b/frontend/src/lib/products.ts
@@ -403,6 +403,23 @@ export const PRODUCTS: Product[] = [
     detail: 'PTP Grandmaster clock — GNSS-synced, G.8275.1 telecom profile, Class A',
   },
 
+  // ── GPU Compute Servers ──────────────────────────────────────────────────
+  {
+    id: 'gpu-server-4u',
+    model: 'GPU Server 4U (8x H100)',
+    vendor: 'NVIDIA',
+    subLayer: 'gpu-compute',
+    ports: 4,
+    uplinks: 0,
+    speed: '100G',
+    asic: 'H100 SXM',
+    powerW: 6500,
+    priceUSD: 150000,
+    features: ['RoCEv2', 'RDMA', 'NCCL', 'GPU-Direct', 'NVLink'],
+    useCases: ['gpu'],
+    detail: '4U chassis, 8x H100 SXM GPUs, dual ConnectX-7 100G NICs',
+  },
+
   // ── Aviatrix ────────────────────────────────────────────────────────────────
   {
     id: 'aviatrix-gw',

--- a/frontend/src/test/bom.test.ts
+++ b/frontend/src/test/bom.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { buildDeviceList, buildBOM, SCALE_DEFS, alphaLabel, generateHostnames } from '@/lib/bom'
+import { buildDeviceList, buildBOM, SCALE_DEFS, alphaLabel, generateHostnames, GPUS_PER_SERVER } from '@/lib/bom'
 import { haPairInfo } from '@/lib/configgen'
 import type { BOMDevice } from '@/types'
 
@@ -132,5 +132,65 @@ describe('generateHostnames at large scale (regression: leaf > 52)', () => {
     expect(info.isPrimary).toBe(true)
     expect(info.peerHostname).toBe('IAD-LEAF-AA02')
     expect(info.domainId).toBe('IAD-LEAF-AA')
+  })
+})
+
+describe('GPU compute server injection', () => {
+  it('adds compute servers when GPU use case has totalEndpoints', () => {
+    const devices = buildDeviceList({
+      useCase: 'gpu', scale: 'small', siteCode: 'IAD', totalEndpoints: 64,
+    })
+    const compute = devices.filter(d => d.subLayer === 'gpu-compute')
+    expect(compute.length).toBe(Math.ceil(64 / GPUS_PER_SERVER)) // 8 servers
+  })
+
+  it('does not add compute servers when totalEndpoints is 0', () => {
+    const devices = buildDeviceList({ useCase: 'gpu', scale: 'small', siteCode: 'IAD' })
+    const compute = devices.filter(d => d.subLayer === 'gpu-compute')
+    expect(compute.length).toBe(0)
+  })
+
+  it('does not add compute servers for DC use case', () => {
+    const devices = buildDeviceList({
+      useCase: 'dc', scale: 'small', siteCode: 'IAD', totalEndpoints: 500,
+    })
+    const compute = devices.filter(d => d.subLayer === 'gpu-compute')
+    expect(compute.length).toBe(0)
+  })
+
+  it('compute servers have sequential hostnames (not HA-paired)', () => {
+    const devices = buildDeviceList({
+      useCase: 'gpu', scale: 'small', siteCode: 'IAD', totalEndpoints: 24,
+    })
+    const compute = devices.filter(d => d.subLayer === 'gpu-compute')
+    expect(compute.length).toBe(3) // 24/8 = 3
+    expect(compute[0].hostname).toBe('IAD-GPU-001')
+    expect(compute[1].hostname).toBe('IAD-GPU-002')
+    expect(compute[2].hostname).toBe('IAD-GPU-003')
+  })
+
+  it('derives correct server count for large GPU fabric (2048 GPUs)', () => {
+    const devices = buildDeviceList({
+      useCase: 'gpu', scale: 'large', siteCode: 'IAD',
+      totalEndpoints: 2048, bandwidthPerServer: '100G', oversubscription: 1,
+    })
+    const compute = devices.filter(d => d.subLayer === 'gpu-compute')
+    const leaves = devices.filter(d => d.subLayer === 'leaf')
+    const spines = devices.filter(d => d.subLayer === 'spine')
+    expect(compute.length).toBe(256) // 2048 / 8
+    expect(leaves.length).toBeGreaterThan(0)
+    expect(spines.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('compute servers included in BOM summary and grandTotal', () => {
+    const { summary, grandTotal, devices } = buildBOM({
+      useCase: 'gpu', scale: 'small', siteCode: 'IAD', totalEndpoints: 16,
+    })
+    const gpuRow = Object.values(summary).find(r => r.subLayer === 'gpu-compute')
+    expect(gpuRow).toBeDefined()
+    expect(gpuRow!.qty).toBe(2) // 16/8 = 2
+    expect(gpuRow!.totalCost).toBe(gpuRow!.unitCost * gpuRow!.qty)
+    const total = devices.reduce((s, d) => s + d.unitPrice, 0)
+    expect(grandTotal).toBe(total)
   })
 })

--- a/frontend/src/test/rack.test.ts
+++ b/frontend/src/test/rack.test.ts
@@ -106,6 +106,108 @@ describe('computeRackLayout (G-A14)', () => {
   })
 })
 
+describe('computeRackLayout — ToR + GPU compute', () => {
+  function makeCompute(id: string): BOMDevice {
+    return makeDevice({
+      id, hostname: `IAD-GPU-${id}`, subLayer: 'gpu-compute',
+      model: 'GPU Server 4U (8x H100)', vendor: 'NVIDIA',
+      unitPrice: 150000, totalPrice: 150000, ports: 4,
+    })
+  }
+
+  it('uses ToR layout when gpu-compute devices present', () => {
+    const devices = [
+      makeDevice({ id: 's1', hostname: 'SPINE-A01', subLayer: 'spine' }),
+      makeDevice({ id: 'l1', hostname: 'LEAF-A01', subLayer: 'leaf' }),
+      makeDevice({ id: 'l2', hostname: 'LEAF-A02', subLayer: 'leaf' }),
+      makeCompute('001'), makeCompute('002'), makeCompute('003'),
+    ]
+    const racks = computeRackLayout(devices)
+    const computeRacks = racks.filter(r => r.rackId.startsWith('CR'))
+    const netRacks = racks.filter(r => r.rackId.startsWith('NW'))
+    expect(computeRacks.length).toBe(1) // 3 servers fit in 1 rack
+    expect(netRacks.length).toBe(1) // 1 spine
+    // Compute rack has leaf pair at top + compute below
+    expect(computeRacks[0].slots[0].device.subLayer).toBe('leaf')
+    expect(computeRacks[0].slots[1].device.subLayer).toBe('leaf')
+    expect(computeRacks[0].slots[2].device.subLayer).toBe('gpu-compute')
+  })
+
+  it('places 10 compute servers per rack (40U / 4U = 10)', () => {
+    const leaves = Array.from({ length: 4 }, (_, i) =>
+      makeDevice({ id: `l${i}`, hostname: `LEAF-${i}`, subLayer: 'leaf' }),
+    )
+    const servers = Array.from({ length: 20 }, (_, i) => makeCompute(`${i}`))
+    const racks = computeRackLayout([...leaves, ...servers])
+    const computeRacks = racks.filter(r => r.rackId.startsWith('CR'))
+    expect(computeRacks.length).toBe(2) // 20 servers / 10 per rack
+    expect(computeRacks[0].slots.filter(s => s.device.subLayer === 'gpu-compute').length).toBe(10)
+    expect(computeRacks[1].slots.filter(s => s.device.subLayer === 'gpu-compute').length).toBe(10)
+  })
+
+  it('assigns gpu-compute 4U height', () => {
+    const devices = [
+      makeDevice({ id: 'l1', subLayer: 'leaf' }),
+      makeDevice({ id: 'l2', subLayer: 'leaf' }),
+      makeCompute('001'),
+    ]
+    const racks = computeRackLayout(devices)
+    const gpuSlot = racks[0].slots.find(s => s.device.subLayer === 'gpu-compute')
+    expect(gpuSlot?.heightU).toBe(4)
+  })
+
+  it('spines go to network rack, not compute rack', () => {
+    const devices = [
+      makeDevice({ id: 's1', subLayer: 'spine' }),
+      makeDevice({ id: 's2', subLayer: 'spine' }),
+      makeDevice({ id: 'l1', subLayer: 'leaf' }),
+      makeDevice({ id: 'l2', subLayer: 'leaf' }),
+      makeCompute('001'),
+    ]
+    const racks = computeRackLayout(devices)
+    const netRack = racks.find(r => r.rackId.startsWith('NW'))
+    expect(netRack).toBeDefined()
+    expect(netRack!.slots.every(s => s.device.subLayer === 'spine')).toBe(true)
+  })
+
+  it('labels compute racks with alphaLabel', () => {
+    const servers = Array.from({ length: 30 }, (_, i) => makeCompute(`${i}`))
+    const racks = computeRackLayout(servers)
+    const computeRacks = racks.filter(r => r.rackId.startsWith('CR'))
+    expect(computeRacks[0].label).toBe('Compute A')
+    expect(computeRacks[1].label).toBe('Compute B')
+    expect(computeRacks[2].label).toBe('Compute C')
+  })
+
+  it('handles large GPU fabric — 256 servers yield ~26 compute racks', () => {
+    const leaves = Array.from({ length: 52 }, (_, i) =>
+      makeDevice({ id: `l${i}`, hostname: `LEAF-${i}`, subLayer: 'leaf' }),
+    )
+    const servers = Array.from({ length: 256 }, (_, i) => makeCompute(`${i}`))
+    const spines = Array.from({ length: 3 }, (_, i) =>
+      makeDevice({ id: `s${i}`, hostname: `SPINE-${i}`, subLayer: 'spine' }),
+    )
+    const racks = computeRackLayout([...spines, ...leaves, ...servers])
+    const computeRacks = racks.filter(r => r.rackId.startsWith('CR'))
+    const netRacks = racks.filter(r => r.rackId.startsWith('NW'))
+    expect(computeRacks.length).toBe(26) // 256 / 10 = 25.6 → 26
+    expect(netRacks.length).toBeGreaterThanOrEqual(1)
+    // Each compute rack should have leaf pair + servers
+    expect(computeRacks[0].slots[0].device.subLayer).toBe('leaf')
+  })
+
+  it('falls back to dense layout when no gpu-compute devices', () => {
+    const devices = [
+      makeDevice({ id: 's1', subLayer: 'spine' }),
+      makeDevice({ id: 'l1', subLayer: 'leaf' }),
+    ]
+    const racks = computeRackLayout(devices)
+    // Dense layout puts spine before leaf (role order), uses R-prefix rack IDs
+    expect(racks[0].rackId).toBe('R1')
+    expect(racks[0].slots[0].device.subLayer).toBe('spine')
+  })
+})
+
 describe('buildCableSchedule (G-A14)', () => {
   it('generates cable runs from cabling data', () => {
     const devices = [


### PR DESCRIPTION
## Summary

- **GPU compute server injection**: when `useCase=gpu` and `totalEndpoints > 0`, derives server count from GPU count (2048 GPUs ÷ 8 GPUs/server = 256 servers) and adds them to the BOM as `gpu-compute` devices
- **ToR-based rack layout**: `computeRackLayout` now detects `gpu-compute` devices and switches to realistic datacenter placement — each compute rack gets a leaf MLAG pair (ToR) at the top + up to 10 GPU servers (4U each) filling the remaining 40U, with spines/firewalls in dedicated network racks
- **New product**: `gpu-server-4u` (4U chassis, 8× H100 SXM GPUs, 6.5kW, $150k) in products.ts
- **Sequential hostnames**: compute servers get `IAD-GPU-001, IAD-GPU-002, ...` (not HA-paired)
- **SVG cap**: rack elevation SVGs capped at 12 for large fabrics; full schedule always in table

Fixes the user-reported issue where a 2048-GPU design produced only 2 racks (dense-packing 73 switches). Now produces ~26 compute racks + network rack(s) — realistic datacenter layout.

## Test plan

- [x] 13 new tests (7 ToR rack layout + 6 GPU compute BOM)
- [x] All 432 tests passing
- [x] `tsc --noEmit` clean
- [x] `npm run build` succeeds
- [x] Existing rack/BOM tests unchanged and passing
- [ ] Visual check: GPU use case with totalEndpoints shows compute racks in Step 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DiH1v2ufYHuupbP4xn6pPb

---
_Generated by [Claude Code](https://claude.ai/code/session_01DiH1v2ufYHuupbP4xn6pPb)_