### PR TITLE
feat: S1+S2 — Day-N incremental config change tool (BGP/firewall/ACL/VLAN/route)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -866,6 +866,23 @@ config-gen tests must keep passing; add new tests alongside).
 
 ---
 
+### S. Day-N incremental config change tool (sourced 2026-06-29)
+
+> User-requested: after ZTP builds a device, a tool to push **subsequent**
+> targeted config changes to already-live devices (a BGP policy, a firewall
+> policy, an ACL, a VLAN, a static route …). Audit confirmed this "incremental
+> policy push" was the one **missing** Day-2 capability — `policies.ts` renders
+> full-config placeholder snippets (no rollback, not parameterized), and
+> drift remediation is reactive-only. The new tool is proactive, parameterized,
+> per-vendor, and reversible.
+
+| # | Item | Status | Notes |
+|---|------|--------|-------|
+| S1 | Day-N change engine (`lib/config-update.ts`) — `CHANGE_CATALOG` of parameterized change ops (bgp-neighbor, bgp-route-policy[prefix-list+route-map], firewall-rule[ACL/zone], vlan, static-route), each with per-CLI-family forward + **rollback** generation. `cliFamily(vendor)` (ios/junos/nokia/fortios/panos). `buildChangeSet(op, params, devices)` scopes to selected live devices, marks each supported by role+family, summary byFamily; `changeSetToScript`/`changeSetRollbackScript` push + rollback runbooks; `validateChangeParams`. firewall-rule covers ios/junos ACL + **fortios/panos NGFW** policy. 19 tests in `test/config-update.test.ts` | [x] | new `lib/config-update.ts` + `test/config-update.test.ts` (19) |
+| S2 | Wire into Day-2 Ops tab — "🔧 Push Incremental Change (Day-N)" card: change-type picker + dynamic param form, multi-select target devices (from BOM, select-all/clear), "Generate change + rollback" → side-by-side delta vs rollback panes, download push script + rollback runbook, per-device supported count + required-field validation | [x] | `Step6Deploy.tsx` (change-op state + card); tsc + build green; 1064 tests |
+
+---
+
 ## 23. Autonomous "Start Improving" Mode (2026-06-11 →)
 
 ### Purpose

--- a/CODE_REFERENCE.md
+++ b/CODE_REFERENCE.md
@@ -1139,8 +1139,25 @@ management-plane Day-0 + the role-matched Day-N production config).
   (by BOM id from `generateAllConfigs`); `summary` byVendor/byMethod/byRole +
   `withDayN`. `ztpPlanToCsv(plan)` — provisioning manifest CSV.
 - **Tests**: 39 in `test/ztp.test.ts`.
-- **Status**: engine + tests done (R1). Not yet wired into the Step 6 ZTP tab
-  (R2) or ported to `backend/ztp` (R3) — see CLAUDE.md §22 group R.
+- **Status**: R1 engine + R2 Step-6 wiring + R3/R4 backend port all done — backend renders Day-0 for all 12 platforms with `<CHANGE-ME>` secrets + option-60 DHCP. See CLAUDE.md §22 group R.
+
+## Frontend — `lib/config-update.ts` (Day-N incremental change engine — S1)
+
+**Purpose:** After ZTP builds a device, push **subsequent targeted changes**
+to already-live devices — a BGP policy, firewall/ACL rule, VLAN, static route —
+as vendor-correct INCREMENTAL deltas with matching ROLLBACK. Distinct from
+`policies.ts` (full-config placeholder snippets) and drift remediation
+(reactive): this is proactive, parameterized, and reversible.
+
+**Key exports:**
+- `CliFamily` (`ios`/`junos`/`nokia`/`fortios`/`panos`), `cliFamily(vendor)`, `FAMILY_LABEL`.
+- `ChangeOperation` / `ChangeFieldSpec` / `RenderResult` types; `CHANGE_CATALOG` + `getChangeOp(id)`.
+- Change ops: **bgp-neighbor**, **bgp-route-policy** (prefix-list + route-map/policy), **firewall-rule** (ios/junos ACL + fortios/panos NGFW policy), **vlan** (+ SVI), **static-route** (+ VRF). Each `render(family, params)` returns `{commands, rollback}`.
+- `validateChangeParams(op, params)` — missing required field labels.
+- `buildChangeSet(op, params, devices): ChangeSet` — per-device delta + rollback scoped to the selected live devices, each marked `supported` by role+family; `summary` total/supported/byFamily.
+- `changeSetToScript(cs)` / `changeSetRollbackScript(cs)` — copy/paste push + rollback runbooks (supported devices only).
+- **UI**: Day-2 Ops tab "🔧 Push Incremental Change (Day-N)" card — change picker + dynamic param form + device multi-select + side-by-side delta/rollback preview + downloads.
+- **Tests**: 19 in `test/config-update.test.ts`.
 
 ## Frontend — `lib/containerlab.ts` (Containerlab topology export — N1)
 

