### PR TITLE
feat: T1+T2 — monitoring engine: computed threshold alerting + fleet health

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -886,6 +886,20 @@ config-gen tests must keep passing; add new tests alongside).
 | S4 | Pre-flight safety analysis for the Day-N change — `analyzeChangeSet(cs)` returns `ChangeWarning[]` (info/warn/danger) before the operator pushes: skipped (unsupported) devices, unfilled `<CHANGE-ME>` placeholders in the generated commands, **irreversible** changes (supported device with no rollback), and two genuinely-risky patterns — admin-down on a fabric (spine/leaf/core) interface, and a broad `deny any → any` firewall rule. Surfaced as a severity-colored warning banner in the Day-2 Ops change card before the delta/rollback preview. 5 new tests | [x] | `config-update.ts` (`analyzeChangeSet`/`ChangeWarning`) + `Step6Deploy.tsx` banner; `config-update.test.ts` 24→29; 1074 tests, build green |
 | S5 (backend) | Backend parity for the Day-N change tool — `backend/change_update.py` mirrors the frontend engine (same 7 ops × ios/junos/nokia/fortios/panos forward+rollback, `build_change_set`, `analyze_change_set`, `validate_change_params`, `CHANGE_CATALOG`); new `GET /api/change/catalog` + `POST /api/change/preview` (generation only, like /api/drift/remediate — returns per-device delta+rollback + pre-flight warnings + summary). 16 pytest in `test_change_update.py` | [x] | `backend/change_update.py` + `main.py` endpoints; backend pytest 16 (108 with ztp suites) |
 
