### PR TITLE
feat: K1 — auto-rollback on post-check regression (closed-loop)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -758,6 +758,18 @@ config-gen tests must keep passing; add new tests alongside).
 | J1 | Auth foundation + login UI + per-user My Designs + role gating | [x] | `store/useAuthStore.ts` (backend login via `/api/auth/token`+`/totp-verify`, demo local profiles, `can()` mirroring backend `ROLE_PERMISSIONS`, per-user `prefsByUser`, `authScopeKey()`); `LoginModal.tsx` (account + demo-profile tabs, MFA step); Sidebar account block (user badge, role chip, sign in/out) + role-gated Enterprise/policy items (gating only applies when signed in — guests keep full access); `MyDesigns` storage key namespaced per user; `client.ts` `login()`/`verifyTotp()`; 14 tests `auth-store.test.ts` |
 | J2 | Per-user activity dashboard + full preferences sync + backend-persisted designs (`/api/designs`) — apply saved theme/vendorPrefs on login, "recent designs" view, profile switcher UI, server-side design storage when live | [x] | `activitiesByUser` in auth store (per-user, capped 50, persisted); `logActivity()` action tracks create/load/delete/deploy/export; `getActivities()` selector; `useApplyPrefsOnLogin` hook (theme, vendorPrefs, lastUseCase synced on login); MyDesigns: tabs (Saved/Recent Activity), activity timeline with action icons + relative timestamps; Sidebar: profile switcher dropdown (avatar click reveals other saved profiles); `client.ts`: `fetchUserPrefs`/`saveUserPrefs`/`fetchUserActivity`/`postUserActivity` for backend sync when live; 7 new tests in `auth-store.test.ts` (21 total) |
 
+### K. Closed-loop automation (sourced 2026-06-22 — §20 + §22 A–J exhausted)
+
+> Per §23 "Sourcing new work" priority 3: drift detection → auto-remediation,
+> auto-rollback on post-check regression. Builds on existing pre/post checks
+> (§12), drift remediation (G-A4/G-A16), and the documented platform-native
+> rollback strategies (§9 ROLLBACK_STRATEGIES — currently Python-only, not
+> exposed in the frontend).
+
+| # | Item | Status | Notes |
+|---|------|--------|-------|
+| K1 | Auto-rollback on post-check regression — detect checks that regressed PASS→FAIL/WARN between pre and post phases, classify severity, and generate platform-native rollback commands (§9 strategies) per affected device; surface as a "Rollback Advisor" in Step 6 | [x] | new `lib/rollback.ts` (`ROLLBACK_STRATEGIES` ported from §9, `vendorToPlatform`, `detectRegressions` PASS→FAIL=critical/WARN→FAIL=major/PASS→WARN=minor, `generateRollbackPlan`, `rollbackCommandsFor`, `rollbackTimestamp`, `rollbackPlanToText`); "🛟 Rollback Advisor" card in Step 6 Checks tab (after Pre→Post Delta) — recommendation banner, per-device regression list + platform-native restore commands, download runbook; 25 tests in `test/rollback.test.ts` |
+
 ---
 
 ## 23. Autonomous "Start Improving" Mode (2026-06-11 →)

--- a/CODE_REFERENCE.md
+++ b/CODE_REFERENCE.md
@@ -926,6 +926,36 @@ capacity-breach year predictions and actionable recommendations
   growth-rate selector and year-by-year projection table.
 - **Tests**: 15 in `test/capacity-planning.test.ts`.
 