--- a/frontend/src/lib/config-update.ts
+++ b/frontend/src/lib/config-update.ts
@@ -1,0 +1,437 @@
+/**
+ * config-update.ts — Day-N incremental config change engine
+ *
+ * After a device is built by ZTP (Day-0 mgmt + Day-N production), operators
+ * still need to push SUBSEQUENT, targeted changes to already-live devices —
+ * add a BGP neighbor/route-policy, a firewall/ACL rule, a VLAN, a static
+ * route, etc. This engine turns a parameterized change into the vendor-correct
+ * INCREMENTAL commands (a delta, not a full config), generates the matching
+ * ROLLBACK (the inverse), and builds a change-set scoped to the selected
+ * live devices with a push script + rollback runbook.
+ *
+ * Pure + dependency-free + fully unit-tested. Distinct from policies.ts (full-
+ * config-bake placeholder snippets) and rollback.ts (checkpoint-based device
+ * rollback): this is per-command, parameterized, and reversible.
+ */
+
+import type { BOMDevice } from '@/types'
+
+// ── CLI families ───────────────────────────────────────────────────────────
+// Day-2 deltas only need the operator-CLI family, not the full platform key.
+export type CliFamily = 'ios' | 'junos' | 'nokia' | 'fortios' | 'panos'
+
+export function cliFamily(vendor: string): CliFamily {
+  switch (vendor) {
+    case 'Juniper':          return 'junos'
+    case 'Nokia':            return 'nokia'
+    case 'Fortinet':         return 'fortios'
+    case 'Palo Alto':        return 'panos'
+    // Cisco / Arista / Dell EMC / Extreme / HPE Aruba / NVIDIA → IOS-like CLI
+    default:                 return 'ios'
+  }
+}
+
+export const FAMILY_LABEL: Record<CliFamily, string> = {
+  ios: 'Cisco/Arista IOS-style', junos: 'Juniper Junos',
+  nokia: 'Nokia SR Linux', fortios: 'Fortinet FortiOS', panos: 'Palo Alto PAN-OS',
+}
+
+// ── Change operations ──────────────────────────────────────────────────────
+
+export interface ChangeFieldSpec {
+  key: string
+  label: string
+  placeholder?: string
+  required?: boolean
+  default?: string
+}
+
+export interface RenderResult {
+  /** Forward (apply) command lines. Empty → not templated for this family. */
+  commands: string[]
+  /** Inverse (rollback) command lines. */
+  rollback: string[]
+}
+
+export interface ChangeOperation {
+  id: string
+  label: string
+  icon: string
+  category: 'Routing' | 'Security' | 'L2' | 'Management'
+  description: string
+  /** Device subLayers this change typically targets ('*' = any). */
+  appliesTo: string[]
+  fields: ChangeFieldSpec[]
+  /** CLI families this op is templated for. */
+  families: CliFamily[]
+  render: (family: CliFamily, p: Record<string, string>) => RenderResult
+}
+
+const v = (p: Record<string, string>, k: string, dflt = ''): string => (p[k]?.trim() || dflt)
+
+// ── BGP neighbor ────────────────────────────────────────────────────────────
+const bgpNeighbor: ChangeOperation = {
+  id: 'bgp-neighbor',
+  label: 'BGP neighbor',
+  icon: '🔗',
+  category: 'Routing',
+  description: 'Add a BGP neighbor (peer IP, remote-AS, optional in/out policy).',
+  appliesTo: ['spine', 'leaf', 'core', 'wan-edge', 'border', 'distribution'],
+  families: ['ios', 'junos', 'nokia'],
+  fields: [
+    { key: 'local_as', label: 'Local ASN', default: '<CHANGE-ME-local-asn>', required: true },
+    { key: 'peer_ip', label: 'Neighbor IP', placeholder: '10.0.0.2', required: true },
+    { key: 'remote_as', label: 'Remote ASN', placeholder: '65010', required: true },
+    { key: 'description', label: 'Description', placeholder: 'to-PE-2' },
+    { key: 'rmap_in', label: 'Inbound policy', placeholder: 'RM-IN' },
+    { key: 'rmap_out', label: 'Outbound policy', placeholder: 'RM-OUT' },
+  ],
+  render: (fam, p) => {
+    const peer = v(p, 'peer_ip'), ras = v(p, 'remote_as'), las = v(p, 'local_as', '<CHANGE-ME-local-asn>')
+    const desc = v(p, 'description'), rin = v(p, 'rmap_in'), rout = v(p, 'rmap_out')
+    if (fam === 'ios') {
+      const c = [`router bgp ${las}`, ` neighbor ${peer} remote-as ${ras}`]
+      if (desc) c.push(` neighbor ${peer} description ${desc}`)
+      c.push(' address-family ipv4 unicast', `  neighbor ${peer} activate`)
+      if (rin) c.push(`  neighbor ${peer} route-map ${rin} in`)
+      if (rout) c.push(`  neighbor ${peer} route-map ${rout} out`)
+      return { commands: c, rollback: [`router bgp ${las}`, ` no neighbor ${peer}`] }
+    }
+    if (fam === 'junos') {
+      const c = [`set protocols bgp group EXTERNAL neighbor ${peer} peer-as ${ras}`]
+      if (desc) c.push(`set protocols bgp group EXTERNAL neighbor ${peer} description "${desc}"`)
+      if (rin) c.push(`set protocols bgp group EXTERNAL neighbor ${peer} import ${rin}`)
+      if (rout) c.push(`set protocols bgp group EXTERNAL neighbor ${peer} export ${rout}`)
+      return { commands: c, rollback: [`delete protocols bgp group EXTERNAL neighbor ${peer}`] }
+    }
+    // nokia
+    const base = `set / network-instance default protocols bgp neighbor ${peer}`
+    const c = [`${base} peer-as ${ras}`, `${base} admin-state enable`]
+    if (rin) c.push(`${base} afi-safi ipv4-unicast import-policy ${rin}`)
+    if (rout) c.push(`${base} afi-safi ipv4-unicast export-policy ${rout}`)
+    return { commands: c, rollback: [`delete / network-instance default protocols bgp neighbor ${peer}`] }
+  },
+}
+
+// ── BGP route policy (prefix-list + route-map / policy) ──────────────────────
+const bgpRoutePolicy: ChangeOperation = {
+  id: 'bgp-route-policy',
+  label: 'BGP route policy',
+  icon: '🧭',
+  category: 'Routing',
+  description: 'Add a route policy: a prefix-list match + permit/deny, optional set local-pref.',
+  appliesTo: ['spine', 'leaf', 'core', 'wan-edge', 'border'],
+  families: ['ios', 'junos', 'nokia'],
+  fields: [
+    { key: 'name', label: 'Policy name', placeholder: 'RM-CUSTOMER-IN', required: true },
+    { key: 'action', label: 'Action (permit/deny)', default: 'permit', required: true },
+    { key: 'prefix', label: 'Prefix', placeholder: '10.20.0.0/16', required: true },
+    { key: 'local_pref', label: 'Set local-pref (optional)', placeholder: '200' },
+  ],
+  render: (fam, p) => {
+    const name = v(p, 'name'), act = v(p, 'action', 'permit').toLowerCase()
+    const prefix = v(p, 'prefix'), lp = v(p, 'local_pref')
+    const pl = `${name}-PL`
+    if (fam === 'ios') {
+      const c = [
+        `ip prefix-list ${pl} seq 10 ${act} ${prefix}`,
+        `route-map ${name} ${act} 10`,
+        ` match ip address prefix-list ${pl}`,
+      ]
+      if (act === 'permit' && lp) c.push(` set local-preference ${lp}`)
+      return { commands: c, rollback: [`no route-map ${name}`, `no ip prefix-list ${pl}`] }
+    }
+    if (fam === 'junos') {
+      const jact = act === 'deny' ? 'reject' : 'accept'
+      const c = [
+        `set policy-options prefix-list ${pl} ${prefix}`,
+        `set policy-options policy-statement ${name} term 10 from prefix-list ${pl}`,
+      ]
+      if (jact === 'accept' && lp) c.push(`set policy-options policy-statement ${name} term 10 then local-preference ${lp}`)
+      c.push(`set policy-options policy-statement ${name} term 10 then ${jact}`)
+      return { commands: c, rollback: [`delete policy-options policy-statement ${name}`, `delete policy-options prefix-list ${pl}`] }
+    }
+    // nokia
+    const c = [
+      `set / routing-policy prefix-set ${pl} prefix ${prefix} mask-length-range exact`,
+      `set / routing-policy policy ${name} statement 10 match prefix-set ${pl}`,
+      `set / routing-policy policy ${name} statement 10 action policy-result ${act === 'deny' ? 'reject' : 'accept'}`,
+    ]
+    if (act === 'permit' && lp) c.push(`set / routing-policy policy ${name} statement 10 action bgp local-preference set ${lp}`)
+    return { commands: c, rollback: [`delete / routing-policy policy ${name}`, `delete / routing-policy prefix-set ${pl}`] }
+  },
+}
+
+// ── Firewall / ACL rule ──────────────────────────────────────────────────────
+const firewallRule: ChangeOperation = {
+  id: 'firewall-rule',
+  label: 'Firewall / ACL rule',
+  icon: '🛡',
+  category: 'Security',
+  description: 'Add a firewall/ACL rule (action, protocol, source, destination, port).',
+  appliesTo: ['*'],
+  families: ['ios', 'junos', 'fortios', 'panos'],
+  fields: [
+    { key: 'name', label: 'ACL / policy name', placeholder: 'ACL-INSIDE-IN', required: true },
+    { key: 'action', label: 'Action (permit/deny)', default: 'permit', required: true },
+    { key: 'protocol', label: 'Protocol', default: 'tcp', placeholder: 'tcp/udp/ip' },
+    { key: 'source', label: 'Source', placeholder: '10.1.0.0/24', required: true },
+    { key: 'destination', label: 'Destination', placeholder: '10.2.0.0/24', required: true },
+    { key: 'port', label: 'Dest port (optional)', placeholder: '443' },
+  ],
+  render: (fam, p) => {
+    const name = v(p, 'name'), act = v(p, 'action', 'permit').toLowerCase()
+    const proto = v(p, 'protocol', 'tcp'), src = v(p, 'source'), dst = v(p, 'destination'), port = v(p, 'port')
+    if (fam === 'ios') {
+      const ace = `${act} ${proto} ${iosWild(src)} ${iosWild(dst)}${port ? ` eq ${port}` : ''}`
+      return {
+        commands: [`ip access-list extended ${name}`, ` ${ace}`],
+        rollback: [`ip access-list extended ${name}`, ` no ${ace}`],
+      }
+    }
+    if (fam === 'junos') {
+      const term = `T-${(src + dst).replace(/[^0-9]/g, '').slice(0, 6) || '10'}`
+      const jact = act === 'deny' ? 'discard' : 'accept'
+      const f = `firewall family inet filter ${name} term ${term}`
+      const c = [
+        `set ${f} from source-address ${src}`,
+        `set ${f} from destination-address ${dst}`,
+        `set ${f} from protocol ${proto}`,
+      ]
+      if (port) c.push(`set ${f} from destination-port ${port}`)
+      c.push(`set ${f} then ${jact}`)
+      return { commands: c, rollback: [`delete firewall family inet filter ${name} term ${term}`] }
+    }
+    if (fam === 'fortios') {
+      const id = 100
+      const c = [
+        `config firewall policy`,
+        `  edit ${id}`,
+        `    set name "${name}"`,
+        `    set srcaddr "${src}"`,
+        `    set dstaddr "${dst}"`,
+        `    set action ${act === 'deny' ? 'deny' : 'accept'}`,
+        `    set service "${proto.toUpperCase()}${port ? '-' + port : ''}"`,
+        `    set schedule "always"`,
+        `  next`,
+        `end`,
+      ]
+      return { commands: c, rollback: [`config firewall policy`, `  delete ${id}`, `end`] }
+    }
+    // panos
+    const c = [
+      `set rulebase security rules ${name} from any to any`,
+      `set rulebase security rules ${name} source ${src} destination ${dst}`,
+      `set rulebase security rules ${name} application any service ${proto === 'ip' ? 'any' : `service-${proto}${port ? '-' + port : ''}`}`,
+      `set rulebase security rules ${name} action ${act === 'deny' ? 'deny' : 'allow'}`,
+    ]
+    return { commands: c, rollback: [`delete rulebase security rules ${name}`] }
+  },
+}
+
+// ── VLAN ──────────────────────────────────────────────────────────────────────
+const vlanAdd: ChangeOperation = {
+  id: 'vlan',
+  label: 'VLAN',
+  icon: '🔢',
+  category: 'L2',
+  description: 'Add a VLAN (id + name) and optional SVI gateway.',
+  appliesTo: ['leaf', 'access', 'distribution', 'core'],
+  families: ['ios', 'junos'],
+  fields: [
+    { key: 'vlan_id', label: 'VLAN ID', placeholder: '120', required: true },
+    { key: 'name', label: 'VLAN name', placeholder: 'PCI-DATA', required: true },
+    { key: 'svi_ip', label: 'SVI gateway (optional)', placeholder: '10.120.0.1/24' },
+  ],
+  render: (fam, p) => {
+    const id = v(p, 'vlan_id'), name = v(p, 'name'), svi = v(p, 'svi_ip')
+    if (fam === 'ios') {
+      const c = [`vlan ${id}`, ` name ${name}`]
+      const rb = [`no vlan ${id}`]
+      if (svi) {
+        const [ip, mask] = svi.split('/')
+        c.push(`interface Vlan${id}`, ` ip address ${ip}${mask ? ` /${mask}` : ''}`, ' no shutdown')
+        rb.unshift(`no interface Vlan${id}`)
+      }
+      return { commands: c, rollback: rb }
+    }
+    // junos
+    const c = [`set vlans ${name} vlan-id ${id}`]
+    const rb = [`delete vlans ${name}`]
+    if (svi) {
+      c.push(`set vlans ${name} l3-interface irb.${id}`, `set interfaces irb unit ${id} family inet address ${svi}`)
+      rb.unshift(`delete interfaces irb unit ${id}`)
+    }
+    return { commands: c, rollback: rb }
+  },
+}
+
+// ── Static route ─────────────────────────────────────────────────────────────
+const staticRoute: ChangeOperation = {
+  id: 'static-route',
+  label: 'Static route',
+  icon: '🧱',
+  category: 'Routing',
+  description: 'Add a static route (prefix → next-hop), optional VRF.',
+  appliesTo: ['*'],
+  families: ['ios', 'junos', 'nokia'],
+  fields: [
+    { key: 'prefix', label: 'Prefix', placeholder: '10.50.0.0/24', required: true },
+    { key: 'next_hop', label: 'Next hop', placeholder: '10.0.0.1', required: true },
+    { key: 'vrf', label: 'VRF (optional)', placeholder: 'TENANT-A' },
+  ],
+  render: (fam, p) => {
+    const prefix = v(p, 'prefix'), nh = v(p, 'next_hop'), vrf = v(p, 'vrf')
+    if (fam === 'ios') {
+      const [net, mask] = prefix.split('/')
+      const vrfPart = vrf ? `vrf ${vrf} ` : ''
+      const cmd = `ip route ${vrfPart}${net} ${mask ? `/${mask}` : ''} ${nh}`.replace(/\s+/g, ' ').trim()
+      return { commands: [cmd], rollback: [`no ${cmd}`] }
+    }
+    if (fam === 'junos') {
+      const ri = vrf ? `routing-instances ${vrf} routing-options` : 'routing-options'
+      return {
+        commands: [`set ${ri} static route ${prefix} next-hop ${nh}`],
+        rollback: [`delete ${ri} static route ${prefix}`],
+      }
+    }
+    // nokia
+    const ni = vrf || 'default'
+    return {
+      commands: [
+        `set / network-instance ${ni} static-routes route ${prefix} next-hop-group nh-${nh.replace(/\./g, '-')}`,
+        `set / network-instance ${ni} next-hop-groups group nh-${nh.replace(/\./g, '-')} nexthop 1 ip-address ${nh}`,
+      ],
+      rollback: [`delete / network-instance ${ni} static-routes route ${prefix}`],
+    }
+  },
+}
+
+export const CHANGE_CATALOG: ChangeOperation[] = [
+  bgpNeighbor, bgpRoutePolicy, firewallRule, vlanAdd, staticRoute,
+]
+
+export function getChangeOp(id: string): ChangeOperation | undefined {
+  return CHANGE_CATALOG.find(o => o.id === id)
+}
+
+// IOS uses wildcard masks for hosts/subnets in some contexts, but named ACLs
+// accept CIDR-ish `a.b.c.d/p` poorly; emit `host`/`any`/`x.x.x.x y.y.y.y` form.
+function iosWild(addr: string): string {
+  const a = addr.trim()
+  if (a === 'any' || a === '0.0.0.0/0') return 'any'
+  if (a.includes('/')) {
+    const [net, plen] = a.split('/')
+    if (plen === '32') return `host ${net}`
+    return `${net} ${wildcardMask(parseInt(plen, 10))}`
+  }
+  return `host ${a}`
+}
+
+function wildcardMask(prefixLen: number): string {
+  const bits = 32 - (isNaN(prefixLen) ? 32 : prefixLen)
+  const hostCount = bits >= 32 ? 0xffffffff : (2 ** bits) - 1
+  return [24, 16, 8, 0].map(s => (hostCount >>> s) & 0xff).join('.')
+}
+
+// ── Change set (scoped to selected devices) ─────────────────────────────────
+
+export interface ChangeSetDevice {
+  device: BOMDevice
+  family: CliFamily
+  /** Op is templated for this device's family + applies to its role. */
+  supported: boolean
+  commands: string[]
+  rollback: string[]
+}
+
+export interface ChangeSet {
+  op: ChangeOperation
+  params: Record<string, string>
+  devices: ChangeSetDevice[]
+  summary: { total: number; supported: number; byFamily: Record<string, number> }
+}
+
+function roleApplies(op: ChangeOperation, dev: BOMDevice): boolean {
+  if (op.appliesTo.includes('*')) return true
+  const l = (dev.subLayer || '').toLowerCase()
+  const r = (dev.role || '').toLowerCase()
+  return op.appliesTo.some(x => l.includes(x) || r.includes(x))
+}
+
+/** List missing required fields for an operation. */
+export function validateChangeParams(op: ChangeOperation, params: Record<string, string>): string[] {
+  return op.fields
+    .filter(f => f.required && !((params[f.key] ?? f.default ?? '').trim()))
+    .map(f => f.label)
+}
+
+/** Build a change-set: per-device delta + rollback, scoped to `devices`. */
+export function buildChangeSet(
+  op: ChangeOperation,
+  params: Record<string, string>,
+  devices: BOMDevice[],
+): ChangeSet {
+  // Merge field defaults into params so render sees complete input.
+  const merged: Record<string, string> = {}
+  for (const f of op.fields) merged[f.key] = (params[f.key] ?? f.default ?? '')
+  for (const k of Object.keys(params)) if (params[k] != null) merged[k] = params[k]
+
+  const byFamily: Record<string, number> = {}
+  const entries: ChangeSetDevice[] = devices.map(device => {
+    const family = cliFamily(device.vendor)
+    const applies = roleApplies(op, device)
+    const templated = op.families.includes(family)
+    const supported = applies && templated
+    if (supported) byFamily[family] = (byFamily[family] ?? 0) + 1
+    const r = supported
+      ? op.render(family, merged)
+      : { commands: [`! ${op.label} not applicable to ${device.hostname} (${family}/${device.subLayer}) — review manually`], rollback: [] }
+    return { device, family, supported, commands: r.commands, rollback: r.rollback }
+  })
+
+  return {
+    op,
+    params: merged,
+    devices: entries,
+    summary: {
+      total: entries.length,
+      supported: entries.filter(e => e.supported).length,
+      byFamily,
+    },
+  }
+}
+
+/** A human-readable, copy/paste push runbook (forward commands per device). */
+export function changeSetToScript(cs: ChangeSet): string {
+  const ts = '<apply during approved change window>'
+  const lines = [
+    `# ── Day-N config change: ${cs.op.label} ──────────────────────────────`,
+    `# ${cs.op.description}`,
+    `# Targets: ${cs.summary.supported}/${cs.summary.total} device(s). ${ts}`,
+    '',
+  ]
+  for (const e of cs.devices) {
+    if (!e.supported) continue
+    lines.push(`# ── ${e.device.hostname} (${e.device.vendor}, ${FAMILY_LABEL[e.family]}) ──`)
+    lines.push(...e.commands)
+    lines.push('')
+  }
+  return lines.join('\n')
+}
+
+/** The rollback runbook (inverse commands per device). */
+export function changeSetRollbackScript(cs: ChangeSet): string {
+  const lines = [
+    `# ── ROLLBACK for: ${cs.op.label} ─────────────────────────────────────`,
+    `# Apply only if the change must be reverted.`,
+    '',
+  ]
+  for (const e of cs.devices) {
+    if (!e.supported || e.rollback.length === 0) continue
+    lines.push(`# ── ${e.device.hostname} (${e.device.vendor}) ──`)
+    lines.push(...e.rollback)
+    lines.push('')
+  }
+  return lines.join('\n')
+}