+### T. Monitoring engine — computed alerting + fleet health (sourced 2026-06-29)
+
+> A full audit of the monitoring engine found it "feature-rich but data-
+> limited": the demo Monitoring tab sampled per-device metrics each tick but
+> only drew gauges — it never *analyzed* them into alerts/health. Real
+> alerting only existed in live mode (`/api/alerts`, telemetry-gated) or as
+> hardcoded lab alerts. Top quick win: client-side threshold alerting + health
+> that works in demo mode (the app's emphasis), with tunable thresholds.
+
+| # | Item | Status | Notes |
+|---|------|--------|-------|
+| T1 | Monitoring analysis/alerting engine (`lib/monitoring.ts`) — turns a `MetricsSummary` into a NOC view: `METRIC_THRESHOLDS` (cpu/mem/iface-errors/pfc, warn+critical, tunable), `evaluateDevice(name, role, m, thresholds?)` → per-device health (healthy/degraded/down) + severity-ranked `MonAlert[]` (routing device with 0 BGP sessions → down/control-plane-isolated; cpu≥99 → down), `evaluateFleet(summary, {roles, thresholds})` → fleet rollup + sorted alert list, `alertsToText` NOC feed export. Pure + 12 tests | [x] | new `lib/monitoring.ts` + `test/monitoring.test.ts` (12) |
+| T2 | Wire into the Monitoring tab — "🔔 Active Alerts & Fleet Health" card computes `evaluateFleet(metrics, {roles})` from the live/demo metrics each tick: health chips (healthy/degraded/down + critical/warning counts), severity-colored alert feed (sorted critical-first), and an "Export alert feed" download. Works in demo mode (previously alert-less) | [x] | `Step6Deploy.tsx` monitor tab; tsc + build green; 1086 tests |
+
 ---
 
 ## 23. Autonomous "Start Improving" Mode (2026-06-11 →)

--- a/CODE_REFERENCE.md
+++ b/CODE_REFERENCE.md
@@ -1160,6 +1160,21 @@ as vendor-correct INCREMENTAL deltas with matching ROLLBACK. Distinct from
 - **UI**: Day-2 Ops tab "🔧 Push Incremental Change (Day-N)" card — change picker + dynamic param form + device multi-select + side-by-side delta/rollback preview + downloads.
 - **Tests**: 19 in `test/config-update.test.ts`.
 
+## Frontend — `lib/monitoring.ts` (Monitoring analysis / alerting — T1)
+
+**Purpose:** Turn a sampled `MetricsSummary` into a real NOC view — threshold
+alerts + per-device health + fleet rollup — client-side, so it works in demo
+mode (not just live `/api/alerts`).
+
+**Key exports:**
+- Types: `HealthStatus` (healthy/degraded/down), `AlertSeverity` (critical/warning/info), `MetricThreshold`, `MonAlert`, `DeviceHealthEval`, `FleetHealth`.
+- `METRIC_THRESHOLDS` — default warn+critical per metric (cpu_util 75/90, mem_util 80/92, interface_errors_in/out 5/50, pfc_drops 50/200); tunable via the `thresholds` arg.
+- `evaluateDevice(device, role, metrics, thresholds?)` — per-device health + severity-ranked alerts. A routing device (name/role hints) with `bgp_sessions_up === 0` → **down** (control-plane isolated); `cpu_util ≥ 99` → **down**; any threshold breach → degraded.
+- `evaluateFleet(summary, {roles?, thresholds?})` — fleet rollup (`healthy`/`degraded`/`down` + `critical`/`warning` counts) + all alerts sorted critical-first.
+- `alertsToText(fleet)` — plain-text NOC alert feed for download.
+- **UI**: Step 6 Monitoring tab "🔔 Active Alerts & Fleet Health" card (health chips + severity-colored feed + export), computed from live/demo metrics each tick.
+- **Tests**: 12 in `test/monitoring.test.ts`.
+
 ## Frontend — `lib/containerlab.ts` (Containerlab topology export — N1)
 
 **Purpose:** Generates containerlab YAML topology files from BOM devices +

--- a/frontend/src/lib/monitoring.ts
+++ b/frontend/src/lib/monitoring.ts
@@ -1,0 +1,175 @@
+/**
+ * monitoring.ts — client-side monitoring analysis / alerting engine
+ *
+ * The Step 6 Monitoring tab samples per-device metrics (CPU, memory, interface
+ * errors, BGP sessions/prefixes, PFC drops, throughput) every tick, but in
+ * demo mode it only drew gauges — it never *analyzed* them. This turns the raw
+ * `MetricsSummary` into a real NOC view:
+ *   - threshold-based, severity-ranked alerts computed from the metrics,
+ *   - per-device health (healthy / degraded / down),
+ *   - fleet roll-up + an exportable alert feed.
+ *
+ * Works without a backend (demo mode) and over live `/api/metrics/summary`.
+ * Pure + dependency-free + unit-tested.
+ */
+
+import type { DeviceMetrics, MetricsSummary } from '@/types'
+
+export type HealthStatus = 'healthy' | 'degraded' | 'down'
+export type AlertSeverity = 'critical' | 'warning' | 'info'
+
+// ── Thresholds ──────────────────────────────────────────────────────────────
+
+export interface MetricThreshold {
+  metric: keyof DeviceMetrics
+  label: string
+  unit: string
+  /** Breach direction: value ABOVE (util/errors) or BELOW (sessions) the limit. */
+  direction: 'above' | 'below'
+  warn: number
+  critical: number
+}
+
+// NOC-style default thresholds. Tunable via `evaluateFleet(..., {thresholds})`.
+export const METRIC_THRESHOLDS: MetricThreshold[] = [
+  { metric: 'cpu_util', label: 'CPU', unit: '%', direction: 'above', warn: 75, critical: 90 },
+  { metric: 'mem_util', label: 'Memory', unit: '%', direction: 'above', warn: 80, critical: 92 },
+  { metric: 'interface_errors_in', label: 'Iface errors (in)', unit: '', direction: 'above', warn: 5, critical: 50 },
+  { metric: 'interface_errors_out', label: 'Iface errors (out)', unit: '', direction: 'above', warn: 5, critical: 50 },
+  { metric: 'pfc_drops', label: 'PFC drops', unit: '', direction: 'above', warn: 50, critical: 200 },
+]
+
+// ── Alerts + health ─────────────────────────────────────────────────────────
+
+export interface MonAlert {
+  device: string
+  metric: string
+  severity: AlertSeverity
+  message: string
+  value: number
+  threshold: number
+}
+
+export interface DeviceHealthEval {
+  device: string
+  role: string
+  status: HealthStatus
+  alerts: MonAlert[]
+  metrics: DeviceMetrics
+}
+
+export interface FleetHealth {
+  devices: DeviceHealthEval[]
+  summary: {
+    total: number
+    healthy: number
+    degraded: number
+    down: number
+    critical: number   // count of critical alerts
+    warning: number    // count of warning alerts
+  }
+  /** All alerts across the fleet, most severe first. */
+  alerts: MonAlert[]
+  timestamp: string
+}
+
+const ROUTING_HINTS = ['spine', 'leaf', 'core', 'wan', 'edge', 'border', 'pe', 'hub', 'rtr', 'router']
+
+function isRoutingDevice(name: string, role: string): boolean {
+  const s = `${name} ${role}`.toLowerCase()
+  return ROUTING_HINTS.some(h => s.includes(h))
+}
+
+/** Evaluate one device's metrics → health + alerts. */
+export function evaluateDevice(
+  device: string,
+  role: string,
+  m: DeviceMetrics,
+  thresholds: MetricThreshold[] = METRIC_THRESHOLDS,
+): DeviceHealthEval {
+  const alerts: MonAlert[] = []
+
+  for (const t of thresholds) {
+    const value = Number(m[t.metric] ?? 0)
+    const breach = t.direction === 'above'
+      ? (value >= t.critical ? 'critical' : value >= t.warn ? 'warning' : null)
+      : (value <= t.critical ? 'critical' : value <= t.warn ? 'warning' : null)
+    if (breach) {
+      const limit = breach === 'critical' ? t.critical : t.warn
+      alerts.push({
+        device, metric: String(t.metric), severity: breach, value, threshold: limit,
+        message: `${t.label} ${value}${t.unit} ${t.direction === 'above' ? '≥' : '≤'} ${limit}${t.unit} (${breach})`,
+      })
+    }
+  }
+
+  // Control-plane down: a routing device with zero BGP sessions up.
+  let controlPlaneDown = false
+  if (isRoutingDevice(device, role) && m.bgp_sessions_up === 0) {
+    controlPlaneDown = true
+    alerts.push({
+      device, metric: 'bgp_sessions_up', severity: 'critical', value: 0, threshold: 1,
+      message: 'All BGP sessions down (0 established) — control plane isolated',
+    })
+  }
+
+  // CPU pegged → treat as down (device effectively unresponsive).
+  const pegged = m.cpu_util >= 99
+
+  const status: HealthStatus = (controlPlaneDown || pegged)
+    ? 'down'
+    : alerts.length > 0 ? 'degraded' : 'healthy'
+
+  return { device, role, status, alerts, metrics: m }
+}
+
+const SEV_RANK: Record<AlertSeverity, number> = { critical: 0, warning: 1, info: 2 }
+
+/** Evaluate the whole fleet from a MetricsSummary. */
+export function evaluateFleet(
+  summary: MetricsSummary,
+  opts: { roles?: Record<string, string>; thresholds?: MetricThreshold[] } = {},
+): FleetHealth {
+  const roles = opts.roles ?? {}
+  const devices: DeviceHealthEval[] = []
+  for (const [name, m] of Object.entries(summary.devices)) {
+    devices.push(evaluateDevice(name, roles[name] ?? '', m, opts.thresholds))
+  }
+
+  const alerts = devices.flatMap(d => d.alerts)
+    .sort((a, b) => SEV_RANK[a.severity] - SEV_RANK[b.severity] || b.value - a.value)
+
+  return {
+    devices: devices.sort((a, b) => a.device.localeCompare(b.device)),
+    summary: {
+      total: devices.length,
+      healthy: devices.filter(d => d.status === 'healthy').length,
+      degraded: devices.filter(d => d.status === 'degraded').length,
+      down: devices.filter(d => d.status === 'down').length,
+      critical: alerts.filter(a => a.severity === 'critical').length,
+      warning: alerts.filter(a => a.severity === 'warning').length,
+    },
+    alerts,
+    timestamp: summary.timestamp,
+  }
+}
+
+/** Export the active alerts as a plain-text NOC feed (most severe first). */
+export function alertsToText(fleet: FleetHealth): string {
+  const lines = [
+    '# Active Alerts — NetDesign AI Monitoring',
+    `# ${fleet.timestamp}`,
+    `# ${fleet.summary.critical} critical · ${fleet.summary.warning} warning · `
+      + `${fleet.summary.down} down / ${fleet.summary.degraded} degraded / ${fleet.summary.healthy} healthy`,
+    '',
+  ]
+  if (fleet.alerts.length === 0) {
+    lines.push('No active alerts — all devices within thresholds.')
+    return lines.join('\n')
+  }
+  for (const a of fleet.alerts) {
+    const tag = a.severity === 'critical' ? 'CRIT' : a.severity === 'warning' ? 'WARN' : 'INFO'
+    lines.push(`[${tag}] ${a.device}: ${a.message}`)
+  }
+  return lines.join('\n')
+}

--- a/frontend/src/pages/Step6Deploy.tsx
+++ b/frontend/src/pages/Step6Deploy.tsx
@@ -26,6 +26,7 @@ import { createWatcher, exportCronTab, exportSystemdTimer, exportScanScript, sim
 import { validateConfigs, validationReportText, type ValidationResult } from '@/lib/config-validator'
 import { buildZTPPlan, generateDhcpConfig, ztpPlanToCsv, type ZTPPlan } from '@/lib/ztp'
 import { CHANGE_CATALOG, getChangeOp, buildChangeSet, changeSetToScript, changeSetRollbackScript, validateChangeParams, analyzeChangeSet, FAMILY_LABEL, type ChangeWarning } from '@/lib/config-update'
+import { evaluateFleet, alertsToText } from '@/lib/monitoring'
 import type { ZTPEvent, BOMDevice, CheckResult, MonitoringResult, ZTPResult, ChecksResult, DeviceMetrics, MetricsSummary, ConfigDriftResponse, ConfigDriftDevice, ConfigRemediationResponse, RemediationDeviceInput, TroubleshootResult } from '@/types'
 
 const STATUS_BADGE: Record<string, 'pass' | 'warn' | 'fail' | 'neutral'> = {
@@ -4214,6 +4215,55 @@ export function Step6Deploy() {
                     <div className="text-xs text-gray-500 mt-1">Interface Errors</div>
                   </Card>
                 </div>
+
+                {/* ── Active Alerts + fleet health (computed from metrics) ──── */}
+                {(() => {
+                  const roles: Record<string, string> = {}
+                  for (const d of simDevices) roles[d.name] = d.role
+                  const fleet = evaluateFleet(metrics, { roles })
+                  const fs = fleet.summary
+                  return (
+                    <Card>
+                      <CardHeader>
+                        <CardTitle>🔔 Active Alerts &amp; Fleet Health</CardTitle>
+                      </CardHeader>
+                      <div className="flex flex-wrap gap-2 mb-3">
+                        <span className="px-2 py-1 rounded-full text-xs bg-green-600/20 border border-green-500/40 text-green-300">{fs.healthy} healthy</span>
+                        <span className="px-2 py-1 rounded-full text-xs bg-yellow-600/20 border border-yellow-500/40 text-yellow-300">{fs.degraded} degraded</span>
+                        <span className="px-2 py-1 rounded-full text-xs bg-red-600/20 border border-red-500/40 text-red-300">{fs.down} down</span>
+                        <span className="px-2 py-1 rounded-full text-xs bg-orange-600/20 border border-orange-500/40 text-orange-300">{fs.critical} critical · {fs.warning} warning</span>
+                        {fleet.alerts.length > 0 && (
+                          <button
+                            className="ml-auto text-xs text-blue-400 hover:underline cursor-pointer"
+                            onClick={() => { downloadBlob('active-alerts.txt', alertsToText(fleet)); showToast('Alert feed downloaded', 'success') }}
+                          >⬇ Export alert feed</button>
+                        )}
+                      </div>
+                      {fleet.alerts.length === 0 ? (
+                        <div className="text-xs text-green-400 border border-green-500/20 bg-green-500/5 rounded px-3 py-2">
+                          ✅ No active alerts — all devices within thresholds.
+                        </div>
+                      ) : (
+                        <div className="space-y-1 max-h-60 overflow-y-auto">
+                          {fleet.alerts.slice(0, 30).map((a, i) => (
+                            <div key={i} className={cn(
+                              'text-xs rounded px-3 py-1.5 border flex items-center gap-2',
+                              a.severity === 'critical' ? 'bg-red-500/10 border-red-500/40 text-red-300'
+                                : a.severity === 'warning' ? 'bg-yellow-500/10 border-yellow-500/40 text-yellow-300'
+                                : 'bg-blue-500/10 border-blue-500/40 text-blue-300')}>
+                              <span className="font-semibold">{a.severity === 'critical' ? 'CRIT' : a.severity === 'warning' ? 'WARN' : 'INFO'}</span>
+                              <span className="text-gray-200 font-medium">{a.device}</span>
+                              <span className="text-gray-400">{a.message}</span>
+                            </div>
+                          ))}
+                          {fleet.alerts.length > 30 && (
+                            <p className="text-[11px] text-gray-600">+{fleet.alerts.length - 30} more…</p>
+                          )}
+                        </div>
+                      )}
+                    </Card>
+                  )
+                })()}
 
                 {/* ── Per-device metric cards ───────────────────────────────── */}
                 <div>

--- a/frontend/src/test/monitoring.test.ts
+++ b/frontend/src/test/monitoring.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest'
+import {
+  evaluateDevice, evaluateFleet, alertsToText, METRIC_THRESHOLDS,
+} from '@/lib/monitoring'
+import type { DeviceMetrics, MetricsSummary } from '@/types'
+
+const m = (o: Partial<DeviceMetrics> = {}): DeviceMetrics => ({
+  cpu_util: 20, mem_util: 40, interface_errors_in: 0, interface_errors_out: 0,
+  bgp_sessions_up: 3, bgp_prefixes_received: 500, pfc_drops: 0, throughput_mbps: 1000, ...o,
+})
+
+describe('evaluateDevice', () => {
+  it('healthy when all metrics are within thresholds', () => {
+    const d = evaluateDevice('SPINE-01', 'spine', m())
+    expect(d.status).toBe('healthy')
+    expect(d.alerts).toHaveLength(0)
+  })
+
+  it('warning CPU → degraded with a warning alert', () => {
+    const d = evaluateDevice('SPINE-01', 'spine', m({ cpu_util: 80 }))
+    expect(d.status).toBe('degraded')
+    const a = d.alerts.find(x => x.metric === 'cpu_util')!
+    expect(a.severity).toBe('warning')
+    expect(a.threshold).toBe(75)
+  })
+
+  it('critical memory → degraded with a critical alert', () => {
+    const d = evaluateDevice('LF-01', 'leaf', m({ mem_util: 95 }))
+    expect(d.status).toBe('degraded')
+    expect(d.alerts.some(a => a.metric === 'mem_util' && a.severity === 'critical')).toBe(true)
+  })
+
+  it('routing device with 0 BGP sessions → down (control plane isolated)', () => {
+    const d = evaluateDevice('SPINE-01', 'spine', m({ bgp_sessions_up: 0 }))
+    expect(d.status).toBe('down')
+    expect(d.alerts.some(a => a.metric === 'bgp_sessions_up' && a.severity === 'critical')).toBe(true)
+  })
+
+  it('access device with 0 BGP sessions is NOT down (no BGP expected)', () => {
+    const d = evaluateDevice('ACC-01', 'access', m({ bgp_sessions_up: 0 }))
+    expect(d.status).toBe('healthy')
+    expect(d.alerts).toHaveLength(0)
+  })
+
+  it('CPU pegged at 99 → down', () => {
+    const d = evaluateDevice('SPINE-01', 'spine', m({ cpu_util: 99 }))
+    expect(d.status).toBe('down')
+  })
+
+  it('PFC drops over critical → degraded with alert', () => {
+    const d = evaluateDevice('GPU-LEAF-01', 'leaf', m({ pfc_drops: 250 }))
+    expect(d.alerts.some(a => a.metric === 'pfc_drops' && a.severity === 'critical')).toBe(true)
+  })
+
+  it('interface errors warn vs critical boundaries', () => {
+    expect(evaluateDevice('X', 'spine', m({ interface_errors_in: 6 })).alerts[0].severity).toBe('warning')
+    expect(evaluateDevice('X', 'spine', m({ interface_errors_in: 60 })).alerts[0].severity).toBe('critical')
+  })
+
+  it('honors custom thresholds', () => {
+    const d = evaluateDevice('X', 'spine', m({ cpu_util: 50 }),
+      METRIC_THRESHOLDS.map(t => t.metric === 'cpu_util' ? { ...t, warn: 40, critical: 45 } : t))
+    expect(d.alerts.some(a => a.metric === 'cpu_util' && a.severity === 'critical')).toBe(true)
+  })
+})
+
+describe('evaluateFleet', () => {
+  const summary = (): MetricsSummary => ({
+    timestamp: '2026-06-29T00:00:00Z',
+    devices: {
+      'SP-01': m(),                                  // healthy
+      'LF-01': m({ cpu_util: 80 }),                  // degraded (warn)
+      'LF-02': m({ bgp_sessions_up: 0 }),            // down (routing, no bgp)
+      'AC-01': m({ bgp_sessions_up: 0 }),            // access (role via map), healthy
+    },
+  })
+
+  it('rolls up health + alert counts, sorted most-severe-first', () => {
+    const f = evaluateFleet(summary(), { roles: { 'SP-01': 'spine', 'LF-01': 'leaf', 'LF-02': 'leaf', 'AC-01': 'access' } })
+    expect(f.summary.total).toBe(4)
+    expect(f.summary.down).toBe(1)        // LF-02
+    expect(f.summary.degraded).toBe(1)    // LF-01
+    expect(f.summary.healthy).toBe(2)     // SP-01, AC-01
+    expect(f.summary.critical).toBeGreaterThanOrEqual(1)
+    expect(f.alerts[0].severity).toBe('critical')   // sorted critical-first
+  })
+
+  it('infers routing role from the device name when roles map absent', () => {
+    const f = evaluateFleet({ timestamp: 't', devices: { 'DC-SPINE-09': m({ bgp_sessions_up: 0 }) } })
+    expect(f.summary.down).toBe(1)        // name contains "spine" → routing
+  })
+
+  it('alertsToText lists critical alerts and a clean message when none', () => {
+    const f = evaluateFleet({ timestamp: 't', devices: { 'SP-01': m() } }, { roles: { 'SP-01': 'spine' } })
+    expect(alertsToText(f)).toContain('No active alerts')
+    const f2 = evaluateFleet({ timestamp: 't', devices: { 'SP-01': m({ cpu_util: 95 }) } }, { roles: { 'SP-01': 'spine' } })
+    expect(alertsToText(f2)).toMatch(/\[CRIT\] SP-01: CPU/)
+  })
+})


### PR DESCRIPTION
## Summary

Improves the **monitoring engine**. A full audit found it "feature-rich but data-limited": the demo Monitoring tab sampled per-device metrics every tick but only drew gauges — it never *analyzed* them. Real alerting existed only in live + telemetry mode (`/api/alerts`) or as 3 hardcoded lab alerts. The top quick win is **client-side threshold alerting + health that works in demo mode** (the app's whole emphasis).

## T1 — `lib/monitoring.ts` (engine)
- `METRIC_THRESHOLDS` — warn+critical per metric (CPU 75/90, mem 80/92, iface errors 5/50, PFC drops 50/200); **tunable** via arg (addresses the audit's "configurable thresholds" gap)
- `evaluateDevice(name, role, metrics, thresholds?)` → per-device **health** (healthy/degraded/down) + severity-ranked **alerts**. Role-aware: a routing device with `bgp_sessions_up === 0` → **down** (control-plane isolated); `cpu_util ≥ 99` → **down**; access devices with 0 BGP aren't falsely flagged
- `evaluateFleet(summary, {roles, thresholds})` → fleet rollup (healthy/degraded/down + critical/warning counts) + alerts sorted **critical-first**
- `alertsToText(fleet)` → exportable NOC alert feed

## T2 — Monitoring tab
New **"🔔 Active Alerts & Fleet Health"** card: computes `evaluateFleet(metrics)` from the live/demo metrics each tick — health chips, severity-colored alert feed, and an export button. Demo mode previously had **no alerting at all**; it now shows a real, computed NOC view.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — succeeds
- [x] 12 new tests in `test/monitoring.test.ts` (thresholds, role-aware down, custom thresholds, fleet rollup + sorting, text export)
- [x] 1086 total frontend tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DiH1v2ufYHuupbP4xn6pPb

---
_Generated by [Claude Code](https://claude.ai/code/session_01DiH1v2ufYHuupbP4xn6pPb)_