### PR TITLE
feat: D2 — vendor-aware LLD diagrams (campus + WAN)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -701,6 +701,7 @@ config-gen tests must keep passing; add new tests alongside).
 | # | Item | Status | Notes |
 |---|------|--------|-------|
 | D1 | HLD diagram + design summary reflect computed topology (MLAG pairs, FHRP VIPs, DCI links) once A1–A3 land | [x] (`e3492a7`) | `pairInfo()` + node annotations/peer-links in `HLDTopologyDiagram.tsx`; `genComputedTopology()` + summary card in `Step4NetworkDesign.tsx`; exported `haPairInfo`/`DCI_RT_ASN` from `configgen.ts` |
+| D2 | LLD diagram vendor-awareness — the LLD builders (`buildCampusLLD`, `buildWANLLD`) received the BOM `devices` array but ignored it (`_devices`) and hardcoded Cisco SKUs (C9500/C9300/ASR), so picking Juniper/Arista/Nokia showed wrong hardware in the Low-Level Design (inconsistent with the HLD, which already derives from BOM per E3). Add shared `bomRole(devices, subLayer, fallback)` helper; campus core/distribution/access/wan-edge + WAN PE routers now derive vendor/model/hostname from the BOM (fallback to the Cisco defaults only when the BOM lacks that role); 5 new tests | [x] | `LLDTopologyDiagram.tsx`; new `test/LLDTopologyDiagram.test.tsx` (5) |
 
 ### E. Dead-code / consistency cleanup (sourced 2026-06-18 — §20+§22 A–D exhausted)
 

--- a/CODE_REFERENCE.md
+++ b/CODE_REFERENCE.md
@@ -1759,12 +1759,12 @@ hooks they used (`useRunZTP`/`useRunChecks`/`usePollMonitoring`) are retained
 - Internal types: `LLDInterface` (name, ip, vlan?, mac?, speed?), `LLDNode` (id, hostname, model, tier, vendor, interfaces[], configLines[], services[], specs, haRole?, x/y/w/h, color/border/textColor, icon), `LLDLink` (id, from, to, fromPort, toPort, speed, vlan?, subnet?, protocol, isDashed?), `LLDZone` (id, label, sublabel, yStart/yEnd, fill, stroke), `CablingEntry` (server, serverPort, ipv4, switchPort, mgmtPort, vlan), `LLDTopo` (nodes, links, zones, cabling, title, subtitle, svgH)
 - Layout constants: `SVG_W=1400`, `LEFT_W=160`, `RIGHT_PAD=16`, `CONTENT_W = SVG_W - LEFT_W - RIGHT_PAD`
 - `TIER_STYLE` maps tier names (internet, dmz, internal, loadbalancer, server, application, database, wan, core, distribution, access, endpoint, spine, leaf, gpu, storage, oob, cloud, transit, spoke, branch) → `{ color, border, textColor }`
-- Helpers: `sty(tier)`, `xCenter(count, gap, nodeW)`, `mkNode(...)`, `mkLink(...)`, `lldLinkPath(n1, n2, isDashed?)`
+- Helpers: `sty(tier)`, `xCenter(count, gap, nodeW)`, `bomRole(devices, subLayer, fallback)` *(D2 — derives `{vendor(i), model(i), name(i), count}` for the i-th BOM device of a role so LLD nodes reflect the selected vendor, with Cisco-default fallback)*, `mkNode(...)`, `mkLink(...)`, `lldLinkPath(n1, n2, isDashed?)`
 - **7 per-use-case topology builders** (each returns `LLDTopo`):
   - `buildDCLLD` — Internet → Firewall HA (PA-5450) → Core/Edge routers → F5 LB cluster → 3× Web Servers → API GW + App Server + Database; mirrors the reference datacenter LLD image
-  - `buildCampusLLD` — WAN Edge (ASR pair) → Core VSS (C9500 HSRP) → 4× Distribution MLAG → 4× Access 802.1X/PoE+ → 5× Endpoints (PC, Phone, AP, Printer, Server)
+  - `buildCampusLLD` — WAN Edge pair → Core VSS (HSRP) → 4× Distribution MLAG → 4× Access 802.1X/PoE+ → 5× Endpoints (PC, Phone, AP, Printer, Server). **D2:** core/dist/access/wan-edge vendor+model+hostname derived from the BOM (Cisco SKUs are fallback only)
   - `buildGPULLD` — OOB MGMT → 2× GPU Spine (SN4800) → 4× GPU Leaf/ToR (SN4600C MLAG) → 4× DGX A100 servers → 2× NVMe-oF storage; PFC P3, ECN, DCQCN detail