+## Frontend — `lib/rollback.ts` (Closed-loop auto-rollback — K1)
+
+**Purpose:** Detects post-check regressions (a check that was healthy
+pre-deploy now FAILs/WARNs) and generates the platform-native rollback
+commands to restore each affected device from its pre-deploy checkpoint.
+Pure functions, demo-mode friendly. The backend
+(`jobs/deploy_job.py::_initiate_rollback`) performs the *actual* restore
+from captured backups; this is the design-time advisor + exact commands.
+
+**Key exports:**
+- `Platform` = `'nxos'|'iosxe'|'eos'|'junos'|'sonic'`.
+- `ROLLBACK_STRATEGIES: Record<Platform, RollbackStrategy>` — ported from
+  CLAUDE.md §9 (keep in sync). `{ pre?, exec?, deployCmd?, note? }` with
+  `{ts}` token.
+- `vendorToPlatform(vendor, subLayer)` — Cisco spine/leaf→nxos, Cisco
+  edge/campus→iosxe, Arista→eos, Juniper→junos, Dell/NVIDIA→sonic, else iosxe.
+- `Regression { device, checkName, fromStatus, toStatus, severity, message }`;
+  `Severity` = critical (PASS→FAIL) | major (WARN→FAIL) | minor (PASS→WARN).
+- `detectRegressions(pre, post)` — matches CheckResults on `device::name`,
+  flags strict worsening (STATUS_RANK PASS<WARN<FAIL, SKIP ignored).
+- `generateRollbackPlan(pre, post, devices, ts?)` → `RollbackPlan
+  { regressions, devices: DeviceRollbackPlan[], recommended, summary }`;
+  `recommended` = any critical/major. Sorts worst-affected device first.
+- `rollbackCommandsFor(platform, ts)`, `rollbackTimestamp(date?)`
+  (`YYYYMMDD-HHMMSS`), `rollbackPlanToText(plan, ts?)` (copy/paste runbook).
+- **UI**: "🛟 Rollback Advisor" card in Step 6 Checks tab (after Pre→Post
+  Delta) — appears once both pre+post checks ran; recommendation banner,
+  per-device regression list + restore commands, download runbook.
+- **Tests**: 25 in `test/rollback.test.ts`.
+
 ## Frontend — `lib/netbox.ts` (NetBox/Nautobot import — Enterprise Upgrade B1)
 
 **Purpose:** Reads existing inventory from a NetBox or Nautobot instance

