### PR TITLE
feat: M2 — config validation engine replacing fake Batfish placeholder

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -783,7 +783,7 @@ config-gen tests must keep passing; add new tests alongside).
 | # | Item | Status | Notes |
 |---|------|--------|-------|
 | M1 | Accessibility pass — add ARIA attributes, roles, labels, and keyboard navigation to Step 6 tabs, HLD/LLD SVG diagrams, interactive controls, and all Card/Button/Badge UI primitives | [x] | ARIA tablist/tab/tabpanel + keyboard nav on Step 6 tabs; `role="img"` + `aria-label` + `<title>` on HLD/LLD/Rack SVGs; `nav` landmarks + `aria-current` + `aria-expanded` on Sidebar; `role="status"` on Badge; observability panel `aria-expanded`/`aria-controls` |
-| M2 | Batfish validation engine — replace the fake 5-step setTimeout animation with real client-side config validation (parse generated configs against intent constraints, check reachability invariants, protocol consistency, ACL coverage) | [ ] | Currently purely cosmetic; a real validator adds genuine pre-deploy confidence |
+| M2 | Batfish validation engine — replace the fake 5-step setTimeout animation with real client-side config validation (parse generated configs against intent constraints, check reachability invariants, protocol consistency, ACL coverage) | [x] | `lib/config-validator.ts` — 13 checks (V-01…V-13): single underlay, duplicate router-IDs, BGP presence/peer reachability, EVPN consistency, hostname/management/loopback, no hardcoded secrets, undefined ACL refs, GPU QoS, BFD; `ValidationResult` w/ summary counts; `validationReportText` export; wired into Step 6 Batfish tab with real results + download report; 24 tests |
 
 ---
 

--- a/CODE_REFERENCE.md
+++ b/CODE_REFERENCE.md
@@ -1011,6 +1011,23 @@ simulated scan-history timeline for the demo UI.
   crontab / systemd timer / scan-runner.sh, simulated scan history timeline.
 - **Tests**: 27 in `test/scheduled-scans.test.ts`.
 
+## Frontend — `lib/config-validator.ts` (Config validation engine — M2)
+
+**Purpose:** Client-side static analysis of generated device configs against
+design intent. Replaces the former fake Batfish placeholder with 13 real
+validation checks that parse config text and cross-reference with intent
+(use case, devices, protocols).
+
+**Key exports:**
+- `validateConfigs(input: ValidateInput): ValidationResult` — runs all 13 checks (V-01 through V-13) against the provided configs/devices/useCase and returns structured results with per-check severity (pass/fail/warn/info), detail, and affected device list.
+- `validationReportText(result: ValidationResult): string` — renders a plain-text report for download.
+
+**Checks:** V-01 Single underlay (no IS-IS+OSPF mix), V-02 Duplicate router-IDs, V-03 BGP fabric presence, V-04 BGP peer reachability, V-05 No hardcoded secrets, V-06 Hostname config, V-07 Management plane, V-08 EVPN/VXLAN consistency, V-09 GPU QoS (PFC/ECN/DCQCN), V-10 Undefined ACL references, V-11 Non-empty configs, V-12 Loopback presence, V-13 BFD for fast failover.
+
+**Types:** `ValidationCheck`, `ValidationResult`, `ValidateInput`, `CheckSeverity`.
+
+- **Tests**: 24 in `test/config-validator.test.ts`.
+
 ## Frontend — `lib/netbox.ts` (NetBox/Nautobot import — Enterprise Upgrade B1)
 
 **Purpose:** Reads existing inventory from a NetBox or Nautobot instance
@@ -1532,9 +1549,9 @@ These four files appear to be retained purely so `e2e-features.test.ts` can smok
 - **State:** `changeWindow` (`'immediate'|'scheduled'|'emergency'`, default immediate); G-A4: `driftResult: ConfigDriftResponse|null`, `driftFaultDevice` (id of device to simulate drift on, demo mode only), `expandedDriftDevices: Set<string>` (per-device diff expand/collapse), `useConfigDrift()` → `runConfigDrift`/`driftChecking`; G-A16: `remediationResult: ConfigRemediationResponse|null`, `useConfigRemediation()` → `runRemediation`/`remediationPending`, `configIdToPlatform` (id→vendor map), cleared via `useEffect` whenever `driftResult` changes
 - **UI:** Change Window card (scheduled shows "Sun 02:00-04:00 UTC"; emergency shows CAB-approval warning); **Config Drift Detection card (G-A4)** — reads `configs` from the Zustand store (generated in Step 3); if empty, shows "No generated configs yet" prompt. Otherwise: demo-mode-only "Simulate drift on" device selector, "Run Drift Check" button → `handleDriftCheck()` (live: `runConfigDrift({configs})`→`/api/drift/config`; demo: `simulateConfigDrift(configs, driftFaultDevice)`); results table (Device / Status — "✓ In sync", "⚠ Drift detected", or "— no baseline" / Added count / Removed count / "View diff" toggle) with an expandable colorized unified-diff row (`toggleDriftDevice`); summary line shows `drift_count`/`device_count`. **Inline remediation (G-A16)** — when `drift_count > 0`, a "🛠 Generate Remediation" button (`handleGenerateRemediation()`; live → `runRemediation` to `/api/drift/remediate`, demo → `simulateRemediation`) renders per-device platform-aware command blocks (restore-then-prune) with Copy-all / Download (`remediation.txt` via `downloadBlob`); platform comes from `configIdToPlatform` (device vendor). Compliance Audit card (7 hardcoded "✓ PASS" checks: password complexity, SSHv2, NTP, syslog, SNMP strings, unused interfaces shut, logging buffered)
 
-##### Tab: Batfish Validate (`batfish`, lines ~3030-3130)
-- **State:** `batfishRunning`, `batfishStep` (default -1), `batfishDone`, local `BATFISH_STEPS` (5 labels: Initializing snapshot / Parsing configs / Forwarding analysis / BGP reachability / Validation complete)
-- **UI:** header card + bullet list (forwarding analysis, BGP reachability, undefined references, duplicate router IDs); "Run Batfish Validation" → `handleBatfishValidation()` (900ms/step async progression through `BATFISH_STEPS`); Validation Results card (5 hardcoded PASS rows: route reachability, undefined references, BGP peer reachability, duplicate router-ids, invalid BGP configs)
+##### Tab: Batfish Validate (`batfish`) — Config Validation Engine (M2)
+- **State:** `batfishRunning`, `batfishStep` (default -1), `batfishDone`, `batfishResult: ValidationResult | null`; local `BATFISH_STEPS` (5 labels: Initializing snapshot / Parsing configs / Analyzing routing & fabric / BGP peer reachability / Validating security & QoS)
+- **UI:** header card + bullet list (single underlay, BGP peer reachability, duplicate router-IDs, EVPN/VXLAN, security audit, GPU QoS); warning when no configs generated; "Run Config Validation" → `handleBatfishValidation()` (600ms/step animation + `validateConfigs({configs, devices, useCase})` from `lib/config-validator.ts`); Validation Results card with real results table (ID, Check, Category, Status badge, Details + affected devices), summary badges (PASS/FAIL/WARN/INFO counts), "Download Report" button (`handleDownloadValidationReport` → `validationReportText`); 13 checks: V-01 single underlay, V-02 duplicate router-IDs, V-03 BGP presence, V-04 BGP peer reachability, V-05 no hardcoded secrets, V-06 hostname config, V-07 management plane, V-08 EVPN/VXLAN consistency, V-09 GPU QoS, V-10 undefined ACL refs, V-11 non-empty configs, V-12 loopback presence, V-13 BFD
 
 **Notes (whole file):**
 - Component closes at line 3209; **all helpers are module-level functions defined BEFORE the component** (lines ~757-1253) — nothing after the component's closing brace.

