### PR TITLE
feat: U — RCA demo-mode engine + rich output + un-shadow real engine

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -909,6 +909,27 @@ config-gen tests must keep passing; add new tests alongside).
 
 ---
 
+### U. RCA engine — demo-mode parity + rich output + un-shadow (sourced 2026-07-05)
+
+> Audit found the RCA feature had two coupled defects. (1) **Route
+> shadowing**: `backend/routers/lab.py` registers a static 3-hypothesis stub
+> at `/api/rca/analyze` *before* the real correlation engine (`backend/rca/
+> engine.py`, `@app.post` at `main.py:1083`) — Starlette matches in
+> registration order, so the stub wins and the real `RCAEngine` (blast-radius,
+> multi-step remediation, automation playbooks) is dead code. (2) **No demo
+> mode**: unlike every other Step 6 feature (§3 — the app is fully functional
+> without a backend), `RcaPanel` short-circuited to "configure a backend URL"
+> when `!isLive`, and the frontend `RcaHypothesis` type only modeled the
+> stub's flat `{rank,cause,remediation}` shape — the engine's rich output was
+> discarded even in live mode.
+
+| # | Item | Status | Notes |
+|---|------|--------|-------|
+| U1 | Client-side RCA engine + rich output — new `lib/rca.ts` (`analyzeRca(input)` mirroring the backend's 5 hypothesis checkers: BGP session loss, PFC/RDMA deadlock, EVPN/VXLAN overlay, underlay/IGP, recent-change; keyword + design-state driven, deterministic blast-radius from role adjacency, dedup+rank, generic fallback) + `normalizeRcaResponse()` mapping BOTH the real engine (snake_case) and the legacy stub shape → the canonical rich `RcaHypothesis`. Rich `RcaHypothesis` type (`rootCause/confidence/evidence/blastRadius/remediationSteps/automationAvailable/automationPlaybook`); `client.runRca` normalizes; `useRunRca` falls back to `analyzeRca` in demo mode; `RcaPanel` renders blast-radius chips + remediation steps + automation playbook affordance and works in demo mode. Tests in `test/rca.test.ts` | [x] | `lib/rca.ts` + `types/index.ts` + `api/client.ts` + `hooks/useRca.ts` + `components/RcaPanel.tsx`; `test/rca.test.ts` (14); 1125 tests, tsc + build green |
+| U2 | Un-shadow the real engine — rename the `lab.py` stub route to `/api/lab/rca` so `/api/rca/analyze` resolves to the real `RCAEngine` (`main.py:1083`); backend suite stays green | [x] | `backend/routers/lab.py` (`@router.post("/api/lab/rca")`); backend lab/rca pytest 21 pass (pre-existing unrelated `test_config_gen.py` failures untouched) |
+
+---
+
 ## 23. Autonomous "Start Improving" Mode (2026-06-11 →)
 
 ### Purpose

--- a/CODE_REFERENCE.md
+++ b/CODE_REFERENCE.md
@@ -78,7 +78,7 @@ coloProvider, dcEdgeVendor, bgpAsn, orgCidr, aviatrixOptions`), and
 
 **Observability**
 - `Alert` — `{ id, device, severity: critical|warning|info, summary, detail?, timestamp, resolved }`.
-- `RcaHypothesis` — `{ rank, cause, confidence, evidence[], remediation }`.
+- `RcaHypothesis` — `{ rank, rootCause, confidence(0..1), evidence[], blastRadius[], remediationSteps[], automationAvailable, automationPlaybook? }` (rich shape — matches the real backend engine `backend/rca/engine.py`, group U).
 
 **Intent NLP parser (G-A1)**
 - `IntentParseResult` — `{ use_case, app_types[], scale, redundancy, compliance[], org_name, org_size, budget_tier, vendor_prefs[], industry, primary_contact, confidence, notes, source: 'ai'|'heuristic' }`. Mirrors `backend/intent_ai.RESPONSE_SCHEMA` + `source`.
@@ -1394,7 +1394,7 @@ alert groups (core vs. GPU-only), and Grafana dashboard JSON validity/panels
 - `saveSettings(patch: Partial<BackendSettings>)` — merges into `localStorage['nd_backend_settings']`
 - `login(username, password): Promise<{token, role}>` — POST `{baseUrl}/api/auth/token`; saves token via `saveSettings`
 - `fetchAlerts(): Promise<Alert[]>` — GET `/api/alerts`
-- `runRca(symptom, affectedDevices, designId?): Promise<RcaHypothesis[]>` — POST `/api/rca/analyze` with `{symptom, affected_devices, design_id}`
+- `runRca(symptom, affectedDevices, designId?): Promise<RcaHypothesis[]>` — POST `/api/rca/analyze` with `{symptom, affected_devices, design_id}`; result passed through `normalizeRcaResponse()` (`lib/rca.ts`) so both the real engine (rich snake_case) and the legacy stub shape map onto the canonical `RcaHypothesis` (group U)
 - `parseIntent(description: string): Promise<IntentParseResult>` — POST `/api/intent/parse` with `{description}` (G-A1)
 - `checkConfigDrift(configs: Record<string,string>, deploymentId?: string): Promise<ConfigDriftResponse>` — POST `/api/drift/config` with `{configs, deployment_id}` (G-A4)
 - `generateRemediation(devices: RemediationDeviceInput[]): Promise<ConfigRemediationResponse>` — POST `/api/drift/remediate` with `{devices}` (G-A16)
@@ -1431,7 +1431,7 @@ alert groups (core vs. GPU-only), and Grafana dashboard JSON validity/panels
 - **Fallback:** `Step6Deploy.tsx` and `Step6Monitor.tsx` call `usePollMonitoring().mutate`; on error/demo, `Step6Deploy.tsx` falls back to local `simulateMonitoringMetrics(simDevices, tick)` returning a `MonitoringResult`-shaped object, polled on a local interval (`monitorTick`).
 
 #### `hooks/useRca.ts`
-- `useRunRca()` — `useMutation<RcaHypothesis[], Error, RcaRequest>` where `RcaRequest = { symptom, devices: string[], designId? }`; `mutationFn` calls `runRca(symptom, devices, designId)` from `api/client.ts` → POST `/api/rca/analyze`. Returns `RcaHypothesis[]`. No simulation fallback defined in this file (consumed by `RcaPanel`/`TroubleshootingEngine`).
+- `useRunRca()` — `useMutation<RcaHypothesis[], Error, RcaRequest>` where `RcaRequest = { symptom, devices: string[], designId?, design? }`; `mutationFn` runs the client-side `analyzeRca()` (`lib/rca.ts`) in demo mode (`!isLiveMode()`) and `runRca(...)` (real backend engine) in live mode — parity with every other Step 6 feature (§3). Returns `RcaHypothesis[]` (consumed by `RcaPanel`).
 
 #### `hooks/useIntentParse.ts` (G-A1)
 - `useIntentParse()` — `useMutation<IntentParseResult, Error, string>`; `mutationFn` calls `parseIntent(description)` from `api/client.ts` → POST `/api/intent/parse`. Returns `IntentParseResult` (`source: 'ai'|'heuristic'`). Consumed by `Step1UseCase.tsx`'s free-text "Describe Your Network" card. No client-side simulation — requires a live backend (`useBackendMode().isLive`); the Parse button is disabled otherwise.
@@ -1943,14 +1943,23 @@ hooks they used (`useRunZTP`/`useRunChecks`/`usePollMonitoring`) are retained
 **Purpose:** Form-driven Root Cause Analysis panel — submits symptom + optional device list to `useRunRca` (TanStack Query mutation), renders ranked hypothesis cards.
 
 **Key exports / structure:**
-- `export function RcaPanel({ deviceNames? })` — uses `useRunRca()` and `isLiveMode()`
+- `export function RcaPanel({ deviceNames? })` — uses `useRunRca()`, `isLiveMode()`, and reads `devices`/`useCase`/`overlayProtocols`/`underlayProtocol` from `useAppStore` to build the `design` state (device roles → blast-radius adjacency, protocols/use-case → hypothesis confidence). Works in demo mode.
 - `ConfidenceBar({ value })` — colored progress bar (red ≥75%, yellow ≥50%, blue otherwise)
-- `HypothesisCard({ h })` — rank badge, cause, confidence bar, evidence bullets, remediation callout (`RcaHypothesis`)
+- `HypothesisCard({ h })` — rank badge, `rootCause`, confidence bar, evidence bullets, blast-radius chips, numbered remediation steps, automation-playbook affordance (`RcaHypothesis` rich shape)
 
 **Notes:**
-- "configure backend" placeholder when `!isLiveMode()`; textarea for symptom + toggleable device-name chips.
+- No longer gated on live mode — runs the client-side RCA engine in demo mode (banner note); textarea for symptom + toggleable device chips (from prop or the store BOM).
 - "Run RCA" disabled while pending or symptom empty; "Clear" calls `reset()`.
-- Only referenced from `e2e-features.test.ts` — **not yet mounted in any page**.
+- Mounted in Step6Deploy's Deploy-tab observability panel (RCA tab, L1).
+
+#### `frontend/src/lib/rca.ts` (group U)
+**Purpose:** Client-side RCA engine (demo-mode parity with the real backend engine) + live-response normalizer.
+
+**Key exports:**
+- `analyzeRca(input: RcaInput): RcaHypothesis[]` — 5 keyword/design-driven hypothesis checkers (BGP session loss, PFC/RDMA deadlock, EVPN/VXLAN overlay, underlay/IGP, recent deployment change), each producing a rich hypothesis; dedups by `rootCause` (keep max confidence), ranks by descending confidence, and returns a generic `Undetermined Root Cause` fallback when nothing matches (never empty). Blast radius = 2-hop expansion over a role-based adjacency (spine↔leaf full mesh + edge/border→aggregation).
+- `normalizeRcaResponse(raw: unknown): RcaHypothesis[]` — maps a live `/api/rca/analyze` response onto the canonical `RcaHypothesis`, tolerant of BOTH the real engine (snake_case `root_cause`/`blast_radius`/`remediation_steps`/`automation_*`) and the legacy stub (`cause`/`remediation:string`); assigns ranks by descending confidence when the backend omits them.
+- Types: `RcaInput`, `RcaDesignState`, `RcaDesignDevice`.
+- Tests: `test/rca.test.ts` (14).
 
 ---
 

--- a/backend/routers/lab.py
+++ b/backend/routers/lab.py
@@ -275,8 +275,13 @@ def lab_alerts() -> list[dict[str, Any]]:
 
 
 # ── RCA (lab flavour) ─────────────────────────────────────────────────────────
+#
+# NOTE: served at /api/lab/rca (not /api/rca/analyze). The canonical
+# /api/rca/analyze route is the real correlation engine (backend/rca/engine.py,
+# wired in main.py) — this static demo stub used to shadow it because the lab
+# router is registered first and Starlette matches in registration order.
 
-@router.post("/api/rca/analyze")
+@router.post("/api/lab/rca")
 def lab_rca(body: dict[str, Any] = {}) -> list[dict[str, Any]]:
     symptom = body.get("symptom", "")
     devices  = body.get("devices", [])

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -105,18 +105,23 @@ export const postUserActivity  = (activity: Omit<UserActivity, 'id'>) => post<nu
 // ── Observability ─────────────────────────────────────────────────────────────
 
 import type { Alert, RcaHypothesis } from '@/types'
+import { normalizeRcaResponse } from '@/lib/rca'
 
 export const fetchAlerts = () => get<Alert[]>('/api/alerts')
 
-export const runRca = (
+export const runRca = async (
   symptom: string,
   affectedDevices: string[],
   designId?: string,
-) => post<RcaHypothesis[]>('/api/rca/analyze', {
-  symptom,
-  affected_devices: affectedDevices,
-  design_id: designId,
-})
+): Promise<RcaHypothesis[]> => {
+  // Tolerate both the real engine (rich snake_case) and the legacy stub shape.
+  const raw = await post<unknown>('/api/rca/analyze', {
+    symptom,
+    affected_devices: affectedDevices,
+    design_id: designId,
+  })
+  return normalizeRcaResponse(raw)
+}
 
 // ── Troubleshooting Tooling Engine (G-A19) ────────────────────────────────────
 

--- a/frontend/src/components/RcaPanel.tsx
+++ b/frontend/src/components/RcaPanel.tsx
@@ -1,6 +1,7 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { useRunRca } from '@/hooks/useRca'
 import { isLiveMode } from '@/api/client'
+import { useAppStore } from '@/store/useAppStore'
 import { Button } from '@/components/ui/Button'
 import { Badge } from '@/components/ui/Badge'
 import type { RcaHypothesis } from '@/types'
@@ -9,7 +10,7 @@ function ConfidenceBar({ value }: { value: number }) {
   const pct = Math.round(value * 100)
   const color = pct >= 75 ? 'bg-red-500' : pct >= 50 ? 'bg-yellow-500' : 'bg-blue-500'
   return (
-    <div className="flex items-center gap-2">
+    <div className="flex items-center gap-2 w-28">
       <div className="flex-1 h-1.5 rounded-full bg-white/10 overflow-hidden">
         <div className={`h-full rounded-full ${color}`} style={{ width: `${pct}%` }} />
       </div>
@@ -24,7 +25,7 @@ function HypothesisCard({ h }: { h: RcaHypothesis }) {
       <div className="flex items-start justify-between gap-2">
         <div className="flex items-center gap-2">
           <Badge variant="neutral" className="text-xs">#{h.rank}</Badge>
-          <span className="font-semibold text-gray-200 text-sm">{h.cause}</span>
+          <span className="font-semibold text-gray-200 text-sm">{h.rootCause}</span>
         </div>
         <ConfidenceBar value={h.confidence} />
       </div>
@@ -40,19 +41,71 @@ function HypothesisCard({ h }: { h: RcaHypothesis }) {
         </ul>
       )}
 
-      <div className="rounded-lg bg-blue-500/10 border border-blue-500/20 px-3 py-2">
-        <span className="text-xs font-medium text-blue-400">Remediation: </span>
-        <span className="text-xs text-gray-300">{h.remediation}</span>
+      {h.blastRadius.length > 0 && (
+        <div className="space-y-1">
+          <span className="text-[11px] uppercase tracking-wide text-gray-500">
+            Blast radius · {h.blastRadius.length} device{h.blastRadius.length !== 1 ? 's' : ''}
+          </span>
+          <div className="flex flex-wrap gap-1">
+            {h.blastRadius.map(d => (
+              <span key={d} className="px-1.5 py-0.5 rounded text-[11px] bg-amber-500/10 border border-amber-500/20 text-amber-300">
+                {d}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <div className="rounded-lg bg-blue-500/10 border border-blue-500/20 px-3 py-2 space-y-1">
+        <span className="text-xs font-medium text-blue-400">Remediation</span>
+        <ol className="space-y-0.5">
+          {h.remediationSteps.map((step, i) => (
+            <li key={i} className="text-xs text-gray-300 flex items-start gap-1.5">
+              <span className="text-blue-500/70 shrink-0 tabular-nums">{i + 1}.</span>
+              {step}
+            </li>
+          ))}
+        </ol>
       </div>
+
+      {h.automationAvailable && (
+        <div className="flex items-center justify-between gap-2 rounded-lg bg-emerald-500/10 border border-emerald-500/20 px-3 py-2">
+          <div className="min-w-0">
+            <div className="text-xs font-medium text-emerald-400">⚙️ Automated remediation available</div>
+            {h.automationPlaybook && (
+              <div className="text-[11px] text-gray-400 truncate font-mono">{h.automationPlaybook}</div>
+            )}
+          </div>
+          <Button type="button" variant="ghost" className="text-xs shrink-0" disabled title="Demo — playbook run is a live-mode action">
+            ▶ Run playbook
+          </Button>
+        </div>
+      )}
     </div>
   )
 }
 
-export function RcaPanel({ deviceNames = [] }: { deviceNames?: string[] }) {
+export function RcaPanel({ deviceNames }: { deviceNames?: string[] }) {
   const [symptom, setSymptom]   = useState('')
   const [selected, setSelected] = useState<string[]>([])
   const { mutate, data, isPending, isError, error, reset } = useRunRca()
   const liveMode = isLiveMode()
+
+  const storeDevices      = useAppStore(s => s.devices)
+  const useCase           = useAppStore(s => s.useCase)
+  const overlayProtocols  = useAppStore(s => s.overlayProtocols)
+  const underlayProtocol  = useAppStore(s => s.underlayProtocol)
+
+  const devicePool = useMemo(
+    () => (deviceNames && deviceNames.length ? deviceNames : storeDevices.map(d => d.hostname).filter(Boolean)),
+    [deviceNames, storeDevices],
+  )
+
+  const design = useMemo(() => ({
+    useCase,
+    protocols: [...(overlayProtocols || []), ...(underlayProtocol ? [underlayProtocol] : [])],
+    devices: storeDevices.map(d => ({ hostname: d.hostname, role: d.role, subLayer: d.subLayer })),
+  }), [useCase, overlayProtocols, underlayProtocol, storeDevices])
 
   function toggleDevice(name: string) {
     setSelected(prev =>
@@ -63,22 +116,17 @@ export function RcaPanel({ deviceNames = [] }: { deviceNames?: string[] }) {
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
     if (!symptom.trim()) return
-    mutate({ symptom: symptom.trim(), devices: selected })
-  }
-
-  if (!liveMode) {
-    return (
-      <div className="rounded-xl border border-white/10 bg-white/5 p-6 text-center">
-        <p className="text-sm text-gray-500">
-          Configure a backend URL in settings to enable RCA analysis.
-        </p>
-      </div>
-    )
+    mutate({ symptom: symptom.trim(), devices: selected, design })
   }
 
   return (
     <div className="space-y-4">
       <form onSubmit={handleSubmit} className="space-y-3">
+        {!liveMode && (
+          <p className="text-[11px] text-gray-500">
+            Demo mode — running the client-side RCA engine. Configure a backend URL to correlate live telemetry.
+          </p>
+        )}
         <div>
           <label className="text-xs text-gray-400 block mb-1">Symptom description</label>
           <textarea
@@ -92,13 +140,13 @@ export function RcaPanel({ deviceNames = [] }: { deviceNames?: string[] }) {
           />
         </div>
 
-        {deviceNames.length > 0 && (
+        {devicePool.length > 0 && (
           <div>
             <label className="text-xs text-gray-400 block mb-1">
               Affected devices (optional)
             </label>
             <div className="flex flex-wrap gap-1.5">
-              {deviceNames.map(name => (
+              {devicePool.map(name => (
                 <button
                   key={name}
                   type="button"
@@ -135,7 +183,7 @@ export function RcaPanel({ deviceNames = [] }: { deviceNames?: string[] }) {
       {data && data.length > 0 && (
         <div className="space-y-3">
           <h4 className="text-sm font-semibold text-gray-300">
-            {data.length} Root Cause Hypothesis{data.length !== 1 ? 'es' : ''}
+            {data.length} Root Cause Hypothes{data.length !== 1 ? 'es' : 'is'}
           </h4>
           {data.map(h => <HypothesisCard key={h.rank} h={h} />)}
         </div>

--- a/frontend/src/hooks/useRca.ts
+++ b/frontend/src/hooks/useRca.ts
@@ -1,16 +1,24 @@
 import { useMutation } from '@tanstack/react-query'
-import { runRca } from '@/api/client'
+import { runRca, isLiveMode } from '@/api/client'
+import { analyzeRca, type RcaDesignState } from '@/lib/rca'
 import type { RcaHypothesis } from '@/types'
 
 interface RcaRequest {
   symptom: string
   devices: string[]
   designId?: string
+  design?: RcaDesignState
 }
 
 export function useRunRca() {
   return useMutation<RcaHypothesis[], Error, RcaRequest>({
-    mutationFn: ({ symptom, devices, designId }) =>
-      runRca(symptom, devices, designId),
+    mutationFn: async ({ symptom, devices, designId, design }) => {
+      // Demo mode (no backend): run the client-side RCA engine, like every
+      // other Step 6 feature (§3). Live mode hits the real backend engine.
+      if (!isLiveMode()) {
+        return analyzeRca({ symptom, affectedDevices: devices, design })
+      }
+      return runRca(symptom, devices, designId)
+    },
   })
 }

--- a/frontend/src/lib/rca.ts
+++ b/frontend/src/lib/rca.ts
@@ -1,0 +1,298 @@
+// ── RCA (Root Cause Analysis) — client-side engine (group U) ──────────────────
+//
+// Mirrors the backend hypothesis engine (backend/rca/engine.py) so RCA works in
+// demo mode (no backend), like every other Step 6 feature (§3). Given a symptom
+// string + affected devices + design state, it runs a set of keyword/design
+// driven hypothesis checkers, each producing a rich hypothesis (blast radius,
+// multi-step remediation, automation playbook), then dedups + confidence-ranks.
+//
+// Also exposes normalizeRcaResponse() so live-mode responses from EITHER the
+// real engine (snake_case rich shape) OR the legacy lab stub ({rank, cause,
+// remediation}) map onto the same canonical RcaHypothesis the UI renders.
+
+import type { RcaHypothesis } from '@/types'
+
+export interface RcaDesignDevice {
+  hostname: string
+  role?: string
+  subLayer?: string
+}
+
+export interface RcaDesignState {
+  useCase?: string
+  protocols?: string[]
+  devices?: RcaDesignDevice[]
+}
+
+export interface RcaInput {
+  symptom: string
+  affectedDevices?: string[]
+  design?: RcaDesignState
+}
+
+const has = (s: string, ...keys: string[]) => keys.some(k => s.includes(k))
+const clamp01 = (n: number) => Math.max(0, Math.min(1, n))
+
+/** Build a role-based adjacency: every spine peers every leaf, and border/edge
+ *  nodes (firewall/wan-edge/core) attach to the spine/core tier. Deterministic. */
+function buildAdjacency(devices: RcaDesignDevice[]): Record<string, string[]> {
+  const roleOf = (d: RcaDesignDevice) => (d.role || d.subLayer || '').toLowerCase()
+  const spines = devices.filter(d => roleOf(d).includes('spine')).map(d => d.hostname)
+  const leaves = devices.filter(d => roleOf(d).includes('leaf')).map(d => d.hostname)
+  const cores  = devices.filter(d => roleOf(d).includes('core')).map(d => d.hostname)
+  const edges  = devices.filter(d => {
+    const r = roleOf(d)
+    return r.includes('firewall') || r.includes('wan') || r.includes('edge') || r.includes('border')
+  }).map(d => d.hostname)
+
+  const adj: Record<string, Set<string>> = {}
+  const link = (a: string, b: string) => {
+    if (a === b) return
+    ;(adj[a] ??= new Set()).add(b)
+    ;(adj[b] ??= new Set()).add(a)
+  }
+  // Clos: spine <-> leaf full mesh
+  for (const s of spines) for (const l of leaves) link(s, l)
+  // Edge/border attach to the aggregation tier (spine, or core when present)
+  const agg = spines.length ? spines : cores
+  for (const e of edges) for (const a of agg) link(e, a)
+  // Core <-> spine (collapsed campus/DC border)
+  for (const c of cores) for (const s of spines) link(c, s)
+
+  const out: Record<string, string[]> = {}
+  for (const [k, v] of Object.entries(adj)) out[k] = [...v].sort()
+  return out
+}
+
+/** Two-hop blast radius from the affected set over the role adjacency. */
+function blastRadius(affected: string[], adj: Record<string, string[]>): string[] {
+  const visited = new Set(affected)
+  let frontier = [...affected]
+  for (let hop = 0; hop < 2; hop++) {
+    const next: string[] = []
+    for (const node of frontier) {
+      for (const nb of adj[node] || []) {
+        if (!visited.has(nb)) { visited.add(nb); next.push(nb) }
+      }
+    }
+    frontier = next
+  }
+  return [...visited].sort()
+}
+
+interface Checker {
+  (input: RcaInput, symptom: string, affected: string[], adj: Record<string, string[]>):
+    RcaHypothesis | null
+}
+
+const rich = (
+  rootCause: string,
+  confidence: number,
+  evidence: string[],
+  affected: string[],
+  adj: Record<string, string[]>,
+  remediationSteps: string[],
+  automationPlaybook: string | null,
+): RcaHypothesis => ({
+  rank: 0,
+  rootCause,
+  confidence: clamp01(confidence),
+  evidence,
+  blastRadius: blastRadius(affected, adj),
+  remediationSteps,
+  automationAvailable: !!automationPlaybook,
+  automationPlaybook,
+})
+
+const spinesIn = (affected: string[]) => affected.filter(h => /spine/i.test(h))
+
+const CHECKERS: Checker[] = [
+  // 1. BGP session loss
+  (input, s, affected, adj) => {
+    if (!has(s, 'bgp', 'prefix', 'neighbor', 'session', 'peer', 'adjacency')) return null
+    let conf = 0.35
+    const ev: string[] = []
+    if (has(s, 'bgp')) conf += 0.2
+    if (has(s, 'prefix', 'neighbor', 'peer')) conf += 0.15
+    if (affected.length) ev.push(`Reported on: ${affected.join(', ')}`)
+    ev.push(`Symptom matches BGP session-loss pattern: "${input.symptom.trim()}"`)
+    return rich('BGP Session Loss', conf, ev, affected, adj, [
+      'show bgp summary / show ip bgp neighbors',
+      'Verify BGP neighbor timers and hold-time',
+      'Check for recent route-map / prefix-list policy changes',
+      'Review interface status on the peering links',
+    ], 'playbooks/rca/bgp_session_restore.yml')
+  },
+  // 2. PFC / RDMA deadlock
+  (input, s, affected, adj) => {
+    const gpu = input.design?.useCase === 'gpu'
+    if (!has(s, 'pfc', 'rdma', 'roce', 'deadlock', 'watchdog') && !(gpu && has(s, 'gpu', 'drop', 'stall'))) return null
+    let conf = 0.4
+    const ev: string[] = []
+    if (has(s, 'pfc', 'watchdog')) conf += 0.2
+    if (has(s, 'rdma', 'roce', 'deadlock')) conf += 0.15
+    if (gpu) { conf += 0.15; ev.push('Design is a GPU/RDMA fabric — PFC deadlock risk elevated') }
+    if (affected.length) ev.push(`Reported on: ${affected.join(', ')}`)
+    ev.push(`Symptom matches PFC/RDMA deadlock pattern: "${input.symptom.trim()}"`)
+    return rich('PFC Watchdog Deadlock', conf, ev, affected, adj, [
+      'show pfc watchdog status',
+      'Verify DCQCN / ECN configuration on the lossless queues',
+      'Check PFC priority groups and queue depths',
+      'Temporarily disable the PFC watchdog to restore traffic if a queue is stuck',
+    ], 'playbooks/rca/pfc_reset.yml')
+  },
+  // 3. EVPN / VXLAN overlay fault
+  (input, s, affected, adj) => {
+    if (!has(s, 'evpn', 'vxlan', 'vtep', 'vni', 'l2vpn', 'overlay', 'mac')) return null
+    let conf = 0.35
+    const ev: string[] = []
+    const protos = (input.design?.protocols || []).map(p => p.toUpperCase())
+    if (protos.some(p => p.includes('EVPN') || p.includes('VXLAN'))) {
+      conf += 0.2; ev.push('Design uses an EVPN/VXLAN overlay')
+    }
+    const spines = spinesIn(affected)
+    if (spines.length) { conf += 0.15; ev.push(`Spine/RR device(s) affected: ${spines.join(', ')} — possible route-reflector fault`) }
+    ev.push(`Symptom matches EVPN/VXLAN fault pattern: "${input.symptom.trim()}"`)
+    return rich('EVPN/VXLAN Overlay Fault', conf, ev, affected, adj, [
+      'show bgp l2vpn evpn summary',
+      'Verify NVE interface state and VTEP reachability',
+      'Check VNI-to-VLAN bindings on all leaves',
+      'Confirm the route-reflector is advertising EVPN type-2/type-5 routes',
+    ], null)
+  },
+  // 4. Underlay / IGP failure
+  (input, s, affected, adj) => {
+    if (!has(s, 'ospf', 'isis', 'is-is', 'link', 'interface', 'flap', 'underlay', 'igp', 'crc', 'error', 'cable', 'sfp', 'optic')) return null
+    let conf = 0.3
+    const ev: string[] = []
+    if (has(s, 'flap', 'link', 'interface', 'crc', 'error', 'sfp', 'optic', 'cable')) conf += 0.15
+    if (has(s, 'ospf', 'isis', 'is-is', 'igp', 'underlay')) conf += 0.15
+    const spines = spinesIn(affected)
+    if (spines.length >= 2) { conf += 0.2; ev.push(`Multiple spine devices affected: ${spines.join(', ')}`) }
+    if (affected.length) ev.push(`Reported on: ${affected.join(', ')}`)
+    ev.push(`Symptom matches underlay/IGP failure pattern: "${input.symptom.trim()}"`)
+    return rich('Underlay / IGP Failure', conf, ev, affected, adj, [
+      'Check interface error counters and the physical layer (SFP, cable)',
+      'Verify OSPF/IS-IS adjacency state',
+      'Confirm BFD sessions are up',
+      'Review recent interface or cabling changes',
+    ], 'playbooks/rca/underlay_check.yml')
+  },
+  // 5. Recent deployment / config change
+  (_input, s, affected, adj) => {
+    if (!has(s, 'deploy', 'change', 'maintenance', 'window', 'push', 'rollback', 'config', 'after', 'upgrade')) return null
+    let conf = 0.3
+    const ev: string[] = []
+    if (has(s, 'after', 'maintenance', 'window')) conf += 0.2
+    if (has(s, 'deploy', 'push', 'change', 'config', 'upgrade')) conf += 0.15
+    if (has(s, 'rollback')) conf += 0.1
+    ev.push('Symptom is temporally correlated with a recent change ("after maintenance/deploy")')
+    if (affected.length) ev.push(`Reported on: ${affected.join(', ')}`)
+    return rich('Recent Deployment Change', conf, ev, affected, adj, [
+      'Review the deployment diff (running vs pre-deploy checkpoint)',
+      'Check the rollback status and post-check results',
+      'Re-run post-deployment checks',
+      'Trigger a rollback to the pre-deploy checkpoint if the change is confirmed at fault',
+    ], 'playbooks/rca/rollback_verify.yml')
+  },
+]
+
+/**
+ * Run the client-side RCA engine. Returns confidence-ranked hypotheses. Falls
+ * back to a single generic low-confidence hypothesis when nothing matches, so
+ * the demo UI is never empty for a free-text symptom.
+ */
+export function analyzeRca(input: RcaInput): RcaHypothesis[] {
+  const symptom = (input.symptom || '').toLowerCase()
+  const affected = (input.affectedDevices || []).filter(Boolean)
+  const adj = buildAdjacency(input.design?.devices || [])
+
+  const raw: RcaHypothesis[] = []
+  for (const check of CHECKERS) {
+    const h = check(input, symptom, affected, adj)
+    if (h) raw.push(h)
+  }
+
+  // Dedup by rootCause, keep highest confidence
+  const byCause = new Map<string, RcaHypothesis>()
+  for (const h of raw) {
+    const prev = byCause.get(h.rootCause)
+    if (!prev || h.confidence > prev.confidence) byCause.set(h.rootCause, h)
+  }
+
+  let ranked = [...byCause.values()].sort((a, b) => b.confidence - a.confidence)
+
+  if (ranked.length === 0) {
+    ranked = [rich(
+      'Undetermined Root Cause',
+      0.15,
+      [
+        `No known fault pattern matched: "${input.symptom.trim()}"`,
+        'Falling back to general fabric diagnostics',
+      ],
+      affected,
+      adj,
+      [
+        'Confirm device reachability (ping / SSH) to the affected devices',
+        'show logging last 200 — look for the first error in the time window',
+        'show interface status / counters errors on the involved links',
+        'Compare running-config against the intended design (drift check)',
+      ],
+      null,
+    )]
+  }
+
+  return ranked.map((h, i) => ({ ...h, rank: i + 1 }))
+}
+
+// ── Live-mode response normalization ──────────────────────────────────────────
+
+type RawHypothesis = Record<string, unknown>
+
+const asStr = (v: unknown): string => (typeof v === 'string' ? v : '')
+const asNum = (v: unknown): number => (typeof v === 'number' && isFinite(v) ? v : 0)
+const asStrArr = (v: unknown): string[] =>
+  Array.isArray(v) ? v.filter((x): x is string => typeof x === 'string') : []
+
+/**
+ * Map a live-mode `/api/rca/analyze` response onto the canonical rich shape.
+ * Tolerant of BOTH the real engine (snake_case: root_cause, blast_radius,
+ * remediation_steps, automation_available, automation_playbook) AND the legacy
+ * lab stub (rank, cause, remediation:string). Missing ranks are assigned by
+ * descending confidence.
+ */
+export function normalizeRcaResponse(raw: unknown): RcaHypothesis[] {
+  if (!Array.isArray(raw)) return []
+  const mapped: RcaHypothesis[] = raw.map((r0): RcaHypothesis => {
+    const r = (r0 && typeof r0 === 'object' ? r0 : {}) as RawHypothesis
+    const rootCause = asStr(r.root_cause) || asStr(r.cause) || asStr(r.rootCause) || 'Unknown'
+    // remediation: rich array (remediation_steps) or a single stub string
+    let steps = asStrArr(r.remediation_steps)
+    if (steps.length === 0) steps = asStrArr(r.remediationSteps)
+    if (steps.length === 0 && asStr(r.remediation)) steps = [asStr(r.remediation)]
+    const playbook = asStr(r.automation_playbook) || asStr(r.automationPlaybook) || null
+    const autoFlag = typeof r.automation_available === 'boolean'
+      ? r.automation_available
+      : typeof r.automationAvailable === 'boolean'
+        ? r.automationAvailable
+        : !!playbook
+    return {
+      rank: asNum(r.rank),
+      rootCause,
+      confidence: clamp01(asNum(r.confidence)),
+      evidence: asStrArr(r.evidence),
+      blastRadius: asStrArr(r.blast_radius).length ? asStrArr(r.blast_radius) : asStrArr(r.blastRadius),
+      remediationSteps: steps,
+      automationAvailable: autoFlag,
+      automationPlaybook: playbook || null,
+    }
+  })
+
+  // If the backend didn't supply ranks (all 0), assign by descending confidence.
+  if (mapped.every(h => h.rank === 0) && mapped.length > 0) {
+    return [...mapped]
+      .sort((a, b) => b.confidence - a.confidence)
+      .map((h, i) => ({ ...h, rank: i + 1 }))
+  }
+  return mapped
+}

--- a/frontend/src/test/rca.test.ts
+++ b/frontend/src/test/rca.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from 'vitest'
+import { analyzeRca, normalizeRcaResponse, type RcaDesignState } from '@/lib/rca'
+
+const fabric: RcaDesignState = {
+  useCase: 'dc',
+  protocols: ['VXLAN', 'EVPN', 'isis'],
+  devices: [
+    { hostname: 'IAD-SPINE-01', role: 'spine' },
+    { hostname: 'IAD-SPINE-02', role: 'spine' },
+    { hostname: 'IAD-LEAF-01', role: 'leaf' },
+    { hostname: 'IAD-LEAF-02', role: 'leaf' },
+    { hostname: 'IAD-FW-01', role: 'firewall' },
+  ],
+}
+
+describe('analyzeRca — hypothesis checkers', () => {
+  it('flags BGP session loss on a BGP symptom', () => {
+    const h = analyzeRca({ symptom: 'BGP neighbor down, prefixes dropped', affectedDevices: ['IAD-SPINE-01'], design: fabric })
+    const bgp = h.find(x => x.rootCause === 'BGP Session Loss')
+    expect(bgp).toBeTruthy()
+    expect(bgp!.confidence).toBeGreaterThan(0.5)
+    expect(bgp!.automationAvailable).toBe(true)
+    expect(bgp!.automationPlaybook).toContain('bgp')
+    expect(bgp!.remediationSteps.length).toBeGreaterThan(1)
+  })
+
+  it('flags PFC deadlock and boosts confidence for a GPU design', () => {
+    const gpu: RcaDesignState = { ...fabric, useCase: 'gpu' }
+    const h = analyzeRca({ symptom: 'PFC watchdog triggered, RoCE stall', affectedDevices: ['IAD-LEAF-01'], design: gpu })
+    const pfc = h.find(x => x.rootCause === 'PFC Watchdog Deadlock')
+    expect(pfc).toBeTruthy()
+    expect(pfc!.evidence.some(e => /GPU\/RDMA/.test(e))).toBe(true)
+    expect(pfc!.confidence).toBeGreaterThan(0.6)
+  })
+
+  it('flags EVPN/VXLAN overlay fault and credits the overlay protocol', () => {
+    const h = analyzeRca({ symptom: 'VXLAN VNI not learning MAC across VTEPs', affectedDevices: ['IAD-LEAF-02'], design: fabric })
+    const evpn = h.find(x => x.rootCause === 'EVPN/VXLAN Overlay Fault')
+    expect(evpn).toBeTruthy()
+    expect(evpn!.evidence.some(e => /EVPN\/VXLAN overlay/.test(e))).toBe(true)
+    expect(evpn!.automationAvailable).toBe(false)
+  })
+
+  it('flags underlay/IGP failure and escalates for multiple spines', () => {
+    const h = analyzeRca({
+      symptom: 'OSPF adjacency flapping, interface CRC errors',
+      affectedDevices: ['IAD-SPINE-01', 'IAD-SPINE-02'],
+      design: fabric,
+    })
+    const under = h.find(x => x.rootCause === 'Underlay / IGP Failure')
+    expect(under).toBeTruthy()
+    expect(under!.evidence.some(e => /Multiple spine devices/.test(e))).toBe(true)
+  })
+
+  it('flags recent deployment change on a temporal symptom', () => {
+    const h = analyzeRca({ symptom: 'issue started right after the maintenance window deploy', design: fabric })
+    const dep = h.find(x => x.rootCause === 'Recent Deployment Change')
+    expect(dep).toBeTruthy()
+    expect(dep!.automationPlaybook).toContain('rollback')
+  })
+})
+
+describe('analyzeRca — ranking, dedup, blast radius, fallback', () => {
+  it('returns hypotheses ranked by descending confidence with sequential ranks', () => {
+    const h = analyzeRca({ symptom: 'BGP peer down and OSPF interface flap', affectedDevices: ['IAD-SPINE-01'], design: fabric })
+    expect(h.length).toBeGreaterThanOrEqual(2)
+    for (let i = 1; i < h.length; i++) {
+      expect(h[i - 1].confidence).toBeGreaterThanOrEqual(h[i].confidence)
+    }
+    expect(h.map(x => x.rank)).toEqual(h.map((_, i) => i + 1))
+  })
+
+  it('computes a blast radius that expands from an affected leaf to its spines', () => {
+    const h = analyzeRca({ symptom: 'BGP down', affectedDevices: ['IAD-LEAF-01'], design: fabric })
+    const bgp = h.find(x => x.rootCause === 'BGP Session Loss')!
+    expect(bgp.blastRadius).toContain('IAD-LEAF-01')
+    // leaf -> spines (adjacency) within 2 hops
+    expect(bgp.blastRadius).toContain('IAD-SPINE-01')
+    expect(bgp.blastRadius).toContain('IAD-SPINE-02')
+  })
+
+  it('confidence never exceeds 1', () => {
+    const gpu: RcaDesignState = { ...fabric, useCase: 'gpu' }
+    const h = analyzeRca({ symptom: 'pfc rdma roce deadlock watchdog gpu', affectedDevices: ['IAD-LEAF-01'], design: gpu })
+    for (const x of h) expect(x.confidence).toBeLessThanOrEqual(1)
+  })
+
+  it('returns a generic fallback when nothing matches (never empty)', () => {
+    const h = analyzeRca({ symptom: 'the printer is jammed', design: fabric })
+    expect(h.length).toBe(1)
+    expect(h[0].rootCause).toBe('Undetermined Root Cause')
+    expect(h[0].remediationSteps.length).toBeGreaterThan(0)
+  })
+
+  it('handles no design/devices gracefully (empty blast radius)', () => {
+    const h = analyzeRca({ symptom: 'bgp session down' })
+    expect(h.length).toBeGreaterThan(0)
+    expect(h[0].blastRadius).toEqual([])
+  })
+})
+
+describe('normalizeRcaResponse', () => {
+  it('maps the real engine (snake_case) rich shape', () => {
+    const raw = [{
+      root_cause: 'BGP Session Loss',
+      confidence: 0.82,
+      evidence: ['peer down'],
+      blast_radius: ['A', 'B'],
+      remediation_steps: ['step 1', 'step 2'],
+      automation_available: true,
+      automation_playbook: 'playbooks/rca/bgp_session_restore.yml',
+    }]
+    const [h] = normalizeRcaResponse(raw)
+    expect(h.rootCause).toBe('BGP Session Loss')
+    expect(h.confidence).toBe(0.82)
+    expect(h.blastRadius).toEqual(['A', 'B'])
+    expect(h.remediationSteps).toEqual(['step 1', 'step 2'])
+    expect(h.automationAvailable).toBe(true)
+    expect(h.automationPlaybook).toContain('bgp')
+  })
+
+  it('maps the legacy stub shape (cause + single remediation string) and assigns ranks by confidence', () => {
+    const raw = [
+      { rank: 2, cause: 'Low conf', confidence: 0.3, evidence: [], remediation: 'do X' },
+      { rank: 1, cause: 'High conf', confidence: 0.9, evidence: ['e'], remediation: 'do Y' },
+    ]
+    const out = normalizeRcaResponse(raw)
+    // stub provides explicit ranks -> preserved
+    expect(out.find(h => h.rootCause === 'High conf')!.rank).toBe(1)
+    expect(out.find(h => h.rootCause === 'Low conf')!.remediationSteps).toEqual(['do X'])
+    expect(out.find(h => h.rootCause === 'Low conf')!.automationAvailable).toBe(false)
+  })
+
+  it('assigns ranks by descending confidence when the backend omits ranks', () => {
+    const raw = [
+      { root_cause: 'B', confidence: 0.4, remediation_steps: [] },
+      { root_cause: 'A', confidence: 0.7, remediation_steps: [] },
+    ]
+    const out = normalizeRcaResponse(raw)
+    expect(out[0].rootCause).toBe('A')
+    expect(out[0].rank).toBe(1)
+    expect(out[1].rank).toBe(2)
+  })
+
+  it('returns [] for a non-array payload', () => {
+    expect(normalizeRcaResponse(null)).toEqual([])
+    expect(normalizeRcaResponse({ detail: 'error' })).toEqual([])
+  })
+})

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -267,10 +267,13 @@ export interface Alert {
 
 export interface RcaHypothesis {
   rank: number
-  cause: string
-  confidence: number
+  rootCause: string
+  confidence: number          // 0..1
   evidence: string[]
-  remediation: string
+  blastRadius: string[]
+  remediationSteps: string[]
+  automationAvailable: boolean
+  automationPlaybook?: string | null
 }
 
 // ── Troubleshooting Tooling Engine (G-A19) ──────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes two coupled defects in the RCA (Root Cause Analysis) feature surfaced by an audit, and brings it to demo-mode parity with every other Step 6 feature.

**The problem**
1. **Route shadowing (backend)** — `backend/routers/lab.py` registered a static 3-hypothesis stub at `/api/rca/analyze` *before* the real correlation engine (`backend/rca/engine.py`, `@app.post` at `main.py:1083`). Starlette matches in registration order, so the stub won and the real `RCAEngine` (blast-radius, multi-step remediation, automation playbooks) was dead code.
2. **No demo mode (frontend)** — unlike every other Step 6 feature (the app is fully functional without a backend), `RcaPanel` short-circuited to "configure a backend URL" when not live, and the frontend `RcaHypothesis` type only modeled the stub's flat `{rank, cause, remediation}` shape — the engine's rich output was discarded even in live mode.

## Changes

### U1 — Client-side RCA engine + rich output
- **New `frontend/src/lib/rca.ts`**: `analyzeRca(input)` mirrors the backend's 5 hypothesis checkers (BGP session loss, PFC/RDMA deadlock, EVPN/VXLAN overlay, underlay/IGP, recent deployment change). Keyword + design-state driven, deterministic 2-hop blast radius over a role-based adjacency (spine↔leaf mesh + edge/border→aggregation), dedup + confidence-rank, and a generic fallback so the demo UI is never empty.
- **`normalizeRcaResponse()`** maps a live `/api/rca/analyze` response onto the canonical `RcaHypothesis`, tolerant of BOTH the real engine (snake_case) and the legacy stub shape.
- Rich `RcaHypothesis` type (`rootCause`/`confidence`/`evidence`/`blastRadius`/`remediationSteps`/`automationAvailable`/`automationPlaybook`) replaces the flat shape.
- `client.runRca` normalizes; `useRunRca` falls back to `analyzeRca` in demo mode; `RcaPanel` renders blast-radius chips, numbered remediation steps, and an automation-playbook affordance — and works with no backend.
- **14 tests** in `test/rca.test.ts`.

### U2 — Un-shadow the real engine
- Renamed the `lab.py` stub route to `/api/lab/rca` so `/api/rca/analyze` now resolves to the real `RCAEngine`.

## Testing
- Frontend: **1125 tests** pass, `tsc --noEmit` clean, `npm run build` ✓.
- Backend: **lab/rca pytest 21 pass**. (Pre-existing, unrelated `test_config_gen.py` failures on `main` are untouched — the backend Python config-gen is legacy; the frontend TS configgen is the source of truth.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DiH1v2ufYHuupbP4xn6pPb)_