--- a/frontend/src/lib/rollback.ts
+++ b/frontend/src/lib/rollback.ts
@@ -1,0 +1,246 @@
+/**
+ * Closed-loop automation — auto-rollback on post-check regression (K1).
+ *
+ * When a deployment's post-checks regress relative to the pre-deploy baseline
+ * (a check that was PASS before the change now FAILs/WARNs), the change has
+ * likely caused damage and should be rolled back. This module:
+ *
+ *   1. detectRegressions(pre, post)  — diffs pre vs post CheckResult[] and
+ *      classifies every check that got *worse* by severity.
+ *   2. generateRollbackPlan(...)     — for the affected devices, emits the
+ *      platform-native rollback commands (CLAUDE.md §9 ROLLBACK_STRATEGIES,
+ *      ported here from backend Python) so an operator can restore the
+ *      pre-deploy checkpoint.
+ *
+ * Pure functions, no backend required — works in demo mode. The backend
+ * (`backend/jobs/deploy_job.py::_initiate_rollback`) performs the *actual*
+ * restore from captured backups; this is the design-time advisor + the
+ * exact commands that restore would run.
+ */
+import type { CheckResult, BOMDevice } from '@/types'
+
+// ── Platform model ──────────────────────────────────────────────────────────
+
+export type Platform = 'nxos' | 'iosxe' | 'eos' | 'junos' | 'sonic'
+
+export interface RollbackStrategy {
+  /** Checkpoint/backup command to run *before* deploy (uses `{ts}` token). */
+  pre?: string
+  /** Restore command to run to roll back (uses `{ts}` token). */
+  exec?: string
+  /** Junos-style: deploy with auto-rollback if not confirmed. */
+  deployCmd?: string
+  note?: string
+}
+
+/**
+ * Platform-native rollback strategies — mirror of CLAUDE.md §9
+ * `ROLLBACK_STRATEGIES` (kept identical so the doc and code stay in sync).
+ */
+export const ROLLBACK_STRATEGIES: Record<Platform, RollbackStrategy> = {
+  nxos: {
+    pre: 'checkpoint pre-deploy-{ts}',
+    exec: 'rollback running-config checkpoint pre-deploy-{ts} atomic',
+  },
+  iosxe: {
+    pre: 'copy running-config flash:pre-deploy-{ts}.cfg',
+    exec: 'configure replace flash:pre-deploy-{ts}.cfg force',
+  },
+  eos: {
+    pre: 'copy running-config checkpoint://pre-deploy-{ts}',
+    exec: 'rollback clean-config checkpoint://pre-deploy-{ts}',
+  },
+  junos: {
+    deployCmd: 'commit confirmed 5',
+    exec: 'rollback 1\ncommit',
+    note: 'commit confirmed auto-reverts if the change is not confirmed within the window',
+  },
+  sonic: {
+    pre: 'config save /etc/sonic/config_db_pre_{ts}.json',
+    exec: 'config load /etc/sonic/config_db_pre_{ts}.json -y',
+  },
+}
+
+/**
+ * Map a BOM device's vendor + role to its rollback platform key. Mirrors the
+ * config-gen dispatch (Cisco spine/leaf = NX-OS, Cisco edge/campus = IOS-XE)
+ * and `telemetry-gen.ts::deviceOS`.
+ */
+export function vendorToPlatform(vendor: string, subLayer: string): Platform {
+  switch (vendor) {
+    case 'Cisco':
+      return subLayer === 'spine' || subLayer === 'leaf' ? 'nxos' : 'iosxe'
+    case 'Arista':
+      return 'eos'
+    case 'Juniper':
+      return 'junos'
+    case 'Dell EMC':
+    case 'NVIDIA':
+      return 'sonic'
+    default:
+      return 'iosxe'
+  }
+}
+
+// ── Regression detection ────────────────────────────────────────────────────
+
+export type CheckStatus = CheckResult['status']
+
+export type Severity = 'critical' | 'major' | 'minor'
+
+export interface Regression {
+  device: string
+  checkName: string
+  fromStatus: CheckStatus
+  toStatus: CheckStatus
+  severity: Severity
+  message: string
+}
+
+/** Ordinal health ranking — higher is worse. SKIP is neutral (excluded). */
+const STATUS_RANK: Record<CheckStatus, number> = { PASS: 0, WARN: 1, FAIL: 2, SKIP: -1 }
+
+function severityFor(from: CheckStatus, to: CheckStatus): Severity {
+  if (from === 'PASS' && to === 'FAIL') return 'critical'
+  if (to === 'FAIL') return 'major' // WARN → FAIL
+  return 'minor' // PASS → WARN
+}
+
+/**
+ * Compare pre-deploy and post-deploy checks, returning every check that
+ * regressed (got strictly worse). Checks are matched on `device` + `name`.
+ * SKIP results on either side are ignored (nothing meaningful to compare).
+ */
+export function detectRegressions(pre: CheckResult[], post: CheckResult[]): Regression[] {
+  const preIndex = new Map<string, CheckResult>()
+  for (const c of pre) preIndex.set(`${c.device}::${c.name}`, c)
+
+  const regressions: Regression[] = []
+  for (const p of post) {
+    const baseline = preIndex.get(`${p.device}::${p.name}`)
+    if (!baseline) continue
+    const fromRank = STATUS_RANK[baseline.status]
+    const toRank = STATUS_RANK[p.status]
+    // Ignore SKIP on either side, and only flag a strict worsening.
+    if (fromRank < 0 || toRank < 0 || toRank <= fromRank) continue
+    regressions.push({
+      device: p.device,
+      checkName: p.name,
+      fromStatus: baseline.status,
+      toStatus: p.status,
+      severity: severityFor(baseline.status, p.status),
+      message: p.message,
+    })
+  }
+  return regressions
+}
+
+// ── Rollback plan generation ────────────────────────────────────────────────
+
+export interface DeviceRollbackPlan {
+  device: string
+  platform: Platform
+  regressions: Regression[]
+  /** Restore commands to roll the device back to its pre-deploy checkpoint. */
+  commands: string[]
+}
+
+export interface RollbackPlan {
+  regressions: Regression[]
+  devices: DeviceRollbackPlan[]
+  /** True when a rollback is advised (any critical or major regression). */
+  recommended: boolean
+  summary: { total: number; critical: number; major: number; minor: number; devices: number }
+}
+
+/** Format a Date as a checkpoint timestamp token, e.g. `20260622-053000`. */
+export function rollbackTimestamp(d: Date = new Date()): string {
+  const p = (n: number) => String(n).padStart(2, '0')
+  return (
+    `${d.getFullYear()}${p(d.getMonth() + 1)}${p(d.getDate())}` +
+    `-${p(d.getHours())}${p(d.getMinutes())}${p(d.getSeconds())}`
+  )
+}
+
+/** Build the platform-native restore commands for one device. */
+export function rollbackCommandsFor(platform: Platform, ts: string): string[] {
+  const strat = ROLLBACK_STRATEGIES[platform]
+  if (!strat.exec) return []
+  return strat.exec.replace(/\{ts\}/g, ts).split('\n')
+}
+
+/**
+ * Diff pre/post checks, then for every device with a regression emit a
+ * platform-native rollback command block. Rollback is *recommended* when any
+ * regression is critical or major (a PASS/WARN → FAIL).
+ */
+export function generateRollbackPlan(
+  pre: CheckResult[],
+  post: CheckResult[],
+  devices: BOMDevice[],
+  ts: string = rollbackTimestamp(),
+): RollbackPlan {
+  const regressions = detectRegressions(pre, post)
+
+  // Resolve hostname → platform via the BOM (fallback to iosxe).
+  const platformByHost = new Map<string, Platform>()
+  for (const d of devices) {
+    platformByHost.set(d.hostname, vendorToPlatform(d.vendor, d.subLayer))
+  }
+
+  const byDevice = new Map<string, Regression[]>()
+  for (const r of regressions) {
+    const list = byDevice.get(r.device) ?? []
+    list.push(r)
+    byDevice.set(r.device, list)
+  }
+
+  const devicePlans: DeviceRollbackPlan[] = []
+  for (const [device, regs] of byDevice) {
+    const platform = platformByHost.get(device) ?? 'iosxe'
+    devicePlans.push({
+      device,
+      platform,
+      regressions: regs,
+      commands: rollbackCommandsFor(platform, ts),
+    })
+  }
+  // Stable order: worst-affected (most regressions) first, then by name.
+  devicePlans.sort((a, b) => b.regressions.length - a.regressions.length || a.device.localeCompare(b.device))
+
+  const summary = {
+    total: regressions.length,
+    critical: regressions.filter(r => r.severity === 'critical').length,
+    major: regressions.filter(r => r.severity === 'major').length,
+    minor: regressions.filter(r => r.severity === 'minor').length,
+    devices: devicePlans.length,
+  }
+
+  return {
+    regressions,
+    devices: devicePlans,
+    recommended: summary.critical > 0 || summary.major > 0,
+    summary,
+  }
+}
+
+/** Render a rollback plan as a copy/paste runbook (one block per device). */
+export function rollbackPlanToText(plan: RollbackPlan, ts: string = rollbackTimestamp()): string {
+  if (plan.devices.length === 0) return '! No regressions detected — no rollback required.\n'
+  const lines: string[] = [
+    `! Rollback runbook — generated ${new Date().toISOString()}`,
+    `! Checkpoint tag: pre-deploy-${ts}`,
+    `! ${plan.summary.total} regression(s) across ${plan.summary.devices} device(s)`,
+    `! ${plan.summary.critical} critical, ${plan.summary.major} major, ${plan.summary.minor} minor`,
+    '',
+  ]
+  for (const d of plan.devices) {
+    lines.push(`! ===== ${d.device} (${d.platform}) =====`)
+    for (const r of d.regressions) {
+      lines.push(`!  ${r.checkName}: ${r.fromStatus} -> ${r.toStatus} [${r.severity}]`)
+    }
+    for (const c of d.commands) lines.push(c)
+    lines.push('')
+  }
+  return lines.join('\n')
+}