--- a/frontend/src/lib/config-validator.ts
+++ b/frontend/src/lib/config-validator.ts
@@ -1,0 +1,626 @@
+/**
+ * config-validator.ts — Client-side network config validation engine (M2)
+ *
+ * Replaces the fake Batfish placeholder with real static analysis of
+ * generated device configs against intent constraints.
+ */
+
+import type { BOMDevice, UseCase } from '@/types'
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export type CheckSeverity = 'pass' | 'fail' | 'warn' | 'info'
+
+export interface ValidationCheck {
+  id: string
+  name: string
+  category: 'Routing' | 'Fabric' | 'Security' | 'Identity' | 'QoS' | 'Protocol'
+  severity: CheckSeverity
+  detail: string
+  devices?: string[]
+}
+
+export interface ValidationResult {
+  checks: ValidationCheck[]
+  summary: { pass: number; fail: number; warn: number; info: number }
+  timestamp: number
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function hostnamesWithPattern(configs: Record<string, string>, pattern: RegExp): string[] {
+  return Object.entries(configs)
+    .filter(([, cfg]) => pattern.test(cfg))
+    .map(([host]) => host)
+}
+
+function extractRouterIds(configs: Record<string, string>): Map<string, string[]> {
+  const ridMap = new Map<string, string[]>()
+  for (const [host, cfg] of Object.entries(configs)) {
+    const matches = cfg.match(/router-id\s+(\d+\.\d+\.\d+\.\d+)/g) ?? []
+    for (const m of matches) {
+      const ip = m.replace(/router-id\s+/, '')
+      const hosts = ridMap.get(ip) ?? []
+      hosts.push(host)
+      ridMap.set(ip, hosts)
+    }
+  }
+  return ridMap
+}
+
+function extractBgpNeighborIPs(cfg: string): string[] {
+  const ips: string[] = []
+  const pattern = /neighbor\s+(\d+\.\d+\.\d+\.\d+)/g
+  let m: RegExpExecArray | null
+  while ((m = pattern.exec(cfg)) !== null) {
+    if (!ips.includes(m[1])) ips.push(m[1])
+  }
+  return ips
+}
+
+function extractLoopbacks(configs: Record<string, string>): Map<string, string[]> {
+  const loopbacks = new Map<string, string[]>()
+  for (const [host, cfg] of Object.entries(configs)) {
+    const ips: string[] = []
+    const loMatch = cfg.match(/interface [Ll]oopback\d+[\s\S]*?(?=\ninterface |\n!|\n$)/g) ?? []
+    for (const block of loMatch) {
+      const ipMatch = block.match(/ip address\s+(\d+\.\d+\.\d+\.\d+)/)
+      if (ipMatch) ips.push(ipMatch[1])
+    }
+    if (ips.length > 0) loopbacks.set(host, ips)
+  }
+  return loopbacks
+}
+
+// ── Validation checks ─────────────────────────────────────────────────────────
+
+function checkSingleUnderlay(
+  configs: Record<string, string>,
+  useCase: UseCase | '',
+): ValidationCheck {
+  const hasISIS = hostnamesWithPattern(configs, /router isis|isis enable/i)
+  const hasOSPF = hostnamesWithPattern(configs, /router ospf\s|ospf area/i)
+  const bothDevices = hasISIS.filter(h => hasOSPF.includes(h))
+
+  if (bothDevices.length > 0) {
+    return {
+      id: 'V-01',
+      name: 'Single underlay protocol',
+      category: 'Routing',
+      severity: 'fail',
+      detail: `${bothDevices.length} device(s) have BOTH IS-IS and OSPF configured: ${bothDevices.slice(0, 3).join(', ')}${bothDevices.length > 3 ? '…' : ''}`,
+      devices: bothDevices,
+    }
+  }
+
+  const expectedISIS = ['dc', 'gpu', 'multisite', 'multicloud', 'aviatrix'].includes(useCase)
+  const expectedOSPF = ['campus', 'wan'].includes(useCase)
+
+  if (expectedISIS && hasISIS.length === 0 && hasOSPF.length > 0) {
+    return {
+      id: 'V-01',
+      name: 'Single underlay protocol',
+      category: 'Routing',
+      severity: 'warn',
+      detail: `Use case "${useCase}" typically uses IS-IS but only OSPF found`,
+    }
+  }
+  if (expectedOSPF && hasOSPF.length === 0 && hasISIS.length > 0) {
+    return {
+      id: 'V-01',
+      name: 'Single underlay protocol',
+      category: 'Routing',
+      severity: 'warn',
+      detail: `Use case "${useCase}" typically uses OSPF but only IS-IS found`,
+    }
+  }
+
+  return {
+    id: 'V-01',
+    name: 'Single underlay protocol',
+    category: 'Routing',
+    severity: 'pass',
+    detail: hasISIS.length > 0
+      ? `IS-IS underlay on ${hasISIS.length} device(s) — consistent`
+      : hasOSPF.length > 0
+        ? `OSPF underlay on ${hasOSPF.length} device(s) — consistent`
+        : 'No underlay routing protocol detected (may be expected for non-routing devices)',
+  }
+}
+
+function checkDuplicateRouterIds(configs: Record<string, string>): ValidationCheck {
+  const ridMap = extractRouterIds(configs)
+  const dupes: { ip: string; hosts: string[] }[] = []
+  for (const [ip, hosts] of ridMap) {
+    if (hosts.length > 1) dupes.push({ ip, hosts })
+  }
+
+  if (dupes.length > 0) {
+    const detail = dupes
+      .slice(0, 3)
+      .map(d => `${d.ip} on [${d.hosts.join(', ')}]`)
+      .join('; ')
+    return {
+      id: 'V-02',
+      name: 'Duplicate router-IDs',
+      category: 'Routing',
+      severity: 'fail',
+      detail: `${dupes.length} duplicate router-ID(s): ${detail}`,
+      devices: dupes.flatMap(d => d.hosts),
+    }
+  }
+
+  return {
+    id: 'V-02',
+    name: 'Duplicate router-IDs',
+    category: 'Routing',
+    severity: 'pass',
+    detail: `${ridMap.size} unique router-ID(s) — no conflicts`,
+  }
+}
+
+function checkBGPPresence(
+  configs: Record<string, string>,
+  useCase: UseCase | '',
+): ValidationCheck {
+  const hasBGP = hostnamesWithPattern(configs, /router bgp\s+\d+/i)
+  const fabricUseCases: (UseCase | '')[] = ['dc', 'gpu', 'multisite', 'multicloud', 'aviatrix']
+
+  if (fabricUseCases.includes(useCase) && hasBGP.length === 0) {
+    return {
+      id: 'V-03',
+      name: 'BGP fabric configuration',
+      category: 'Fabric',
+      severity: 'fail',
+      detail: `Use case "${useCase}" requires BGP for EVPN/VXLAN but no BGP config found`,
+    }
+  }
+
+  if (hasBGP.length > 0) {
+    return {
+      id: 'V-03',
+      name: 'BGP fabric configuration',
+      category: 'Fabric',
+      severity: 'pass',
+      detail: `BGP configured on ${hasBGP.length} device(s)`,
+    }
+  }
+
+  return {
+    id: 'V-03',
+    name: 'BGP fabric configuration',
+    category: 'Fabric',
+    severity: 'info',
+    detail: 'No BGP configured (expected for this use case)',
+  }
+}
+
+function checkBGPPeerSymmetry(configs: Record<string, string>): ValidationCheck {
+  const allLoopbacks = extractLoopbacks(configs)
+  const allIPs = new Set<string>()
+  for (const ips of allLoopbacks.values()) {
+    for (const ip of ips) allIPs.add(ip)
+  }
+  for (const cfg of Object.values(configs)) {
+    const ifaceIPs = cfg.match(/ip address\s+(\d+\.\d+\.\d+\.\d+)/g) ?? []
+    for (const m of ifaceIPs) {
+      const ip = m.replace(/ip address\s+/, '')
+      allIPs.add(ip)
+    }
+  }
+
+  const unreachable: { host: string; peer: string }[] = []
+  for (const [host, cfg] of Object.entries(configs)) {
+    const neighbors = extractBgpNeighborIPs(cfg)
+    for (const nbr of neighbors) {
+      if (!allIPs.has(nbr)) {
+        unreachable.push({ host, peer: nbr })
+      }
+    }
+  }
+
+  if (unreachable.length > 0) {
+    const sample = unreachable.slice(0, 3).map(u => `${u.host}→${u.peer}`).join(', ')
+    return {
+      id: 'V-04',
+      name: 'BGP peer reachability',
+      category: 'Routing',
+      severity: 'warn',
+      detail: `${unreachable.length} BGP neighbor(s) reference IPs not found in any config: ${sample}`,
+      devices: [...new Set(unreachable.map(u => u.host))],
+    }
+  }
+
+  const totalNeighbors = Object.values(configs).reduce(
+    (sum, cfg) => sum + extractBgpNeighborIPs(cfg).length, 0,
+  )
+  return {
+    id: 'V-04',
+    name: 'BGP peer reachability',
+    category: 'Routing',
+    severity: 'pass',
+    detail: totalNeighbors > 0
+      ? `${totalNeighbors} BGP neighbor(s) — all peer IPs found in device configs`
+      : 'No BGP neighbors to validate',
+  }
+}
+
+function checkNoHardcodedSecrets(configs: Record<string, string>): ValidationCheck {
+  const secretPatterns = [
+    /password\s+"?(?!<CHANGE-ME)[A-Za-z0-9!@#$%^&*()+]{4,}/i,
+    /secret\s+"?(?!<CHANGE-ME)[A-Za-z0-9!@#$%^&*()+]{8,}/i,
+    /key\s+"?(?!<CHANGE-ME)[A-Za-z0-9!@#$%^&*()+]{8,}/i,
+  ]
+
+  const violations: string[] = []
+  for (const [host, cfg] of Object.entries(configs)) {
+    for (const pat of secretPatterns) {
+      if (pat.test(cfg)) {
+        if (!violations.includes(host)) violations.push(host)
+      }
+    }
+  }
+
+  if (violations.length > 0) {
+    return {
+      id: 'V-05',
+      name: 'No hardcoded secrets',
+      category: 'Security',
+      severity: 'fail',
+      detail: `${violations.length} device(s) may have hardcoded credentials: ${violations.slice(0, 3).join(', ')}`,
+      devices: violations,
+    }
+  }
+
+  return {
+    id: 'V-05',
+    name: 'No hardcoded secrets',
+    category: 'Security',
+    severity: 'pass',
+    detail: 'All credentials use <CHANGE-ME-*> placeholders',
+  }
+}
+
+function checkHostnameConsistency(
+  configs: Record<string, string>,
+  devices: BOMDevice[],
+): ValidationCheck {
+  const missing: string[] = []
+  for (const [host, cfg] of Object.entries(configs)) {
+    const hasHostname = /hostname\s+\S+/i.test(cfg)
+    if (!hasHostname) missing.push(host)
+  }
+
+  if (missing.length > 0) {
+    return {
+      id: 'V-06',
+      name: 'Hostname configuration',
+      category: 'Identity',
+      severity: 'warn',
+      detail: `${missing.length} config(s) missing hostname command: ${missing.slice(0, 3).join(', ')}`,
+      devices: missing,
+    }
+  }
+
+  const configCount = Object.keys(configs).length
+  const deviceCount = devices.reduce((s, d) => s + d.count, 0)
+  return {
+    id: 'V-06',
+    name: 'Hostname configuration',
+    category: 'Identity',
+    severity: 'pass',
+    detail: `${configCount} config(s) with hostname set (${deviceCount} BOM device instances)`,
+  }
+}
+
+function checkManagementBlock(configs: Record<string, string>): ValidationCheck {
+  const missingMgmt: string[] = []
+  for (const [host, cfg] of Object.entries(configs)) {
+    const hasMgmt = /MANAGEMENT|ntp server|logging host|snmp-server/i.test(cfg)
+    if (!hasMgmt) missingMgmt.push(host)
+  }
+
+  if (missingMgmt.length > 0) {
+    return {
+      id: 'V-07',
+      name: 'Management plane config',
+      category: 'Security',
+      severity: 'warn',
+      detail: `${missingMgmt.length} device(s) missing NTP/syslog/SNMP management block: ${missingMgmt.slice(0, 3).join(', ')}`,
+      devices: missingMgmt,
+    }
+  }
+
+  return {
+    id: 'V-07',
+    name: 'Management plane config',
+    category: 'Security',
+    severity: 'pass',
+    detail: `All ${Object.keys(configs).length} config(s) include management plane (NTP, syslog, SNMP)`,
+  }
+}
+
+function checkEVPNConsistency(
+  configs: Record<string, string>,
+  useCase: UseCase | '',
+): ValidationCheck {
+  const fabricUseCases: (UseCase | '')[] = ['dc', 'gpu', 'multisite', 'multicloud', 'aviatrix']
+  if (!fabricUseCases.includes(useCase)) {
+    return {
+      id: 'V-08',
+      name: 'EVPN/VXLAN consistency',
+      category: 'Fabric',
+      severity: 'info',
+      detail: 'EVPN/VXLAN not expected for this use case',
+    }
+  }
+
+  const hasNVE = hostnamesWithPattern(configs, /interface nve|vxlan/i)
+  const hasEVPN = hostnamesWithPattern(configs, /evpn|l2vpn evpn/i)
+
+  if (hasNVE.length === 0 && hasEVPN.length === 0) {
+    return {
+      id: 'V-08',
+      name: 'EVPN/VXLAN consistency',
+      category: 'Fabric',
+      severity: 'warn',
+      detail: `Use case "${useCase}" typically uses VXLAN/EVPN but neither NVE nor EVPN config found`,
+    }
+  }
+
+  const nveNoEvpn = hasNVE.filter(h => !hasEVPN.includes(h))
+  if (nveNoEvpn.length > 0) {
+    return {
+      id: 'V-08',
+      name: 'EVPN/VXLAN consistency',
+      category: 'Fabric',
+      severity: 'warn',
+      detail: `${nveNoEvpn.length} device(s) have NVE/VXLAN but no EVPN config: ${nveNoEvpn.slice(0, 3).join(', ')}`,
+      devices: nveNoEvpn,
+    }
+  }
+
+  return {
+    id: 'V-08',
+    name: 'EVPN/VXLAN consistency',
+    category: 'Fabric',
+    severity: 'pass',
+    detail: `EVPN+VXLAN configured on ${hasEVPN.length} device(s) — consistent`,
+  }
+}
+
+function checkGPUQoS(
+  configs: Record<string, string>,
+  useCase: UseCase | '',
+): ValidationCheck {
+  if (useCase !== 'gpu') {
+    return {
+      id: 'V-09',
+      name: 'GPU QoS (PFC/ECN/DCQCN)',
+      category: 'QoS',
+      severity: 'info',
+      detail: 'GPU QoS not required for this use case',
+    }
+  }
+
+  const hasPFC = hostnamesWithPattern(configs, /priority-flow-control|pfc/i)
+  const hasECN = hostnamesWithPattern(configs, /ecn|explicit-congestion/i)
+  const hasRDMA = hostnamesWithPattern(configs, /rdma|rocev2|dcqcn/i)
+
+  const issues: string[] = []
+  if (hasPFC.length === 0) issues.push('PFC not configured on any device')
+  if (hasECN.length === 0) issues.push('ECN not configured on any device')
+  if (hasRDMA.length === 0) issues.push('RDMA/RoCEv2/DCQCN not configured on any device')
+
+  if (issues.length > 0) {
+    return {
+      id: 'V-09',
+      name: 'GPU QoS (PFC/ECN/DCQCN)',
+      category: 'QoS',
+      severity: 'fail',
+      detail: issues.join('; '),
+    }
+  }
+
+  return {
+    id: 'V-09',
+    name: 'GPU QoS (PFC/ECN/DCQCN)',
+    category: 'QoS',
+    severity: 'pass',
+    detail: `PFC on ${hasPFC.length}, ECN on ${hasECN.length}, RDMA/DCQCN on ${hasRDMA.length} device(s)`,
+  }
+}
+
+function checkUndefinedACLReferences(configs: Record<string, string>): ValidationCheck {
+  const issues: { host: string; ref: string }[] = []
+
+  for (const [host, cfg] of Object.entries(configs)) {
+    const definedACLs = new Set<string>()
+    const aclDefs = cfg.match(/ip access-list (?:standard|extended)\s+(\S+)/g) ?? []
+    for (const d of aclDefs) {
+      const name = d.replace(/ip access-list (?:standard|extended)\s+/, '')
+      definedACLs.add(name)
+    }
+
+    const aclRefs = cfg.match(/access-group\s+(\S+)/g) ?? []
+    for (const r of aclRefs) {
+      const name = r.replace(/access-group\s+/, '')
+      if (!definedACLs.has(name) && !/^\d+$/.test(name)) {
+        issues.push({ host, ref: name })
+      }
+    }
+  }
+
+  if (issues.length > 0) {
+    const sample = issues.slice(0, 3).map(i => `${i.host}: ${i.ref}`).join(', ')
+    return {
+      id: 'V-10',
+      name: 'Undefined ACL references',
+      category: 'Security',
+      severity: 'warn',
+      detail: `${issues.length} access-group reference(s) to undefined ACLs: ${sample}`,
+      devices: [...new Set(issues.map(i => i.host))],
+    }
+  }
+
+  return {
+    id: 'V-10',
+    name: 'Undefined ACL references',
+    category: 'Security',
+    severity: 'pass',
+    detail: 'No dangling ACL or access-group references found',
+  }
+}
+
+function checkNonEmptyConfigs(configs: Record<string, string>): ValidationCheck {
+  const empty = Object.entries(configs)
+    .filter(([, cfg]) => cfg.trim().length < 20)
+    .map(([host]) => host)
+
+  if (empty.length > 0) {
+    return {
+      id: 'V-11',
+      name: 'Non-empty configurations',
+      category: 'Identity',
+      severity: 'fail',
+      detail: `${empty.length} device(s) have empty or near-empty configs: ${empty.slice(0, 3).join(', ')}`,
+      devices: empty,
+    }
+  }
+
+  return {
+    id: 'V-11',
+    name: 'Non-empty configurations',
+    category: 'Identity',
+    severity: 'pass',
+    detail: `All ${Object.keys(configs).length} config(s) contain substantive configuration`,
+  }
+}
+
+function checkLoopbackPresence(configs: Record<string, string>): ValidationCheck {
+  const loopbacks = extractLoopbacks(configs)
+  const routingDevices = Object.entries(configs).filter(
+    ([, cfg]) => /router bgp|router ospf|router isis/i.test(cfg),
+  )
+  const missingLo = routingDevices
+    .filter(([host]) => !loopbacks.has(host))
+    .map(([host]) => host)
+
+  if (missingLo.length > 0) {
+    return {
+      id: 'V-12',
+      name: 'Loopback interfaces',
+      category: 'Routing',
+      severity: 'warn',
+      detail: `${missingLo.length} routing device(s) missing loopback interface: ${missingLo.slice(0, 3).join(', ')}`,
+      devices: missingLo,
+    }
+  }
+
+  return {
+    id: 'V-12',
+    name: 'Loopback interfaces',
+    category: 'Routing',
+    severity: 'pass',
+    detail: `${loopbacks.size} device(s) with loopback interfaces configured`,
+  }
+}
+
+function checkBFDEnabled(
+  configs: Record<string, string>,
+  useCase: UseCase | '',
+): ValidationCheck {
+  const fabricUseCases: (UseCase | '')[] = ['dc', 'gpu', 'multisite']
+  if (!fabricUseCases.includes(useCase)) {
+    return {
+      id: 'V-13',
+      name: 'BFD for fast failover',
+      category: 'Protocol',
+      severity: 'info',
+      detail: 'BFD check not critical for this use case',
+    }
+  }
+
+  const hasBFD = hostnamesWithPattern(configs, /\bbfd\b/i)
+  if (hasBFD.length === 0) {
+    return {
+      id: 'V-13',
+      name: 'BFD for fast failover',
+      category: 'Protocol',
+      severity: 'warn',
+      detail: `Use case "${useCase}" benefits from BFD but no BFD config found`,
+    }
+  }
+
+  return {
+    id: 'V-13',
+    name: 'BFD for fast failover',
+    category: 'Protocol',
+    severity: 'pass',
+    detail: `BFD configured on ${hasBFD.length} device(s) for sub-second failover`,
+  }
+}
+
+// ── Main validation entry point ───────────────────────────────────────────────
+
+export interface ValidateInput {
+  configs: Record<string, string>
+  devices: BOMDevice[]
+  useCase: UseCase | ''
+}
+
+export function validateConfigs(input: ValidateInput): ValidationResult {
+  const { configs, devices, useCase } = input
+
+  if (Object.keys(configs).length === 0) {
+    return {
+      checks: [{
+        id: 'V-00',
+        name: 'Configurations present',
+        category: 'Identity',
+        severity: 'fail',
+        detail: 'No generated configs to validate — generate configs in Step 3 first',
+      }],
+      summary: { pass: 0, fail: 1, warn: 0, info: 0 },
+      timestamp: Date.now(),
+    }
+  }
+
+  const checks: ValidationCheck[] = [
+    checkNonEmptyConfigs(configs),
+    checkSingleUnderlay(configs, useCase),
+    checkDuplicateRouterIds(configs),
+    checkBGPPresence(configs, useCase),
+    checkBGPPeerSymmetry(configs),
+    checkEVPNConsistency(configs, useCase),
+    checkHostnameConsistency(configs, devices),
+    checkManagementBlock(configs),
+    checkNoHardcodedSecrets(configs),
+    checkUndefinedACLReferences(configs),
+    checkGPUQoS(configs, useCase),
+    checkLoopbackPresence(configs),
+    checkBFDEnabled(configs, useCase),
+  ]
+
+  const summary = { pass: 0, fail: 0, warn: 0, info: 0 }
+  for (const c of checks) summary[c.severity]++
+
+  return { checks, summary, timestamp: Date.now() }
+}
+
+export function validationReportText(result: ValidationResult): string {
+  const lines = [
+    '# Network Config Validation Report',
+    `# ${new Date(result.timestamp).toISOString()}`,
+    `# Summary: ${result.summary.pass} PASS, ${result.summary.fail} FAIL, ${result.summary.warn} WARN, ${result.summary.info} INFO`,
+    '',
+  ]
+  for (const c of result.checks) {
+    const icon = c.severity === 'pass' ? 'PASS' : c.severity === 'fail' ? 'FAIL' : c.severity === 'warn' ? 'WARN' : 'INFO'
+    lines.push(`[${icon}] ${c.id} ${c.name}`)
+    lines.push(`       ${c.detail}`)
+    if (c.devices?.length) lines.push(`       Devices: ${c.devices.join(', ')}`)
+    lines.push('')
+  }
+  return lines.join('\n')
+}

--- a/frontend/src/pages/Step6Deploy.tsx
+++ b/frontend/src/pages/Step6Deploy.tsx
@@ -23,6 +23,7 @@ import { AlertsPanel } from '@/components/AlertsPanel'
 import { RcaPanel } from '@/components/RcaPanel'
 import { LiveProgressFeed } from '@/components/LiveProgressFeed'
 import { createWatcher, exportCronTab, exportSystemdTimer, exportScanScript, simulateScanHistory, INTERVAL_PRESETS, type WatcherConfig, type ScanType, type ScanAction, type ScanHistoryEntry } from '@/lib/scheduled-scans'
+import { validateConfigs, validationReportText, type ValidationResult } from '@/lib/config-validator'
 import type { ZTPEvent, BOMDevice, CheckResult, MonitoringResult, ZTPResult, ChecksResult, DeviceMetrics, MetricsSummary, ConfigDriftResponse, ConfigDriftDevice, ConfigRemediationResponse, RemediationDeviceInput, TroubleshootResult } from '@/types'
 
 const STATUS_BADGE: Record<string, 'pass' | 'warn' | 'fail' | 'neutral'> = {
@@ -2118,30 +2119,45 @@ export function Step6Deploy() {
     showToast('scan-runner.sh downloaded', 'success')
   }
 
-  // ── Batfish state (M-68) ──────────────────────────────────────────────────
+  // ── Batfish / Config Validation state (M2) ─────────────────────────────────
   const [batfishRunning, setBatfishRunning] = useState(false)
   const [batfishStep, setBatfishStep] = useState(-1)
   const [batfishDone, setBatfishDone] = useState(false)
+  const [batfishResult, setBatfishResult] = useState<ValidationResult | null>(null)
 
   const BATFISH_STEPS = [
-    'Initializing Batfish snapshot...',
+    'Initializing validation snapshot...',
     'Parsing device configs...',
-    'Running forwarding analysis...',
-    'Checking BGP reachability...',
-    'Validation complete',
+    'Analyzing routing & fabric consistency...',
+    'Checking BGP peer reachability...',
+    'Validating security & QoS policies...',
   ]
 
   async function handleBatfishValidation() {
     if (batfishRunning) return
     setBatfishRunning(true)
     setBatfishDone(false)
+    setBatfishResult(null)
     setBatfishStep(0)
     for (let i = 0; i < BATFISH_STEPS.length; i++) {
       setBatfishStep(i)
-      await new Promise(r => setTimeout(r, 900))
+      await new Promise(r => setTimeout(r, 600))
     }
+    const result = validateConfigs({
+      configs: storeConfigs,
+      devices: storeDevices,
+      useCase: storeUseCase,
+    })
+    setBatfishResult(result)
     setBatfishRunning(false)
     setBatfishDone(true)
+  }
+
+  function handleDownloadValidationReport() {
+    if (!batfishResult) return
+    const text = validationReportText(batfishResult)
+    downloadBlob('validation-report.txt', text)
+    showToast('Validation report downloaded', 'success')
   }
 
   // ── Troubleshooting Tooling Engine state (G-A19) ──────────────────────────
@@ -4479,23 +4495,28 @@ export function Step6Deploy() {
       {tab === 'batfish' && (
         <div className="space-y-6" role="tabpanel" id="tabpanel-batfish" aria-labelledby="tab-batfish">
           <Card>
-            <CardHeader><CardTitle>Batfish Network Validation</CardTitle></CardHeader>
+            <CardHeader><CardTitle>Network Config Validation</CardTitle></CardHeader>
             <p className="text-sm text-gray-400 mb-2">
-              Batfish is an open-source network analysis tool that performs vendor-agnostic
-              static analysis of device configurations. It can identify bugs, guarantee
-              compliance, and verify intent before configs are pushed to production.
+              Static analysis of generated device configurations against your design intent.
+              Validates routing consistency, fabric integrity, security posture, and QoS
+              policies — catching misconfigurations before deployment.
             </p>
             <ul className="list-disc list-inside text-sm text-gray-400 space-y-1 mb-4">
-              <li>Forwarding analysis — verify every packet traverses the intended path</li>
-              <li>BGP reachability — confirm all BGP peers can exchange routes</li>
-              <li>Undefined references — catch references to non-existent ACLs, prefix-lists, etc.</li>
-              <li>Duplicate router IDs — detect OSPF/BGP misconfigurations</li>
+              <li>Single underlay enforcement — no IS-IS + OSPF on the same device</li>
+              <li>BGP peer reachability — all neighbor IPs exist in device configs</li>
+              <li>Duplicate router-ID detection — catch OSPF/BGP conflicts</li>
+              <li>EVPN/VXLAN consistency — NVE + EVPN properly paired</li>
+              <li>Security audit — no hardcoded secrets, ACL reference integrity</li>
+              <li>GPU QoS — PFC, ECN, DCQCN verified for GPU use cases</li>
             </ul>
+            {Object.keys(storeConfigs).length === 0 && (
+              <p className="text-sm text-yellow-400/80 mb-3">⚠ No generated configs found — generate configs in Step 3 first.</p>
+            )}
             <Button
               onClick={handleBatfishValidation}
               disabled={batfishRunning}
             >
-              {batfishRunning ? '⏳ Running Validation…' : '▶ Run Batfish Validation'}
+              {batfishRunning ? '⏳ Running Validation…' : '▶ Run Config Validation'}
             </Button>
           </Card>
 
@@ -4539,38 +4560,54 @@ export function Step6Deploy() {
             </Card>
           )}
 
-          {batfishDone && (
+          {batfishDone && batfishResult && (
             <Card>
-              <CardHeader><CardTitle>Validation Results</CardTitle></CardHeader>
+              <CardHeader>
+                <div className="flex items-center justify-between">
+                  <CardTitle>Validation Results</CardTitle>
+                  <div className="flex items-center gap-2">
+                    <Badge variant="pass">{batfishResult.summary.pass} Pass</Badge>
+                    {batfishResult.summary.fail > 0 && <Badge variant="fail">{batfishResult.summary.fail} Fail</Badge>}
+                    {batfishResult.summary.warn > 0 && <Badge variant="warn">{batfishResult.summary.warn} Warn</Badge>}
+                    {batfishResult.summary.info > 0 && <Badge variant="info">{batfishResult.summary.info} Info</Badge>}
+                  </div>
+                </div>
+              </CardHeader>
               <div className="overflow-x-auto rounded-lg border border-white/10 mt-2">
                 <table className="w-full text-sm">
                   <thead>
                     <tr className="border-b border-white/10 bg-white/5">
-                      {['Check', 'Status', 'Details'].map(h => (
+                      {['ID', 'Check', 'Category', 'Status', 'Details'].map(h => (
                         <th key={h} className="px-4 py-2 text-left text-xs font-semibold text-gray-400 uppercase">{h}</th>
                       ))}
                     </tr>
                   </thead>
                   <tbody>
-                    {[
-                      { check: 'Route reachability',        status: 'PASS', detail: 'All /32 loopbacks reachable across fabric' },
-                      { check: 'Undefined references',      status: 'PASS', detail: 'No dangling ACL or prefix-list references' },
-                      { check: 'BGP peer reachability',     status: 'PASS', detail: 'All BGP neighbors reachable via underlay' },
-                      { check: 'Duplicate router-ids',      status: 'PASS', detail: 'No OSPF/BGP router-id conflicts detected' },
-                      { check: 'Invalid BGP configurations',status: 'PASS', detail: 'All BGP neighbor configs are well-formed' },
-                    ].map(row => (
-                      <tr key={row.check} className="border-b border-white/5 hover:bg-white/[0.02]">
-                        <td className="px-4 py-2 text-sm text-gray-200">{row.check}</td>
+                    {batfishResult.checks.map(row => (
+                      <tr key={row.id} className="border-b border-white/5 hover:bg-white/[0.02]">
+                        <td className="px-4 py-2 text-xs text-gray-500 font-mono">{row.id}</td>
+                        <td className="px-4 py-2 text-sm text-gray-200">{row.name}</td>
+                        <td className="px-4 py-2 text-xs text-gray-400">{row.category}</td>
                         <td className="px-4 py-2">
-                          <span className="text-xs text-green-400 font-semibold bg-green-500/10 border border-green-500/20 rounded px-2 py-0.5">
-                            ✓ {row.status}
-                          </span>
+                          <Badge variant={row.severity === 'pass' ? 'pass' : row.severity === 'fail' ? 'fail' : row.severity === 'warn' ? 'warn' : 'info'}>
+                            {row.severity === 'pass' ? '✓' : row.severity === 'fail' ? '✗' : row.severity === 'warn' ? '⚠' : 'ℹ'} {row.severity.toUpperCase()}
+                          </Badge>
                         </td>
-                        <td className="px-4 py-2 text-xs text-gray-400">{row.detail}</td>
+                        <td className="px-4 py-2 text-xs text-gray-400">
+                          {row.detail}
+                          {row.devices && row.devices.length > 0 && (
+                            <span className="block mt-0.5 text-gray-500">Devices: {row.devices.join(', ')}</span>
+                          )}
+                        </td>
                       </tr>
                     ))}
                   </tbody>
                 </table>
+              </div>
+              <div className="mt-3">
+                <Button onClick={handleDownloadValidationReport}>
+                  ⬇ Download Report
+                </Button>
               </div>
             </Card>
           )}

--- a/frontend/src/test/config-validator.test.ts
+++ b/frontend/src/test/config-validator.test.ts
@@ -1,0 +1,312 @@
+import { describe, it, expect } from 'vitest'
+import { validateConfigs, validationReportText } from '@/lib/config-validator'
+import type { BOMDevice } from '@/types'
+
+const device = (hostname: string, vendor = 'Cisco'): BOMDevice => ({
+  id: hostname,
+  hostname,
+  role: 'leaf',
+  subLayer: 'leaf',
+  model: 'N9K-C93180YC-EX',
+  vendor,
+  count: 1,
+  unitPrice: 20000,
+  totalPrice: 20000,
+  speed: '25G',
+  ports: 48,
+  uplinks: 6,
+  features: [],
+})
+
+const baseConfig = (hostname: string) => `
+! ── MANAGEMENT ──────────────────────────────────────────────────────────────────
+hostname ${hostname}
+ip domain-name <CHANGE-ME-domain.example.com>
+ntp server 10.0.0.1
+logging host 10.0.0.2
+snmp-server community <CHANGE-ME-snmp-community> RO
+username admin privilege 15 algorithm-type sha256 secret <CHANGE-ME-admin-password>
+
+interface Loopback0
+ ip address 10.255.0.1/32
+
+router bgp 65001
+ router-id 10.255.0.1
+ neighbor 10.1.0.1 remote-as 65000
+
+router isis UNDERLAY
+ is-type level-2
+ net 49.0001.0100.0000.0001.00
+`
+
+const dcConfig = (hostname: string, rid: string, nbrIp: string) => `
+! ── MANAGEMENT ──────────────────────────────────────────────────────────────────
+hostname ${hostname}
+ip domain-name <CHANGE-ME-domain.example.com>
+ntp server 10.0.0.1
+logging host 10.0.0.2
+snmp-server community <CHANGE-ME-snmp-community> RO
+username admin privilege 15 algorithm-type sha256 secret <CHANGE-ME-admin-password>
+
+interface Loopback0
+ ip address ${rid}/32
+
+interface nve1
+ no shutdown
+ host-reachability protocol bgp
+ source-interface loopback1
+ member vni 100010
+   ingress-replication protocol bgp
+
+router bgp 65001
+ router-id ${rid}
+ neighbor ${nbrIp} remote-as 65000
+ address-family l2vpn evpn
+   send-community extended
+
+router isis UNDERLAY
+ is-type level-2
+
+evpn
+ vni 100010 l2
+   rd auto
+   route-target import auto
+   route-target export auto
+
+bfd interval 50 min-rx 50 multiplier 3
+`
+
+describe('config-validator', () => {
+  describe('validateConfigs', () => {
+    it('returns fail when no configs provided', () => {
+      const result = validateConfigs({ configs: {}, devices: [], useCase: 'dc' })
+      expect(result.summary.fail).toBe(1)
+      expect(result.checks[0].id).toBe('V-00')
+    })
+
+    it('runs all 13 checks on valid DC configs', () => {
+      const configs: Record<string, string> = {
+        'LEAF-01': dcConfig('LEAF-01', '10.255.0.1', '10.1.0.1'),
+        'LEAF-02': dcConfig('LEAF-02', '10.255.0.2', '10.1.0.2'),
+        'SPINE-01': dcConfig('SPINE-01', '10.255.1.1', '10.1.0.1'),
+      }
+      const result = validateConfigs({
+        configs,
+        devices: [device('LEAF-01'), device('LEAF-02'), device('SPINE-01')],
+        useCase: 'dc',
+      })
+      expect(result.checks).toHaveLength(13)
+      expect(result.summary.fail).toBe(0)
+    })
+
+    it('detects duplicate router-IDs', () => {
+      const configs = {
+        'LEAF-01': dcConfig('LEAF-01', '10.255.0.1', '10.1.0.1'),
+        'LEAF-02': dcConfig('LEAF-02', '10.255.0.1', '10.1.0.2'),
+      }
+      const result = validateConfigs({ configs, devices: [], useCase: 'dc' })
+      const rid = result.checks.find(c => c.id === 'V-02')!
+      expect(rid.severity).toBe('fail')
+      expect(rid.detail).toContain('duplicate')
+    })
+
+    it('detects mixed IS-IS + OSPF underlay', () => {
+      const configs = {
+        'R1': `hostname R1\nrouter isis UNDERLAY\nrouter ospf 1\nntp server 1.1.1.1\nusername admin secret <CHANGE-ME-pw>`,
+      }
+      const result = validateConfigs({ configs, devices: [], useCase: 'dc' })
+      const v01 = result.checks.find(c => c.id === 'V-01')!
+      expect(v01.severity).toBe('fail')
+      expect(v01.detail).toContain('BOTH')
+    })
+
+    it('warns when DC use case has OSPF instead of IS-IS', () => {
+      const configs = {
+        'LEAF-01': `hostname LEAF-01\nrouter ospf 1\nntp server 1.1.1.1\nusername admin secret <CHANGE-ME-pw>\nrouter bgp 65001\n router-id 10.0.0.1\ninterface Loopback0\n ip address 10.0.0.1/32`,
+      }
+      const result = validateConfigs({ configs, devices: [], useCase: 'dc' })
+      const v01 = result.checks.find(c => c.id === 'V-01')!
+      expect(v01.severity).toBe('warn')
+      expect(v01.detail).toContain('IS-IS')
+    })
+
+    it('detects missing BGP in DC use case', () => {
+      const configs = {
+        'LEAF-01': `hostname LEAF-01\nrouter isis UNDERLAY\nntp server 1.1.1.1\nusername admin secret <CHANGE-ME-pw>`,
+      }
+      const result = validateConfigs({ configs, devices: [], useCase: 'dc' })
+      const v03 = result.checks.find(c => c.id === 'V-03')!
+      expect(v03.severity).toBe('fail')
+    })
+
+    it('warns about BGP neighbors referencing unknown IPs', () => {
+      const configs = {
+        'LEAF-01': `hostname LEAF-01\nrouter bgp 65001\n router-id 10.0.0.1\n neighbor 192.168.99.99 remote-as 65002\nntp server 1.1.1.1\nusername admin secret <CHANGE-ME-pw>\ninterface Loopback0\n ip address 10.0.0.1/32`,
+      }
+      const result = validateConfigs({ configs, devices: [], useCase: 'dc' })
+      const v04 = result.checks.find(c => c.id === 'V-04')!
+      expect(v04.severity).toBe('warn')
+      expect(v04.detail).toContain('192.168.99.99')
+    })
+
+    it('detects empty configs', () => {
+      const configs = { 'LEAF-01': '', 'LEAF-02': dcConfig('LEAF-02', '10.0.0.2', '10.0.0.1') }
+      const result = validateConfigs({ configs, devices: [], useCase: 'dc' })
+      const v11 = result.checks.find(c => c.id === 'V-11')!
+      expect(v11.severity).toBe('fail')
+      expect(v11.devices).toContain('LEAF-01')
+    })
+
+    it('detects missing hostname command', () => {
+      const configs = {
+        'LEAF-01': `router bgp 65001\n router-id 10.0.0.1\nntp server 1.1.1.1\nusername admin secret <CHANGE-ME-pw>\ninterface Loopback0\n ip address 10.0.0.1/32`,
+      }
+      const result = validateConfigs({ configs, devices: [], useCase: 'dc' })
+      const v06 = result.checks.find(c => c.id === 'V-06')!
+      expect(v06.severity).toBe('warn')
+    })
+
+    it('detects missing management block', () => {
+      const configs = {
+        'LEAF-01': `hostname LEAF-01\nrouter bgp 65001\n router-id 10.0.0.1\ninterface Loopback0\n ip address 10.0.0.1/32`,
+      }
+      const result = validateConfigs({ configs, devices: [], useCase: 'dc' })
+      const v07 = result.checks.find(c => c.id === 'V-07')!
+      expect(v07.severity).toBe('warn')
+    })
+
+    it('warns when NVE present but no EVPN on DC', () => {
+      const configs = {
+        'LEAF-01': `hostname LEAF-01\ninterface nve1\n no shutdown\nntp server 1.1.1.1\nrouter bgp 65001\n router-id 10.0.0.1\nusername admin secret <CHANGE-ME-pw>\ninterface Loopback0\n ip address 10.0.0.1/32`,
+      }
+      const result = validateConfigs({ configs, devices: [], useCase: 'dc' })
+      const v08 = result.checks.find(c => c.id === 'V-08')!
+      expect(v08.severity).toBe('warn')
+    })
+
+    it('EVPN check returns info for campus use case', () => {
+      const configs = {
+        'SW-01': baseConfig('SW-01'),
+      }
+      const result = validateConfigs({ configs, devices: [], useCase: 'campus' })
+      const v08 = result.checks.find(c => c.id === 'V-08')!
+      expect(v08.severity).toBe('info')
+    })
+
+    it('detects missing GPU QoS for gpu use case', () => {
+      const configs = {
+        'LEAF-01': dcConfig('LEAF-01', '10.0.0.1', '10.0.0.2'),
+      }
+      const result = validateConfigs({ configs, devices: [], useCase: 'gpu' })
+      const v09 = result.checks.find(c => c.id === 'V-09')!
+      expect(v09.severity).toBe('fail')
+      expect(v09.detail).toContain('PFC')
+    })
+
+    it('passes GPU QoS when PFC/ECN/RDMA present', () => {
+      const gpuCfg = dcConfig('LEAF-01', '10.0.0.1', '10.0.0.2') +
+        '\npriority-flow-control mode on\npriority-flow-control priority 3 no-drop\n' +
+        'random-detect ecn\nrdma qos-group 3\ndcqcn enable\n'
+      const configs = { 'LEAF-01': gpuCfg }
+      const result = validateConfigs({ configs, devices: [], useCase: 'gpu' })
+      const v09 = result.checks.find(c => c.id === 'V-09')!
+      expect(v09.severity).toBe('pass')
+    })
+
+    it('GPU QoS returns info for non-gpu use case', () => {
+      const configs = { 'LEAF-01': dcConfig('LEAF-01', '10.0.0.1', '10.0.0.2') }
+      const result = validateConfigs({ configs, devices: [], useCase: 'dc' })
+      const v09 = result.checks.find(c => c.id === 'V-09')!
+      expect(v09.severity).toBe('info')
+    })
+
+    it('detects routing devices missing loopback', () => {
+      const configs = {
+        'LEAF-01': `hostname LEAF-01\nrouter bgp 65001\n router-id 10.0.0.1\nntp server 1.1.1.1\nusername admin secret <CHANGE-ME-pw>`,
+      }
+      const result = validateConfigs({ configs, devices: [], useCase: 'dc' })
+      const v12 = result.checks.find(c => c.id === 'V-12')!
+      expect(v12.severity).toBe('warn')
+      expect(v12.devices).toContain('LEAF-01')
+    })
+
+    it('warns about missing BFD in DC use case', () => {
+      const noBfdCfg = `hostname LEAF-01\nrouter bgp 65001\n router-id 10.0.0.1\nntp server 1.1.1.1\nusername admin secret <CHANGE-ME-pw>\ninterface Loopback0\n ip address 10.0.0.1/32\nrouter isis UNDERLAY`
+      const configs = { 'LEAF-01': noBfdCfg }
+      const result = validateConfigs({ configs, devices: [], useCase: 'dc' })
+      const v13 = result.checks.find(c => c.id === 'V-13')!
+      expect(v13.severity).toBe('warn')
+    })
+
+    it('BFD check returns info for wan use case', () => {
+      const configs = { 'R1': baseConfig('R1') }
+      const result = validateConfigs({ configs, devices: [], useCase: 'wan' })
+      const v13 = result.checks.find(c => c.id === 'V-13')!
+      expect(v13.severity).toBe('info')
+    })
+
+    it('summary counts match check severities', () => {
+      const configs = {
+        'LEAF-01': dcConfig('LEAF-01', '10.255.0.1', '10.1.0.1'),
+        'LEAF-02': dcConfig('LEAF-02', '10.255.0.2', '10.1.0.2'),
+      }
+      const result = validateConfigs({ configs, devices: [device('LEAF-01'), device('LEAF-02')], useCase: 'dc' })
+      const counted = result.checks.reduce(
+        (acc, c) => { acc[c.severity]++; return acc },
+        { pass: 0, fail: 0, warn: 0, info: 0 },
+      )
+      expect(result.summary).toEqual(counted)
+    })
+  })
+
+  describe('validationReportText', () => {
+    it('produces a text report with all checks', () => {
+      const result = validateConfigs({
+        configs: { 'LEAF-01': dcConfig('LEAF-01', '10.0.0.1', '10.0.0.2') },
+        devices: [device('LEAF-01')],
+        useCase: 'dc',
+      })
+      const text = validationReportText(result)
+      expect(text).toContain('# Network Config Validation Report')
+      expect(text).toContain('PASS')
+      expect(text).toContain('V-01')
+      expect(text).toContain('V-13')
+    })
+
+    it('includes device list for failing checks', () => {
+      const configs = {
+        'LEAF-01': dcConfig('LEAF-01', '10.0.0.1', '10.0.0.2'),
+        'LEAF-02': dcConfig('LEAF-02', '10.0.0.1', '10.0.0.3'),
+      }
+      const result = validateConfigs({ configs, devices: [], useCase: 'dc' })
+      const text = validationReportText(result)
+      expect(text).toContain('Devices:')
+    })
+  })
+
+  describe('edge cases', () => {
+    it('handles configs with only non-routing devices', () => {
+      const configs = {
+        'FW-01': `hostname FW-01\nntp server 1.1.1.1\nlogging host 1.1.1.2\nsnmp-server host 1.1.1.3\nusername admin secret <CHANGE-ME-pw>`,
+      }
+      const result = validateConfigs({ configs, devices: [], useCase: 'campus' })
+      expect(result.summary.fail).toBe(0)
+    })
+
+    it('handles single-device campus design', () => {
+      const configs = {
+        'CORE-01': `hostname CORE-01\nrouter ospf 1\n router-id 10.0.0.1\nntp server 1.1.1.1\nlogging host 1.1.1.2\nsnmp-server host 1.1.1.3\nusername admin secret <CHANGE-ME-pw>\ninterface Loopback0\n ip address 10.0.0.1/32`,
+      }
+      const result = validateConfigs({ configs, devices: [device('CORE-01')], useCase: 'campus' })
+      expect(result.summary.fail).toBe(0)
+    })
+
+    it('handles O-RAN use case gracefully', () => {
+      const configs = {
+        'CU-01': `hostname CU-01\nntp server 1.1.1.1\nlogging host 1.1.1.2\nsnmp-server host 1.1.1.3\nusername admin secret <CHANGE-ME-pw>`,
+      }
+      const result = validateConfigs({ configs, devices: [], useCase: 'oran' })
+      expect(result.checks.length).toBeGreaterThan(0)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Replace the hardcoded all-PASS Batfish animation with a real client-side config validation engine (`lib/config-validator.ts`)
- 13 validation checks (V-01…V-13) that parse generated device configs against intent constraints: single underlay, duplicate router-IDs, BGP presence/peer reachability, EVPN/VXLAN consistency, hostname/management/loopback, no hardcoded secrets, undefined ACL refs, GPU QoS (PFC/ECN/DCQCN), BFD
- Step 6 Batfish tab now shows real validation results with summary badges, per-check category/severity, affected device lists, and a downloadable validation report

## Test plan

- [x] 24 new tests in `config-validator.test.ts` covering all 13 checks + edge cases
- [x] All 833 tests pass (`npm test`)
- [x] TypeScript clean (`tsc --noEmit`)
- [x] Build succeeds (`npm run build`)
- [ ] Manual: generate configs for DC/GPU/campus use case → run validation → verify results match config content
- [ ] Manual: run with no configs → verify warning message shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DiH1v2ufYHuupbP4xn6pPb

---
_Generated by [Claude Code](https://claude.ai/code/session_01DiH1v2ufYHuupbP4xn6pPb)_