-  - `buildWANLLD` — SP Backbone → HQ PE pair (BGP RR, MPLS, SR-MPLS) → 3× WAN CPE → 3× Branch routers → 3× Branch endpoints; QoS DSCP 6-class, L3VPN, SD-WAN
+  - `buildWANLLD` — SP Backbone → HQ PE pair (BGP RR, MPLS, SR-MPLS) → 3× WAN CPE → 3× Branch routers → 3× Branch endpoints; QoS DSCP 6-class, L3VPN, SD-WAN. **D2:** HQ PE-router vendor+model+hostname derived from the BOM `wan-edge` devices
   - `buildMultisiteLLD` — Site A + Site B with DCI GW pair, EVPN Type-5 stretched RT 65100, per-site spine/leaf/server with vPC domains
   - `buildMulticloudLLD` — On-prem spine pair → AWS DirectConnect + Azure ExpressRoute + GCP Cloud Interconnect → VPCs/VNets → Cloud workloads (EC2/AKS/GKE)
   - `buildAviatrixLLD` — DC Edge pair → Aviatrix Transit GWs (AWS/Azure/GCP) with multi-cloud peering → Spoke GWs with network segmentation → Cloud workloads
@@ -1777,6 +1777,8 @@ hooks they used (`useRunZTP`/`useRunChecks`/`usePollMonitoring`) are retained
 - Used by `Step4NetworkDesign.tsx` (LLD tab, added alongside HLD).
 - No external graph libraries (pure SVG/JSX) — per Implementation Rule 9.
 - Complements the HLD diagram: HLD shows network-wide topology flow; LLD shows per-device implementation detail.
+- **Tests:** `test/LLDTopologyDiagram.test.tsx` (5) — D2 vendor-awareness (campus dist/access + WAN PE derive from BOM; Cisco fallback when role absent).
+- **Remaining hardcoders (not yet BOM-derived):** `buildDCLLD` (app-tier FW/router/LB/server shape — no clean spine/leaf role mapping), `buildMultisiteLLD`, `buildMulticloudLLD` (cloud-native nodes), `buildAviatrixLLD`, `buildORANLLD` (partly derived). Future D-series work if multi-vendor parity is needed there.
 
 ---
 

--- a/frontend/src/components/LLDTopologyDiagram.tsx
+++ b/frontend/src/components/LLDTopologyDiagram.tsx
@@ -127,6 +127,23 @@ function xCenter(count: number, gap: number, nodeW: number): number[] {
   return Array.from({ length: count }, (_, i) => start + i * (nodeW + gap))
 }
 
