### PR TITLE
fix: skip gpu-compute in config/telemetry gen + React side-effect fixes

### DIFF
--- a/frontend/src/lib/bom.ts
+++ b/frontend/src/lib/bom.ts
@@ -636,6 +636,7 @@ function selectCable(distM: number, speed: string): CableSpec {
 
 const LAYER_CONNECTS: Array<{ from: string; to: string; key: string }> = [
   { from: 'spine',        to: 'leaf',         key: 'spine-leaf'  },
+  { from: 'leaf',         to: 'gpu-compute',  key: 'spine-leaf'  },
   { from: 'core',         to: 'distribution', key: 'core-dist'   },
   { from: 'distribution', to: 'access',       key: 'dist-access' },
   { from: 'wan-edge',     to: 'distribution', key: 'wan-edge'    },

--- a/frontend/src/lib/configgen.ts
+++ b/frontend/src/lib/configgen.ts
@@ -3547,7 +3547,10 @@ function oranConfig(dev: BOMDevice, idx: number): string {
   }
 }
 
+const NON_NETWORK_LAYERS = new Set(['gpu-compute', 'cloud-gw', 'cloud-transit'])
+
 export function generateConfig(dev: BOMDevice, idx: number, useCase: UseCase | '' = '', appTypes: AppType[] = [], allDevices: BOMDevice[] = [], protoFeatures: string[] = []): string {
+  if (NON_NETWORK_LAYERS.has(dev.subLayer)) return ''
   const isGpu = useCase === 'gpu'
   const v = dev.vendor
   const l = dev.subLayer
@@ -3583,13 +3586,15 @@ export function generateAllConfigs(
   appTypes: AppType[] = [],
   protoFeatures: string[] = [],
 ): Record<string, string> {
-  return Object.fromEntries(
-    devices.map((dev, i) => {
-      const base = generateConfig(dev, i, useCase, appTypes, devices, protoFeatures)
-      const withPolicies = policyBlocks.length
-        ? applyPolicies(base, dev, useCase, policyBlocks)
-        : base
-      return [dev.id, withPolicies]
-    })
-  )
+  const entries: [string, string][] = []
+  for (let i = 0; i < devices.length; i++) {
+    const dev = devices[i]
+    const base = generateConfig(dev, i, useCase, appTypes, devices, protoFeatures)
+    if (!base) continue
+    const withPolicies = policyBlocks.length
+      ? applyPolicies(base, dev, useCase, policyBlocks)
+      : base
+    entries.push([dev.id, withPolicies])
+  }
+  return Object.fromEntries(entries)
 }

--- a/frontend/src/lib/telemetry-gen.ts
+++ b/frontend/src/lib/telemetry-gen.ts
@@ -83,7 +83,7 @@ export function buildTelemetryTargets(devices: BOMDevice[]): TelemetryTarget[] {
   const targets: TelemetryTarget[] = []
   let octet = 11
   for (const dev of devices) {
-    if (dev.subLayer === 'firewall') continue
+    if (dev.subLayer === 'firewall' || dev.subLayer === 'gpu-compute') continue
     const os   = deviceOS(dev.vendor, dev.subLayer)
     const port = GNMI_PORT[os] ?? 6030
     const count = Math.min(dev.count, 4)

--- a/frontend/src/pages/Step2Design.tsx
+++ b/frontend/src/pages/Step2Design.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import {
   useReactTable,
   getCoreRowModel,
@@ -257,7 +257,7 @@ export function Step2Design() {
     [useCase, scale, siteCode, totalEndpoints, bandwidthPerServer, oversubscription, vendorPrefs, trafficPattern, firewallModel, overlayProtocols]
   )
 
-  useMemo(() => { setDevices(generatedDevices) }, [generatedDevices, setDevices])
+  useEffect(() => { setDevices(generatedDevices) }, [generatedDevices, setDevices])
 
   const cabling = useMemo(() => buildCabling(generatedDevices, linkDistances), [generatedDevices, linkDistances])
   const optics  = useMemo(() => buildOptics(generatedDevices, linkDistances),  [generatedDevices, linkDistances])

--- a/frontend/src/pages/Step4NetworkDesign.tsx
+++ b/frontend/src/pages/Step4NetworkDesign.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, useRef } from 'react'
+import { useEffect, useMemo, useState, useRef } from 'react'
 import { useAppStore } from '@/store/useAppStore'
 import { buildBOM, buildCabling, computeTCO } from '@/lib/bom'
 import { Button } from '@/components/ui/Button'
@@ -699,7 +699,7 @@ export function Step4NetworkDesign() {
     [useCase, scale, siteCode, totalEndpoints, bandwidthPerServer, oversubscription, vendorPrefs, trafficPattern, firewallModel, overlayProtocols]
   )
 
-  useMemo(() => { setDevices(generatedDevices) }, [generatedDevices, setDevices])
+  useEffect(() => { setDevices(generatedDevices) }, [generatedDevices, setDevices])
 
   const useCaseLabel = (useCase && USE_CASE_LABELS[useCase]) || useCase || '—'
   const uniqueModels = Object.values(summary).length

--- a/frontend/src/store/useAppStore.ts
+++ b/frontend/src/store/useAppStore.ts
@@ -152,7 +152,7 @@ export const useAppStore = create<AppStore>()(
       nextStep: () => set(s => ({ step: Math.min(s.step + 1, 6) })),
       prevStep: () => set(s => ({ step: Math.max(s.step - 1, 1) })),
 
-      setUseCase: useCase => set({ useCase, configs: {} }),
+      setUseCase: useCase => set({ useCase, configs: {}, devices: [], cabling: [], optics: [] }),
       setAppTypes: appTypes => set({ appTypes }),
       setSiteName: siteName => set({ siteName }),
       setSiteCode: siteCode => set({ siteCode }),


### PR DESCRIPTION
## Summary

- **configgen.ts**: Skip config generation for non-network layers (gpu-compute, cloud-gw, cloud-transit) — was falling through to genericConfig()
- **telemetry-gen.ts**: Skip gpu-compute devices in telemetry target generation — was treating them as SONiC switches
- **bom.ts**: Add leaf→gpu-compute cable runs to LAYER_CONNECTS — was silently omitting ~512 cable runs in large GPU designs
- **Step2Design.tsx / Step4NetworkDesign.tsx**: Fix useMemo-as-side-effect anti-pattern → useEffect (React 19 concurrent mode)
- **useAppStore.ts**: Clear devices/cabling/optics on use-case change to prevent stale data in Step 6 simulations

## Test plan
- [x] All 432 tests passing
- [x] tsc clean
- [x] Build passes

---
_Generated by [Claude Code](https://claude.ai/code/session_01DiH1v2ufYHuupbP4xn6pPb)_