--- a/frontend/src/pages/Step6Deploy.tsx
+++ b/frontend/src/pages/Step6Deploy.tsx
@@ -25,6 +25,7 @@ import { LiveProgressFeed } from '@/components/LiveProgressFeed'
 import { createWatcher, exportCronTab, exportSystemdTimer, exportScanScript, simulateScanHistory, INTERVAL_PRESETS, type WatcherConfig, type ScanType, type ScanAction, type ScanHistoryEntry } from '@/lib/scheduled-scans'
 import { validateConfigs, validationReportText, type ValidationResult } from '@/lib/config-validator'
 import { buildZTPPlan, generateDhcpConfig, ztpPlanToCsv, type ZTPPlan } from '@/lib/ztp'
+import { CHANGE_CATALOG, getChangeOp, buildChangeSet, changeSetToScript, changeSetRollbackScript, validateChangeParams, FAMILY_LABEL } from '@/lib/config-update'
 import type { ZTPEvent, BOMDevice, CheckResult, MonitoringResult, ZTPResult, ChecksResult, DeviceMetrics, MetricsSummary, ConfigDriftResponse, ConfigDriftDevice, ConfigRemediationResponse, RemediationDeviceInput, TroubleshootResult } from '@/types'
 
 const STATUS_BADGE: Record<string, 'pass' | 'warn' | 'fail' | 'neutral'> = {
@@ -2743,6 +2744,14 @@ export function Step6Deploy() {
   }, [storeDevices, storeConfigs])
   const [ztpDay0View, setZtpDay0View] = useState<string | null>(null)
 