+// Derive the actual BOM hardware (vendor/model/hostname) for the i-th device
+// of a given role, so LLD nodes reflect the user's vendor selection instead of
+// a hardcoded Cisco model. Falls back to the supplied defaults when the BOM has
+// no device for that role (mirrors the GPU LLD / HLD vendor-derivation pattern).
+function bomRole(
+  devices: BOMDevice[], subLayer: string,
+  fallback: { vendor: string; model: string; name: (i: number) => string },
+) {
+  const matches = devices.filter(d => d.subLayer === subLayer)
+  return {
+    vendor: (i: number) => matches[i]?.vendor ?? fallback.vendor,
+    model: (i: number) => matches[i]?.model ?? fallback.model,
+    name: (i: number) => matches[i]?.hostname ?? fallback.name(i),
+    count: matches.length,
+  }
+}
+
 function mkNode(
   id: string, hostname: string, model: string, tier: string, vendor: string,
   x: number, y: number, w: number, h: number,
@@ -352,9 +369,15 @@ function buildDCLLD(_devices: BOMDevice[], sc: string): LLDTopo {
 
 // ─── Campus LLD ───────────────────────────────────────────────────────────────
 
-function buildCampusLLD(_devices: BOMDevice[], sc: string): LLDTopo {
+function buildCampusLLD(devices: BOMDevice[], sc: string): LLDTopo {
   const NW = 190
   const Y = { wan: 60, core: 200, dist: 370, access: 530, hosts: 700 }
+
+  // Reflect the BOM's actual vendor/model for the campus L2/L3 switching tiers.
+  const coreRole = bomRole(devices, 'core', { vendor: 'Cisco', model: 'C9500-32QC', name: i => `CORE-SW-0${i + 1}` })
+  const distRole = bomRole(devices, 'distribution', { vendor: 'Cisco', model: 'C9500-48Y4C', name: i => `DIST-SW-0${i + 1}` })
+  const accRole = bomRole(devices, 'access', { vendor: 'Cisco', model: 'C9300-48P', name: i => `ACC-SW-0${i + 1}` })
+  const wanRole = bomRole(devices, 'wan-edge', { vendor: 'Cisco', model: 'ASR-1001X', name: i => `WAN-RTR-0${i + 1}` })
 
   const zones: LLDZone[] = [
     { id: 'z-wan', label: 'WAN EDGE', sublabel: 'Dual ISP · BGP eBGP · BFD',
@@ -370,7 +393,7 @@ function buildCampusLLD(_devices: BOMDevice[], sc: string): LLDTopo {
   ]
 
   const [w1x, w2x] = xCenter(2, 200, NW)
-  const wan1 = mkNode('wan1', 'WAN-RTR-01', 'ASR-1001X', 'wan', 'Cisco', w1x, Y.wan, NW, 100, {
+  const wan1 = mkNode('wan1', wanRole.name(0), wanRole.model(0), 'wan', wanRole.vendor(0), w1x, Y.wan, NW, 100, {
     haRole: 'active', icon: '🌐',
     interfaces: [
       { name: 'Gi0/0/0', ip: '203.0.113.1/30', vlan: 'ISP-A' },
@@ -380,7 +403,7 @@ function buildCampusLLD(_devices: BOMDevice[], sc: string): LLDTopo {
     configLines: ['BGP AS65000', 'OSPF Area 0', 'BFD multihop'],
     services: ['BGP eBGP', 'OSPF', 'BFD'],
   })
-  const wan2 = mkNode('wan2', 'WAN-RTR-02', 'ASR-1001X', 'wan', 'Cisco', w2x, Y.wan, NW, 100, {
+  const wan2 = mkNode('wan2', wanRole.name(1), wanRole.model(1), 'wan', wanRole.vendor(1), w2x, Y.wan, NW, 100, {
     haRole: 'standby', icon: '🌐',
     interfaces: [
       { name: 'Gi0/0/0', ip: '198.51.100.1/30', vlan: 'ISP-B' },
@@ -392,7 +415,7 @@ function buildCampusLLD(_devices: BOMDevice[], sc: string): LLDTopo {
   })
 
   const [c1x, c2x] = xCenter(2, 200, NW)
-  const core1 = mkNode('core1', 'CORE-SW-01', 'C9500-32QC', 'core', 'Cisco', c1x, Y.core, NW, 120, {
+  const core1 = mkNode('core1', coreRole.name(0), coreRole.model(0), 'core', coreRole.vendor(0), c1x, Y.core, NW, 120, {
     haRole: 'active', icon: '🏛',
     interfaces: [
       { name: 'Te1/0/1', ip: '10.0.0.2/30', vlan: 'WAN-uplink' },
@@ -403,7 +426,7 @@ function buildCampusLLD(_devices: BOMDevice[], sc: string): LLDTopo {
     configLines: ['VSS Active', 'OSPF Area 0 DR', 'HSRP Priority 110', 'DHCP Server'],
     services: ['VSS', 'OSPF', 'HSRP', 'DHCP'],
   })
-  const core2 = mkNode('core2', 'CORE-SW-02', 'C9500-32QC', 'core', 'Cisco', c2x, Y.core, NW, 120, {
+  const core2 = mkNode('core2', coreRole.name(1), coreRole.model(1), 'core', coreRole.vendor(1), c2x, Y.core, NW, 120, {
     haRole: 'standby', icon: '🏛',
     interfaces: [
       { name: 'Te1/0/1', ip: '10.0.0.6/30', vlan: 'WAN-uplink' },
@@ -418,7 +441,7 @@ function buildCampusLLD(_devices: BOMDevice[], sc: string): LLDTopo {
   const distW = 180
   const [d1x, d2x, d3x, d4x] = xCenter(4, 20, distW)
   const dists = [d1x, d2x, d3x, d4x].map((x, i) => mkNode(
-    `dist${i+1}`, `DIST-SW-0${i+1}`, 'C9500-48Y4C', 'distribution', 'Cisco', x, Y.dist, distW, 110, {
+    `dist${i+1}`, distRole.name(i), distRole.model(i), 'distribution', distRole.vendor(i), x, Y.dist, distW, 110, {
       icon: '🔗',
       interfaces: [
         { name: 'Te1/0/1', ip: `10.0.${1+Math.floor(i/2)*2}.${i%2 === 0 ? 1 : 2}/31`, vlan: 'Core-uplink' },
@@ -438,7 +461,7 @@ function buildCampusLLD(_devices: BOMDevice[], sc: string): LLDTopo {
   const accW = 160
   const accXs = xCenter(4, 20, accW)
   const accs = accXs.map((x, i) => mkNode(
-    `acc${i+1}`, `ACC-SW-0${i+1}`, 'C9300-48P', 'access', 'Cisco', x, Y.access, accW, 120, {
+    `acc${i+1}`, accRole.name(i), accRole.model(i), 'access', accRole.vendor(i), x, Y.access, accW, 120, {
       icon: '🔌',
       interfaces: [
         { name: 'Gi0/1', ip: '—', vlan: 'Trunk to Dist' },
@@ -652,9 +675,12 @@ function buildGPULLD(devices: BOMDevice[], sc: string): LLDTopo {
 
 // ─── WAN LLD ──────────────────────────────────────────────────────────────────
 
-function buildWANLLD(_devices: BOMDevice[], sc: string): LLDTopo {
+function buildWANLLD(devices: BOMDevice[], sc: string): LLDTopo {
   const NW = 190
   const Y = { sp: 50, hub: 190, cpe: 370, branch: 530, ep: 680 }
+
+  // PE/CE routers reflect the BOM's actual WAN-edge vendor/model selection.
+  const wanRole = bomRole(devices, 'wan-edge', { vendor: 'Cisco', model: 'ASR-9001', name: i => `HQ-PE-RTR-0${i + 1}` })
 
   const zones: LLDZone[] = [
     { id: 'z-sp', label: 'SP BACKBONE', sublabel: 'MPLS / Internet Transit · BGP full-table',
@@ -681,7 +707,7 @@ function buildWANLLD(_devices: BOMDevice[], sc: string): LLDTopo {
   })
 
   const [h1x, h2x] = xCenter(2, 200, NW)
-  const hub1 = mkNode('hub1', 'HQ-PE-RTR-01', 'ASR-9001', 'wan', 'Cisco', h1x, Y.hub, NW, 110, {
+  const hub1 = mkNode('hub1', wanRole.name(0), wanRole.model(0), 'wan', wanRole.vendor(0), h1x, Y.hub, NW, 110, {
     haRole: 'active', icon: '🔷',
     interfaces: [
       { name: 'Gi0/0/0', ip: '203.0.0.2/30', vlan: 'SP-uplink' },
@@ -691,7 +717,7 @@ function buildWANLLD(_devices: BOMDevice[], sc: string): LLDTopo {
     configLines: ['BGP Route Reflector', 'MPLS PE · LDP', 'SR-MPLS Adj-SID', 'BFD multihop 50ms'],
     services: ['BGP RR', 'MPLS', 'SR-MPLS', 'BFD'],
   })
-  const hub2 = mkNode('hub2', 'HQ-PE-RTR-02', 'ASR-9001', 'wan', 'Cisco', h2x, Y.hub, NW, 110, {
+  const hub2 = mkNode('hub2', wanRole.name(1), wanRole.model(1), 'wan', wanRole.vendor(1), h2x, Y.hub, NW, 110, {
     haRole: 'standby', icon: '🔷',
     interfaces: [
       { name: 'Gi0/0/0', ip: '203.0.0.6/30', vlan: 'SP-uplink' },

--- a/frontend/src/test/LLDTopologyDiagram.test.tsx
+++ b/frontend/src/test/LLDTopologyDiagram.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, cleanup } from '@testing-library/react'
+import { LLDTopologyDiagram } from '@/components/LLDTopologyDiagram'
+import type { BOMDevice } from '@/types'
+
+afterEach(() => cleanup())
+
+const dev = (overrides: Partial<BOMDevice>): BOMDevice => ({
+  id: overrides.hostname ?? 'd', hostname: 'H', role: 'leaf', subLayer: 'leaf',
+  model: 'M', vendor: 'Cisco', count: 1, unitPrice: 0, totalPrice: 0,
+  speed: '10G', ports: 48, uplinks: 4, features: [], ...overrides,
+})
+
+// LLD vendor-awareness (D2): the campus/WAN LLD builders must render the BOM's
+// actual vendor/model, not hardcoded Cisco SKUs.
+describe('LLDTopologyDiagram — vendor-aware (D2)', () => {
+  it('campus LLD shows Juniper distribution/access models from the BOM', () => {
+    // The campus LLD renders a fixed 4-dist / 4-acc layout, so supply a full
+    // set to confirm every tier node derives from the BOM (no Cisco fallback).
+    const devices = [
+      ...Array.from({ length: 4 }, (_, i) =>
+        dev({ hostname: `CAMP-DIST-0${i + 1}`, subLayer: 'distribution', vendor: 'Juniper', model: 'EX4650-48Y' })),
+      ...Array.from({ length: 4 }, (_, i) =>
+        dev({ hostname: `CAMP-ACC-0${i + 1}`, subLayer: 'access', vendor: 'Juniper', model: 'EX4400-48P' })),
+    ]
+    const { container } = render(<LLDTopologyDiagram devices={devices} useCase="campus" />)
+    const text = container.textContent ?? ''
+    expect(text).toContain('EX4650-48Y')
+    expect(text).toContain('EX4400-48P')
+    expect(text).toContain('Juniper')
+    // with a full BOM set, the hardcoded Cisco SKUs must NOT appear
+    expect(text).not.toContain('C9500-48Y4C')
+    expect(text).not.toContain('C9300-48P')
+  })
+
+  it('campus LLD partial BOM: derives present devices, falls back for the rest', () => {
+    const devices = [
+      dev({ hostname: 'CAMP-DIST-01', subLayer: 'distribution', vendor: 'Juniper', model: 'EX4650-48Y' }),
+    ]
+    const { container } = render(<LLDTopologyDiagram devices={devices} useCase="campus" />)
+    const text = container.textContent ?? ''
+    expect(text).toContain('EX4650-48Y')      // index 0 derived from BOM
+    expect(text).toContain('C9500-48Y4C')     // indices 1-3 fall back to Cisco
+  })
+
+  it('campus LLD falls back to Cisco defaults when BOM has no campus devices', () => {
+    const { container } = render(<LLDTopologyDiagram devices={[]} useCase="campus" />)
+    const text = container.textContent ?? ''
+    expect(text).toContain('C9500-48Y4C')
+    expect(text).toContain('C9300-48P')
+  })
+
+  it('WAN LLD shows Juniper wan-edge model from the BOM', () => {
+    const devices = [
+      dev({ hostname: 'WAN-PE-01', subLayer: 'wan-edge', vendor: 'Juniper', model: 'MX204' }),
+      dev({ hostname: 'WAN-PE-02', subLayer: 'wan-edge', vendor: 'Juniper', model: 'MX204' }),
+    ]
+    const { container } = render(<LLDTopologyDiagram devices={devices} useCase="wan" />)
+    const text = container.textContent ?? ''
+    expect(text).toContain('MX204')
+    expect(text).toContain('WAN-PE-01')
+    expect(text).not.toContain('ASR-9001')
+  })
+
+  it('campus LLD reflects Arista when selected', () => {
+    const devices = [
+      dev({ hostname: 'CAMP-DIST-01', subLayer: 'distribution', vendor: 'Arista', model: 'Arista 750' }),
+      dev({ hostname: 'CAMP-ACC-01', subLayer: 'access', vendor: 'Arista', model: 'Arista 720XP' }),
+    ]
+    const { container } = render(<LLDTopologyDiagram devices={devices} useCase="campus" />)
+    const text = container.textContent ?? ''
+    expect(text).toContain('Arista 750')
+    expect(text).toContain('Arista 720XP')
+  })
+})


### PR DESCRIPTION
## Summary

The LLD topology builders received the BOM `devices` array but **ignored it** (`_devices`) and hardcoded Cisco SKUs (C9500/C9300/ASR). So selecting **Juniper/Arista/Nokia** for a campus or WAN design showed the wrong hardware in the Low-Level Design — inconsistent with the HLD, which already derives vendor/model from the BOM (fixed for GPU in E3).

This is the top "design part" gap from an audit of the LLD/HLD builders.

## Changes

- Add a shared **`bomRole(devices, subLayer, fallback)`** helper that returns `{vendor(i), model(i), name(i), count}` for the i-th BOM device of a role, with Cisco-default fallback
- **`buildCampusLLD`** now derives core / distribution / access / wan-edge vendor+model+hostname from the BOM
- **`buildWANLLD`** now derives the HQ PE routers from the BOM `wan-edge` devices
- Fallback to the original Cisco defaults only when the BOM lacks that role (e.g. extra nodes in the fixed 4-dist/4-acc campus layout)
- New `test/LLDTopologyDiagram.test.tsx` (5 tests): campus shows Juniper/Arista models, partial-BOM fallback, WAN PE derives MX204

Out of scope (documented in CODE_REFERENCE.md as future work): `buildDCLLD` (app-tier shape, no clean spine/leaf mapping), multisite/multicloud/aviatrix (cloud-native nodes).

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] 5 new LLD vendor-awareness tests pass
- [x] 969 total tests pass across 39 test files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DiH1v2ufYHuupbP4xn6pPb

---
_Generated by [Claude Code](https://claude.ai/code/session_01DiH1v2ufYHuupbP4xn6pPb)_