--- a/frontend/src/pages/Step6Deploy.tsx
+++ b/frontend/src/pages/Step6Deploy.tsx
@@ -17,6 +17,7 @@ import { genGNMICCollectorConfig, genTelegrafGNMIConfig, genPrometheusAlertRules
 import { useTroubleshoot } from '@/hooks/useTroubleshoot'
 import { runComplianceScan, exportComplianceReport } from '@/lib/compliance-scan'
 import type { ComplianceScanResult } from '@/lib/compliance-scan'
+import { generateRollbackPlan, rollbackPlanToText, rollbackTimestamp } from '@/lib/rollback'
 import type { ZTPEvent, BOMDevice, CheckResult, MonitoringResult, ZTPResult, ChecksResult, DeviceMetrics, MetricsSummary, ConfigDriftResponse, ConfigDriftDevice, ConfigRemediationResponse, RemediationDeviceInput, TroubleshootResult } from '@/types'
 
 const STATUS_BADGE: Record<string, 'pass' | 'warn' | 'fail' | 'neutral'> = {
@@ -3060,6 +3061,102 @@ export function Step6Deploy() {
                           </div>
                         ))}
                       </div>
+                    </Card>
+                  )
+                })()}
+
+                {/* K1: Rollback Advisor — closed-loop auto-rollback on post-check regression */}
+                {preResults.length > 0 && postResults.length > 0 && (() => {
+                  // Expand BOM rows to per-instance hostnames that match the
+                  // check device names (e.g. "LEAF-01"), preserving vendor/role.
+                  const expanded = storeDevices.flatMap(d => {
+                    const count = Math.min(d.count, 4)
+                    return Array.from({ length: count }, (_, i) => ({
+                      ...d, hostname: `${d.hostname}-${String(i + 1).padStart(2, '0')}`,
+                    }))
+                  })
+                  const ts = rollbackTimestamp()
+                  const plan = generateRollbackPlan(preResults, postResults, expanded, ts)
+                  if (plan.summary.total === 0) {
+                    return (
+                      <Card>
+                        <CardHeader><CardTitle>🛟 Rollback Advisor</CardTitle></CardHeader>
+                        <div className="mt-2 flex items-center gap-2 text-sm text-green-400">
+                          <span className="text-lg">✓</span>
+                          <span>No regressions detected between pre and post checks — no rollback required.</span>
+                        </div>
+                      </Card>
+                    )
+                  }
+                  return (
+                    <Card className={cn(plan.recommended && 'border-red-500/40')}>
+                      <CardHeader>
+                        <div className="flex items-center justify-between w-full">
+                          <CardTitle>🛟 Rollback Advisor</CardTitle>
+                          <button
+                            onClick={() => { downloadBlob('rollback-runbook.txt', rollbackPlanToText(plan, ts)); showToast('rollback-runbook.txt downloaded', 'success') }}
+                            className="px-3 py-1 rounded-lg text-xs font-semibold bg-white/5 border border-white/10 text-gray-300 hover:bg-white/10 transition-colors cursor-pointer"
+                          >
+                            ⬇ Download runbook
+                          </button>
+                        </div>
+                      </CardHeader>
+
+                      {/* Recommendation banner */}
+                      <div className={cn(
+                        'mt-2 px-4 py-3 rounded-lg border text-sm flex items-start gap-3',
+                        plan.recommended
+                          ? 'bg-red-500/10 border-red-500/30 text-red-300'
+                          : 'bg-yellow-500/10 border-yellow-500/30 text-yellow-300',
+                      )}>
+                        <span className="text-lg leading-none">{plan.recommended ? '⚠️' : 'ℹ️'}</span>
+                        <div>
+                          <div className="font-semibold">
+                            {plan.recommended
+                              ? 'Rollback recommended — the change regressed healthy checks.'
+                              : 'Minor regressions only — review before rolling back.'}
+                          </div>
+                          <div className="text-xs mt-0.5 opacity-80">
+                            {plan.summary.total} regression(s) across {plan.summary.devices} device(s) ·{' '}
+                            {plan.summary.critical} critical · {plan.summary.major} major · {plan.summary.minor} minor
+                          </div>
+                        </div>
+                      </div>
+
+                      {/* Per-device rollback plans */}
+                      <div className="space-y-2 mt-3">
+                        {plan.devices.map(d => (
+                          <div key={d.device} className="rounded-lg border border-white/10 overflow-hidden">
+                            <div className="flex items-center gap-3 px-4 py-2 bg-white/[0.02]">
+                              <span className="font-mono text-sm font-semibold text-gray-200">{d.device}</span>
+                              <span className="px-2 py-0.5 rounded text-[10px] font-bold uppercase bg-blue-500/15 text-blue-300 border border-blue-500/30">{d.platform}</span>
+                              <span className="ml-auto text-xs text-gray-500">{d.regressions.length} regressed</span>
+                            </div>
+                            <div className="px-4 py-2 space-y-1">
+                              {d.regressions.map((r, i) => (
+                                <div key={i} className="flex items-center gap-2 text-xs">
+                                  <span className="text-gray-500 flex-1 truncate">{r.checkName}</span>
+                                  <Badge variant={badgeVariant(r.fromStatus)}>{r.fromStatus}</Badge>
+                                  <span className="text-gray-600">→</span>
+                                  <Badge variant={badgeVariant(r.toStatus)}>{r.toStatus}</Badge>
+                                  <span className={cn(
+                                    'px-1.5 py-0.5 rounded text-[10px] font-bold uppercase',
+                                    r.severity === 'critical' ? 'bg-red-500/15 text-red-400'
+                                      : r.severity === 'major' ? 'bg-orange-500/15 text-orange-400'
+                                      : 'bg-yellow-500/15 text-yellow-400',
+                                  )}>{r.severity}</span>
+                                </div>
+                              ))}
+                            </div>
+                            <pre className="px-4 py-2 bg-black/30 text-xs font-mono text-green-300 overflow-x-auto border-t border-white/5">{d.commands.join('\n')}</pre>
+                          </div>
+                        ))}
+                      </div>
+                      <p className="text-xs text-gray-600 mt-3">
+                        Commands restore each device from its <span className="font-mono">pre-deploy-{ts}</span> checkpoint
+                        (CLAUDE.md §9 platform-native strategies). In live mode the backend executes rollback automatically
+                        from captured backups when post-checks fail.
+                      </p>
                     </Card>
                   )
                 })()}