+  // Day-N incremental change-push: pick a change op, parameterize it, and
+  // generate per-vendor delta + rollback for the selected live devices.
+  const [changeOpId, setChangeOpId] = useState<string>(CHANGE_CATALOG[0].id)
+  const [changeParams, setChangeParams] = useState<Record<string, string>>({})
+  const [changeTargets, setChangeTargets] = useState<Set<string>>(new Set())
+  const [changeResult, setChangeResult] = useState<{ script: string; rollback: string; supported: number; total: number } | null>(null)
+  const changeOp = getChangeOp(changeOpId) ?? CHANGE_CATALOG[0]
+
   // Auto-tick demo metrics every 15 s when on monitor tab and backend offline
   useEffect(() => {
     if (tab !== 'monitor' || isLive) return
@@ -4363,6 +4372,125 @@ export function Step6Deploy() {
                 </div>
               )}
             </div>
+          </Card>
+
+          {/* L1: Day-N incremental change push (BGP/firewall/ACL/VLAN/route) */}
+          <Card>
+            <CardHeader><CardTitle>🔧 Push Incremental Change (Day-N)</CardTitle></CardHeader>
+            <p className="text-xs text-gray-500 mb-3">
+              After ZTP builds a device, push a targeted change — a BGP policy, firewall/ACL rule,
+              VLAN, or static route — to selected live devices. Generates the vendor-correct delta
+              <span className="text-gray-400"> and the matching rollback</span>.
+            </p>
+
+            <div className="flex flex-wrap gap-3 items-start">
+              {/* Change type */}
+              <div>
+                <label className="text-xs text-gray-400 block mb-1">Change type</label>
+                <select
+                  value={changeOpId}
+                  onChange={e => { setChangeOpId(e.target.value); setChangeParams({}); setChangeResult(null) }}
+                  className="bg-white/5 border border-white/10 rounded px-3 py-2 text-sm text-gray-200 focus:outline-none focus:border-blue-500"
+                >
+                  {CHANGE_CATALOG.map(o => (
+                    <option key={o.id} value={o.id}>{o.icon} {o.label}</option>
+                  ))}
+                </select>
+                <p className="text-[11px] text-gray-600 mt-1 max-w-[220px]">{changeOp.description}</p>
+                <p className="text-[11px] text-gray-600 mt-0.5">
+                  Vendors: {changeOp.families.map(f => FAMILY_LABEL[f].split('/')[0]).join(', ')}
+                </p>
+              </div>
+
+              {/* Params */}
+              <div className="grid grid-cols-2 gap-2 flex-1 min-w-[280px]">
+                {changeOp.fields.map(f => (
+                  <div key={f.key}>
+                    <label className="text-xs text-gray-400 block mb-1">
+                      {f.label}{f.required ? ' *' : ''}
+                    </label>
+                    <input
+                      value={changeParams[f.key] ?? ''}
+                      placeholder={f.placeholder ?? f.default ?? ''}
+                      onChange={e => setChangeParams(p => ({ ...p, [f.key]: e.target.value }))}
+                      className="w-full bg-white/5 border border-white/10 rounded px-2 py-1.5 text-xs text-gray-200 focus:outline-none focus:border-blue-500"
+                    />
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            {/* Target devices */}
+            <div className="mt-3">
+              <div className="flex items-center justify-between mb-1">
+                <label className="text-xs text-gray-400">Target devices ({changeTargets.size} selected)</label>
+                <div className="flex gap-2">
+                  <button className="text-[11px] text-blue-400 hover:underline cursor-pointer"
+                    onClick={() => setChangeTargets(new Set(storeDevices.map(d => d.id)))}>select all</button>
+                  <button className="text-[11px] text-gray-400 hover:underline cursor-pointer"
+                    onClick={() => setChangeTargets(new Set())}>clear</button>
+                </div>
+              </div>
+              <div className="flex flex-wrap gap-1.5 max-h-32 overflow-y-auto">
+                {storeDevices.map(d => {
+                  const sel = changeTargets.has(d.id)
+                  return (
+                    <button key={d.id}
+                      onClick={() => setChangeTargets(prev => { const n = new Set(prev); n.has(d.id) ? n.delete(d.id) : n.add(d.id); return n })}
+                      className={cn('px-2 py-1 rounded text-[11px] border transition-colors cursor-pointer',
+                        sel ? 'bg-blue-600/30 border-blue-500 text-blue-200' : 'bg-white/5 border-white/10 text-gray-400 hover:border-white/30')}>
+                      {d.hostname} <span className="text-gray-600">{d.vendor}</span>
+                    </button>
+                  )
+                })}
+              </div>
+            </div>
+
+            <div className="flex flex-wrap gap-2 mt-3 items-center">
+              <Button className="text-xs"
+                onClick={() => {
+                  const missing = validateChangeParams(changeOp, changeParams)
+                  if (missing.length) { showToast(`Fill required fields: ${missing.join(', ')}`, 'error'); return }
+                  const targets = storeDevices.filter(d => changeTargets.has(d.id))
+                  if (targets.length === 0) { showToast('Select at least one target device', 'error'); return }
+                  const cs = buildChangeSet(changeOp, changeParams, targets)
+                  setChangeResult({
+                    script: changeSetToScript(cs),
+                    rollback: changeSetRollbackScript(cs),
+                    supported: cs.summary.supported,
+                    total: cs.summary.total,
+                  })
+                  showToast(`Generated change for ${cs.summary.supported}/${cs.summary.total} device(s)`, 'success')
+                }}>
+                Generate change + rollback
+              </Button>
+              {changeResult && (
+                <>
+                  <Button variant="secondary" className="text-xs"
+                    onClick={() => { downloadBlob(`change-${changeOp.id}.txt`, changeResult.script); showToast('Change script downloaded', 'success') }}>
+                    ⬇ Push script
+                  </Button>
+                  <Button variant="secondary" className="text-xs"
+                    onClick={() => { downloadBlob(`rollback-${changeOp.id}.txt`, changeResult.rollback); showToast('Rollback runbook downloaded', 'success') }}>
+                    ⬇ Rollback runbook
+                  </Button>
+                  <span className="text-xs text-gray-500">{changeResult.supported}/{changeResult.total} device(s) supported</span>
+                </>
+              )}
+            </div>
+
+            {changeResult && (
+              <div className="grid md:grid-cols-2 gap-3 mt-3">
+                <div>
+                  <div className="text-xs text-gray-400 mb-1">Change (delta) — apply</div>
+                  <pre className="bg-black/40 border border-white/10 rounded p-3 text-xs text-green-300 overflow-x-auto max-h-72">{changeResult.script}</pre>
+                </div>
+                <div>
+                  <div className="text-xs text-gray-400 mb-1">Rollback (inverse)</div>
+                  <pre className="bg-black/40 border border-white/10 rounded p-3 text-xs text-amber-300 overflow-x-auto max-h-72">{changeResult.rollback}</pre>
+                </div>
+              </div>
+            )}
           </Card>
 
           {/* Config Drift Detection (G-A4) */}

--- a/frontend/src/test/config-update.test.ts
+++ b/frontend/src/test/config-update.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect } from 'vitest'
+import {
+  cliFamily, getChangeOp, CHANGE_CATALOG, validateChangeParams,
+  buildChangeSet, changeSetToScript, changeSetRollbackScript,
+} from '@/lib/config-update'
+import type { BOMDevice } from '@/types'
+
+const dev = (o: Partial<BOMDevice>): BOMDevice => ({
+  id: o.hostname ?? 'd', hostname: 'H', role: 'leaf', subLayer: 'leaf',
+  model: 'M', vendor: 'Cisco', count: 1, unitPrice: 0, totalPrice: 0,
+  speed: '100G', ports: 32, uplinks: 4, features: [], ...o,
+})
+
+describe('cliFamily', () => {
+  it('maps vendors to CLI families', () => {
+    expect(cliFamily('Cisco')).toBe('ios')
+    expect(cliFamily('Arista')).toBe('ios')
+    expect(cliFamily('Dell EMC')).toBe('ios')
+    expect(cliFamily('Juniper')).toBe('junos')
+    expect(cliFamily('Nokia')).toBe('nokia')
+    expect(cliFamily('Fortinet')).toBe('fortios')
+    expect(cliFamily('Palo Alto')).toBe('panos')
+  })
+})
+
+describe('CHANGE_CATALOG', () => {
+  it('has the requested change ops with fields + families', () => {
+    const ids = CHANGE_CATALOG.map(o => o.id)
+    expect(ids).toContain('bgp-neighbor')
+    expect(ids).toContain('bgp-route-policy')
+    expect(ids).toContain('firewall-rule')
+    expect(ids).toContain('vlan')
+    expect(ids).toContain('static-route')
+    for (const op of CHANGE_CATALOG) {
+      expect(op.fields.length).toBeGreaterThan(0)
+      expect(op.families.length).toBeGreaterThan(0)
+    }
+  })
+})
+
+describe('validateChangeParams', () => {
+  it('reports missing required fields by label', () => {
+    const op = getChangeOp('bgp-neighbor')!
+    const missing = validateChangeParams(op, { local_as: '65000' })
+    expect(missing).toContain('Neighbor IP')
+    expect(missing).toContain('Remote ASN')
+    expect(missing).not.toContain('Local ASN')
+  })
+})
+
+// ── BGP neighbor ────────────────────────────────────────────────────────────
+describe('bgp-neighbor render', () => {
+  const op = getChangeOp('bgp-neighbor')!
+  const p = { local_as: '65000', peer_ip: '10.0.0.2', remote_as: '65010', rmap_in: 'RM-IN' }
+
+  it('ios: emits router bgp + neighbor, rollback removes it', () => {
+    const r = op.render('ios', p)
+    expect(r.commands).toContain('router bgp 65000')
+    expect(r.commands.join('\n')).toContain('neighbor 10.0.0.2 remote-as 65010')
+    expect(r.commands.join('\n')).toContain('route-map RM-IN in')
+    expect(r.rollback.join('\n')).toContain('no neighbor 10.0.0.2')
+  })
+
+  it('junos: set protocols bgp ... rollback deletes neighbor', () => {
+    const r = op.render('junos', p)
+    expect(r.commands.join('\n')).toContain('set protocols bgp group EXTERNAL neighbor 10.0.0.2 peer-as 65010')
+    expect(r.rollback[0]).toBe('delete protocols bgp group EXTERNAL neighbor 10.0.0.2')
+  })
+
+  it('nokia: network-instance default protocols bgp neighbor', () => {
+    const r = op.render('nokia', p)
+    expect(r.commands.join('\n')).toContain('network-instance default protocols bgp neighbor 10.0.0.2 peer-as 65010')
+    expect(r.rollback[0]).toContain('delete / network-instance default protocols bgp neighbor 10.0.0.2')
+  })
+})
+
+// ── BGP route policy ─────────────────────────────────────────────────────────
+describe('bgp-route-policy render', () => {
+  const op = getChangeOp('bgp-route-policy')!
+  const p = { name: 'RM-CUST', action: 'permit', prefix: '10.20.0.0/16', local_pref: '200' }
+
+  it('ios: prefix-list + route-map + set local-preference', () => {
+    const r = op.render('ios', p)
+    const t = r.commands.join('\n')
+    expect(t).toContain('ip prefix-list RM-CUST-PL seq 10 permit 10.20.0.0/16')
+    expect(t).toContain('route-map RM-CUST permit 10')
+    expect(t).toContain('set local-preference 200')
+    expect(r.rollback).toEqual(['no route-map RM-CUST', 'no ip prefix-list RM-CUST-PL'])
+  })
+
+  it('junos: policy-statement with accept + local-preference', () => {
+    const r = op.render('junos', p)
+    const t = r.commands.join('\n')
+    expect(t).toContain('set policy-options prefix-list RM-CUST-PL 10.20.0.0/16')
+    expect(t).toContain('then local-preference 200')
+    expect(t).toContain('then accept')
+  })
+
+  it('deny maps to reject/deny and omits local-pref', () => {
+    const r = op.render('ios', { name: 'RM-X', action: 'deny', prefix: '10.0.0.0/8', local_pref: '150' })
+    const t = r.commands.join('\n')
+    expect(t).toContain('route-map RM-X deny 10')
+    expect(t).not.toContain('set local-preference')
+  })
+})
+
+// ── Firewall / ACL rule ──────────────────────────────────────────────────────
+describe('firewall-rule render', () => {
+  const op = getChangeOp('firewall-rule')!
+  const p = { name: 'ACL-IN', action: 'permit', protocol: 'tcp', source: '10.1.0.0/24', destination: '10.2.0.0/24', port: '443' }
+
+  it('ios: extended ACL ACE + matching no-rollback', () => {
+    const r = op.render('ios', p)
+    expect(r.commands[0]).toBe('ip access-list extended ACL-IN')
+    expect(r.commands[1]).toContain('permit tcp')
+    expect(r.commands[1]).toContain('eq 443')
+    expect(r.rollback[1].startsWith(' no ')).toBe(true)
+  })
+
+  it('junos: firewall filter term with rollback delete', () => {
+    const r = op.render('junos', p)
+    const t = r.commands.join('\n')
+    expect(t).toContain('firewall family inet filter ACL-IN term')
+    expect(t).toContain('then accept')
+    expect(r.rollback[0]).toContain('delete firewall family inet filter ACL-IN term')
+  })
+
+  it('fortios: config firewall policy block + delete rollback', () => {
+    const r = op.render('fortios', p)
+    const t = r.commands.join('\n')
+    expect(t).toContain('config firewall policy')
+    expect(t).toContain('set action accept')
+    expect(r.rollback.join('\n')).toContain('delete 100')
+  })
+
+  it('panos: security rule set + delete rollback', () => {
+    const r = op.render('panos', { ...p, action: 'deny' })
+    const t = r.commands.join('\n')
+    expect(t).toContain('set rulebase security rules ACL-IN')
+    expect(t).toContain('action deny')
+    expect(r.rollback[0]).toBe('delete rulebase security rules ACL-IN')
+  })
+})
+
+// ── VLAN + static route ──────────────────────────────────────────────────────
+describe('vlan + static-route render', () => {
+  it('vlan ios: vlan + SVI, rollback removes both', () => {
+    const r = getChangeOp('vlan')!.render('ios', { vlan_id: '120', name: 'PCI', svi_ip: '10.120.0.1/24' })
+    expect(r.commands.join('\n')).toContain('vlan 120')
+    expect(r.commands.join('\n')).toContain('interface Vlan120')
+    expect(r.rollback).toContain('no vlan 120')
+    expect(r.rollback).toContain('no interface Vlan120')
+  })
+
+  it('static-route ios: ip route + no-rollback', () => {
+    const r = getChangeOp('static-route')!.render('ios', { prefix: '10.50.0.0/24', next_hop: '10.0.0.1' })
+    expect(r.commands[0]).toContain('ip route')
+    expect(r.commands[0]).toContain('10.0.0.1')
+    expect(r.rollback[0].startsWith('no ')).toBe(true)
+  })
+
+  it('static-route junos with VRF uses routing-instances', () => {
+    const r = getChangeOp('static-route')!.render('junos', { prefix: '10.50.0.0/24', next_hop: '10.0.0.1', vrf: 'TENANT-A' })
+    expect(r.commands[0]).toContain('routing-instances TENANT-A routing-options static route 10.50.0.0/24 next-hop 10.0.0.1')
+  })
+})
+
+// ── Change set ───────────────────────────────────────────────────────────────
+describe('buildChangeSet', () => {
+  const op = getChangeOp('bgp-neighbor')!
+  const params = { local_as: '65000', peer_ip: '10.0.0.2', remote_as: '65010' }
+  const devices = [
+    dev({ id: 'sp1', hostname: 'SP-01', vendor: 'Cisco', subLayer: 'spine' }),
+    dev({ id: 'lf1', hostname: 'LF-01', vendor: 'Juniper', subLayer: 'leaf' }),
+    dev({ id: 'ac1', hostname: 'AC-01', vendor: 'Cisco', subLayer: 'access', role: 'access' }), // BGP not for access
+  ]
+
+  it('marks each device supported/unsupported by role + family', () => {
+    const cs = buildChangeSet(op, params, devices)
+    const sp = cs.devices.find(d => d.device.id === 'sp1')!
+    const lf = cs.devices.find(d => d.device.id === 'lf1')!
+    const ac = cs.devices.find(d => d.device.id === 'ac1')!
+    expect(sp.supported).toBe(true)
+    expect(lf.supported).toBe(true)
+    expect(ac.supported).toBe(false)       // BGP neighbor not for access role
+    expect(cs.summary.supported).toBe(2)
+    expect(cs.summary.byFamily).toMatchObject({ ios: 1, junos: 1 })
+  })
+
+  it('merges field defaults so local_as falls back to placeholder', () => {
+    const cs = buildChangeSet(op, { peer_ip: '10.0.0.5', remote_as: '65020' }, [devices[0]])
+    expect(cs.devices[0].commands.join('\n')).toContain('router bgp <CHANGE-ME-local-asn>')
+  })
+
+  it('push + rollback scripts include only supported devices', () => {
+    const cs = buildChangeSet(op, params, devices)
+    const push = changeSetToScript(cs)
+    const rb = changeSetRollbackScript(cs)
+    expect(push).toContain('SP-01')
+    expect(push).toContain('LF-01')
+    expect(push).not.toContain('AC-01')     // unsupported excluded
+    expect(rb).toContain('no neighbor 10.0.0.2')
+    expect(rb).toContain('delete protocols bgp group EXTERNAL neighbor 10.0.0.2')
+  })
+})


### PR DESCRIPTION
## Summary

After ZTP builds a device (Day-0 mgmt + Day-N production), operators need to push **subsequent targeted changes** to already-live devices — a BGP policy, a firewall policy, an ACL, a VLAN, a static route. An audit confirmed this "incremental policy push" was the one **missing** Day-2 capability: `policies.ts` renders full-config placeholder snippets (no rollback, not parameterized) and drift remediation is reactive-only. This adds a **proactive, parameterized, per-vendor, reversible** change-push tool.

## S1 — `lib/config-update.ts` (engine)

- **`CHANGE_CATALOG`** of parameterized change ops:
  - **bgp-neighbor** (peer IP / remote-AS / in+out policy)
  - **bgp-route-policy** (prefix-list + route-map / policy-statement, optional set local-pref)
  - **firewall-rule** — ios/junos **ACL** + Fortinet/PAN-OS **NGFW policy**
  - **vlan** (+ SVI), **static-route** (+ VRF)
- Each op renders per **CLI family** (`ios`/`junos`/`nokia`/`fortios`/`panos`) the **forward delta** *and* the matching **rollback** (`no …` / `delete …`).
- `buildChangeSet(op, params, devices)` scopes the change to the **selected live devices**, marks each `supported` by role + family, summarizes byFamily; `changeSetToScript` / `changeSetRollbackScript` produce push + rollback runbooks; `validateChangeParams` flags missing required fields.

## S2 — Day-2 Ops UI

"🔧 Push Incremental Change (Day-N)" card: change-type picker + **dynamic param form**, **multi-select target devices**, "Generate change + rollback" → **side-by-side delta vs rollback** preview, download push script + rollback runbook, per-device supported count + required-field validation.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — succeeds
- [x] 19 new tests in `test/config-update.test.ts` (per-op forward+rollback across families, change-set role/family scoping, default merging, push/rollback scripts)
- [x] 1064 total frontend tests pass across 41 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DiH1v2ufYHuupbP4xn6pPb

---
_Generated by [Claude Code](https://claude.ai/code/session_01DiH1v2ufYHuupbP4xn6pPb)_