--- a/frontend/src/test/rollback.test.ts
+++ b/frontend/src/test/rollback.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect } from 'vitest'
+import {
+  ROLLBACK_STRATEGIES,
+  vendorToPlatform,
+  detectRegressions,
+  generateRollbackPlan,
+  rollbackCommandsFor,
+  rollbackTimestamp,
+  rollbackPlanToText,
+  type Platform,
+} from '@/lib/rollback'
+import type { CheckResult, BOMDevice } from '@/types'
+
+function check(device: string, name: string, status: CheckResult['status'], message = ''): CheckResult {
+  return { device, name, status, message, remediation: null }
+}
+
+function dev(hostname: string, vendor: string, subLayer: string): BOMDevice {
+  return {
+    id: hostname, hostname, role: subLayer, subLayer, model: 'M', vendor,
+    count: 1, unitPrice: 0, totalPrice: 0, speed: '100G', ports: 32, features: [],
+  }
+}
+
+describe('K1 — vendorToPlatform', () => {
+  it('Cisco spine/leaf → nxos, edge/campus → iosxe', () => {
+    expect(vendorToPlatform('Cisco', 'spine')).toBe('nxos')
+    expect(vendorToPlatform('Cisco', 'leaf')).toBe('nxos')
+    expect(vendorToPlatform('Cisco', 'wan-edge')).toBe('iosxe')
+    expect(vendorToPlatform('Cisco', 'distribution')).toBe('iosxe')
+  })
+
+  it('maps the other vendors correctly', () => {
+    expect(vendorToPlatform('Arista', 'leaf')).toBe('eos')
+    expect(vendorToPlatform('Juniper', 'leaf')).toBe('junos')
+    expect(vendorToPlatform('Dell EMC', 'spine')).toBe('sonic')
+    expect(vendorToPlatform('NVIDIA', 'leaf')).toBe('sonic')
+  })
+
+  it('defaults unknown vendors to iosxe', () => {
+    expect(vendorToPlatform('Acme', 'leaf')).toBe('iosxe')
+  })
+})
+
+describe('K1 — ROLLBACK_STRATEGIES mirrors CLAUDE.md §9', () => {
+  it('has all five platforms with exec commands', () => {
+    const platforms: Platform[] = ['nxos', 'iosxe', 'eos', 'junos', 'sonic']
+    for (const p of platforms) {
+      expect(ROLLBACK_STRATEGIES[p]).toBeDefined()
+      expect(ROLLBACK_STRATEGIES[p].exec).toBeTruthy()
+    }
+  })
+
+  it('junos uses commit confirmed for auto-rollback', () => {
+    expect(ROLLBACK_STRATEGIES.junos.deployCmd).toContain('commit confirmed')
+  })
+
+  it('nxos uses atomic checkpoint rollback', () => {
+    expect(ROLLBACK_STRATEGIES.nxos.exec).toContain('rollback running-config checkpoint')
+    expect(ROLLBACK_STRATEGIES.nxos.exec).toContain('atomic')
+  })
+})
+
+describe('K1 — rollbackCommandsFor', () => {
+  it('substitutes the {ts} token', () => {
+    const cmds = rollbackCommandsFor('iosxe', '20260622-053000')
+    expect(cmds).toEqual(['configure replace flash:pre-deploy-20260622-053000.cfg force'])
+  })
+
+  it('splits multi-line junos rollback into two commands', () => {
+    const cmds = rollbackCommandsFor('junos', '20260622-053000')
+    expect(cmds).toEqual(['rollback 1', 'commit'])
+  })
+})
+
+describe('K1 — rollbackTimestamp', () => {
+  it('formats as YYYYMMDD-HHMMSS', () => {
+    const ts = rollbackTimestamp(new Date(2026, 5, 22, 5, 30, 9))
+    expect(ts).toBe('20260622-053009')
+  })
+})
+
+describe('K1 — detectRegressions', () => {
+  it('flags PASS → FAIL as critical', () => {
+    const pre = [check('leaf-01', 'BGP Session State', 'PASS')]
+    const post = [check('leaf-01', 'BGP Session State', 'FAIL', 'session down')]
+    const regs = detectRegressions(pre, post)
+    expect(regs).toHaveLength(1)
+    expect(regs[0].severity).toBe('critical')
+    expect(regs[0].fromStatus).toBe('PASS')
+    expect(regs[0].toStatus).toBe('FAIL')
+    expect(regs[0].message).toBe('session down')
+  })
+
+  it('flags WARN → FAIL as major', () => {
+    const pre = [check('leaf-01', 'CPU Utilization', 'WARN')]
+    const post = [check('leaf-01', 'CPU Utilization', 'FAIL')]
+    expect(detectRegressions(pre, post)[0].severity).toBe('major')
+  })
+
+  it('flags PASS → WARN as minor', () => {
+    const pre = [check('leaf-01', 'Memory Utilization', 'PASS')]
+    const post = [check('leaf-01', 'Memory Utilization', 'WARN')]
+    expect(detectRegressions(pre, post)[0].severity).toBe('minor')
+  })
+
+  it('does NOT flag improvements (FAIL → PASS)', () => {
+    const pre = [check('leaf-01', 'BGP Session State', 'FAIL')]
+    const post = [check('leaf-01', 'BGP Session State', 'PASS')]
+    expect(detectRegressions(pre, post)).toHaveLength(0)
+  })
+
+  it('does NOT flag unchanged checks', () => {
+    const pre = [check('leaf-01', 'ICMP Reachability', 'PASS')]
+    const post = [check('leaf-01', 'ICMP Reachability', 'PASS')]
+    expect(detectRegressions(pre, post)).toHaveLength(0)
+  })
+
+  it('ignores SKIP on either side', () => {
+    const pre1 = [check('leaf-01', 'X', 'SKIP')]
+    const post1 = [check('leaf-01', 'X', 'FAIL')]
+    expect(detectRegressions(pre1, post1)).toHaveLength(0)
+    const pre2 = [check('leaf-01', 'X', 'PASS')]
+    const post2 = [check('leaf-01', 'X', 'SKIP')]
+    expect(detectRegressions(pre2, post2)).toHaveLength(0)
+  })
+
+  it('ignores checks with no pre-baseline match', () => {
+    const pre = [check('leaf-01', 'A', 'PASS')]
+    const post = [check('leaf-02', 'A', 'FAIL')] // different device
+    expect(detectRegressions(pre, post)).toHaveLength(0)
+  })
+
+  it('handles multiple devices and checks', () => {
+    const pre = [
+      check('leaf-01', 'BGP', 'PASS'),
+      check('leaf-01', 'CPU', 'PASS'),
+      check('leaf-02', 'BGP', 'PASS'),
+    ]
+    const post = [
+      check('leaf-01', 'BGP', 'FAIL'),
+      check('leaf-01', 'CPU', 'PASS'),
+      check('leaf-02', 'BGP', 'WARN'),
+    ]
+    const regs = detectRegressions(pre, post)
+    expect(regs).toHaveLength(2)
+  })
+})
+
+describe('K1 — generateRollbackPlan', () => {
+  const devices = [
+    dev('leaf-01', 'Cisco', 'leaf'),
+    dev('leaf-02', 'Arista', 'leaf'),
+    dev('edge-01', 'Juniper', 'wan-edge'),
+  ]
+  const ts = '20260622-053000'
+
+  it('recommends rollback when a critical regression exists', () => {
+    const pre = [check('leaf-01', 'BGP', 'PASS')]
+    const post = [check('leaf-01', 'BGP', 'FAIL')]
+    const plan = generateRollbackPlan(pre, post, devices, ts)
+    expect(plan.recommended).toBe(true)
+    expect(plan.summary.critical).toBe(1)
+    expect(plan.devices).toHaveLength(1)
+    expect(plan.devices[0].platform).toBe('nxos')
+    expect(plan.devices[0].commands[0]).toContain('rollback running-config checkpoint pre-deploy-20260622-053000')
+  })
+
+  it('does NOT recommend rollback for minor-only regressions', () => {
+    const pre = [check('leaf-01', 'Memory', 'PASS')]
+    const post = [check('leaf-01', 'Memory', 'WARN')]
+    const plan = generateRollbackPlan(pre, post, devices, ts)
+    expect(plan.recommended).toBe(false)
+    expect(plan.summary.minor).toBe(1)
+  })
+
+  it('emits platform-correct commands per device', () => {
+    const pre = [
+      check('leaf-01', 'BGP', 'PASS'),
+      check('leaf-02', 'BGP', 'PASS'),
+      check('edge-01', 'OSPF', 'PASS'),
+    ]
+    const post = [
+      check('leaf-01', 'BGP', 'FAIL'),
+      check('leaf-02', 'BGP', 'FAIL'),
+      check('edge-01', 'OSPF', 'FAIL'),
+    ]
+    const plan = generateRollbackPlan(pre, post, devices, ts)
+    expect(plan.devices).toHaveLength(3)
+    const byHost = Object.fromEntries(plan.devices.map(d => [d.device, d]))
+    expect(byHost['leaf-01'].platform).toBe('nxos')
+    expect(byHost['leaf-02'].platform).toBe('eos')
+    expect(byHost['leaf-02'].commands[0]).toContain('rollback clean-config checkpoint')
+    expect(byHost['edge-01'].platform).toBe('junos')
+    expect(byHost['edge-01'].commands).toEqual(['rollback 1', 'commit'])
+  })
+
+  it('sorts most-affected device first', () => {
+    const pre = [
+      check('leaf-01', 'BGP', 'PASS'),
+      check('leaf-02', 'BGP', 'PASS'),
+      check('leaf-02', 'CPU', 'PASS'),
+    ]
+    const post = [
+      check('leaf-01', 'BGP', 'FAIL'),
+      check('leaf-02', 'BGP', 'FAIL'),
+      check('leaf-02', 'CPU', 'FAIL'),
+    ]
+    const plan = generateRollbackPlan(pre, post, devices, ts)
+    expect(plan.devices[0].device).toBe('leaf-02') // 2 regressions
+    expect(plan.devices[1].device).toBe('leaf-01') // 1 regression
+  })
+
+  it('returns an empty, non-recommended plan when no regressions', () => {
+    const pre = [check('leaf-01', 'BGP', 'PASS')]
+    const post = [check('leaf-01', 'BGP', 'PASS')]
+    const plan = generateRollbackPlan(pre, post, devices, ts)
+    expect(plan.recommended).toBe(false)
+    expect(plan.devices).toHaveLength(0)
+    expect(plan.summary.total).toBe(0)
+  })
+
+  it('falls back to iosxe when device not in BOM', () => {
+    const pre = [check('mystery-01', 'BGP', 'PASS')]
+    const post = [check('mystery-01', 'BGP', 'FAIL')]
+    const plan = generateRollbackPlan(pre, post, devices, ts)
+    expect(plan.devices[0].platform).toBe('iosxe')
+  })
+})
+
+describe('K1 — rollbackPlanToText', () => {
+  const ts = '20260622-053000'
+  it('renders a runbook with per-device blocks', () => {
+    const pre = [check('leaf-01', 'BGP', 'PASS')]
+    const post = [check('leaf-01', 'BGP', 'FAIL')]
+    const plan = generateRollbackPlan(pre, post, [dev('leaf-01', 'Cisco', 'leaf')], ts)
+    const text = rollbackPlanToText(plan, ts)
+    expect(text).toContain('leaf-01 (nxos)')
+    expect(text).toContain('BGP: PASS -> FAIL [critical]')
+    expect(text).toContain('rollback running-config checkpoint pre-deploy-20260622-053000 atomic')
+  })
+
+  it('renders a no-op message when there are no regressions', () => {
+    const plan = generateRollbackPlan([], [], [], ts)
+    expect(rollbackPlanToText(plan, ts)).toContain('No regressions detected')
+  })
+})


### PR DESCRIPTION
## Summary

Implements **K1 — auto-rollback on post-check regression** (closed-loop automation, the next backlog item after §22 A–J and §20 were exhausted).

When a deployment's post-checks regress relative to the pre-deploy baseline (a check that was PASS now FAILs/WARNs), the change likely caused damage. This adds:

- **`lib/rollback.ts`**:
  - `ROLLBACK_STRATEGIES` — platform-native restore commands ported from CLAUDE.md §9 (nxos/iosxe/eos/junos/sonic), kept in sync with the doc
  - `detectRegressions(pre, post)` — diffs pre/post checks, classifies severity: PASS→FAIL = critical, WARN→FAIL = major, PASS→WARN = minor
  - `generateRollbackPlan(...)` — per-device platform-native rollback commands, `recommended` flag when any critical/major regression
  - `vendorToPlatform`, `rollbackTimestamp`, `rollbackPlanToText` runbook export
- **Step 6 Checks tab**: "🛟 Rollback Advisor" card (appears after both pre+post checks run) — recommendation banner, per-device regression list with restore commands, download runbook button

The backend (`jobs/deploy_job.py::_initiate_rollback`) already performs the actual restore from captured backups; this is the design-time advisor + the exact commands that restore would run.

## Test plan

- [x] 25 new tests in `rollback.test.ts` (770 total, all passing)
- [x] TypeScript compiles clean
- [x] Production build succeeds
- [ ] Visual: run pre-checks, then post-checks with a fault → Rollback Advisor appears with correct per-platform commands


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DiH1v2ufYHuupbP4xn6pPb

---
_Generated by [Claude Code](https://claude.ai/code/session_01DiH1v2ufYHuupbP4xn6pPb)_