### PR TITLE
fix: V1 — repair backend config-gen context; whole backend suite green

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -25,4 +25,10 @@ if [ -d "$FRONTEND_DIR" ]; then
   npm install --no-audit --no-fund
 fi
 
+# ── Backend test dependency fix ──
+# The container's system `cryptography` package is missing its `_cffi_backend`
+# native module, which breaks all JWT/auth tests (pyo3 PanicException on
+# import). Installing cffi repairs it (idempotent, fast when present).
+pip install --quiet cffi 2>/dev/null || true
+
 echo "Frontend deps ready. Run tests with: cd frontend && npm test"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -934,6 +934,23 @@ config-gen tests must keep passing; add new tests alongside).
 
 ---
 
+### V. Backend config-gen repair — green suite (sourced 2026-07-06)
+
+> The backend pytest suite had 21 standing failures on `main`, masking real
+> regressions. 8 were environment (`cryptography` missing `_cffi_backend` in
+> the web container → all JWT/auth tests panic). 13 were `test_config_gen.py`
+> drift — and investigating exposed a REAL production bug: `_build_device_
+> context` stopped supplying variables the Jinja2 templates reference
+> (StrictUndefined), so `/api/generate-configs` returned "! CONFIG GENERATION
+> ERROR" comments instead of configs for NX-OS leaf, IOS-XE access, and
+> IOS-XE distribution.
+
+| # | Item | Status | Notes |
+|---|------|--------|-------|
+| V1 | Repair the backend config-gen context + tests → whole suite green — `_build_device_context` now supplies `spine_ips` (IP-plan spine loopbacks by role, else the `10.0.i.i` scheme — leaf RR sessions point at the loopbacks spines actually get), `voice_vlan` (from VLAN list by name), `dot1x_enabled` (security list), `dai_enabled`/`dhcp_snooping` (campus default), `mgmt_mask`, plus the documented contract flags `bgp_evpn`, `vxlan_vni_base`, `pfc_queues`, and `roce_enabled` now true for GPU use cases per §6.5 (qos_policy already OR'd `uc=="gpu"`). Tests updated where behavior intentionally changed (hostname `DC-SPINE-01` w/o org prefix; empty `selectedProducts` → default-sizing fallback; dash not underscore in hostname filters). Session-start hook installs `cffi` to fix the auth-test env panic. Backend suite 321 passed/21 failed → **342 passed/0 failed**. Follow-up noted: `ios_xe/firewall.j2` doesn't exist → `fw` devices get a stub comment | [x] | `backend/config_gen.py` + `backend/tests/test_config_gen.py` (27 pass) + `.claude/hooks/session-start.sh` |
+
+---
+
 ## 23. Autonomous "Start Improving" Mode (2026-06-11 →)
 
 ### Purpose

--- a/backend/config_gen.py
+++ b/backend/config_gen.py
@@ -225,9 +225,41 @@ def _build_device_context(state: dict[str, Any], layer: str, index: int) -> dict
         for i, ul in enumerate(uplinks_raw)
     ]
 
-    # GPU/RoCEv2 context variables
-    roce_enabled  = any(x in (protocols + overlay) for x in ("rocev2", "roce_v2", "roce"))
+    # GPU/RoCEv2 context variables — a GPU fabric is lossless by definition
+    # (§6 rule 5), so roce is on for GPU use cases even when the protocol list
+    # doesn't carry an explicit roce keyword (the frontend usually doesn't).
+    roce_enabled  = (
+        use_case in ("gpu", "ai_fabric", "gpu_cluster")
+        or any(x in (protocols + overlay) for x in ("rocev2", "roce_v2", "roce"))
+    )
     ecn_threshold = state.get("ecn_threshold", 100_000_000)  # 100 MB default
+    pfc_queues    = state.get("pfc_queues", [3])             # RoCEv2 no-drop priority
+
+    # EVPN/VXLAN overlay flags — evpn keyword or a fabric use case
+    proto_blob = " ".join(str(p).lower() for p in (protocols + overlay))
+    bgp_evpn = "evpn" in proto_blob or use_case in ("dc", "datacenter", "dc_fabric", "gpu", "hybrid")
+    vxlan_vni_base = int(state.get("vxlanVniBase", state.get("vxlan_vni_base", 10000)))
+
+    # Spine RR loopbacks for leaf BGP sessions (nxos/leaf.j2, junos/generic.j2).
+    # Prefer the IP plan's spine entries; otherwise mirror the per-device
+    # loopback scheme above (device i → 10.0.i.i) so the leaf's RR neighbors
+    # point at the loopbacks the spine configs actually get.
+    plan_spines = [d for d in devices_list if "spine" in str(d.get("role", "")).lower()]
+    if plan_spines:
+        spine_ips = [d.get("loopback", f"10.0.{i}.{i}") for i, d in enumerate(plan_spines, 1)]
+    else:
+        num_spine = int(state.get("numSpine", state.get("num_spine", 2)))
+        spine_ips = [f"10.0.{i}.{i}" for i in range(1, num_spine + 1)]
+
+    # Campus access-layer security context (ios_xe/access.j2)
+    security = [str(s).lower() for s in state.get("security", [])]
+    dot1x_enabled = any("802.1x" in s or "dot1x" in s for s in security)
+    dai_enabled   = bool(state.get("dai_enabled", use_case == "campus"))
+    dhcp_snooping = bool(state.get("dhcp_snooping", use_case == "campus"))
+    voice_vlan    = next(
+        (v.get("id") for v in state.get("vlans", []) if "voice" in str(v.get("name", "")).lower()),
+        state.get("voice_vlan", 20),
+    )
 
     return {
         "hostname":        hostname,
@@ -237,6 +269,7 @@ def _build_device_context(state: dict[str, Any], layer: str, index: int) -> dict
         "index":           index,
         "loopback_ip":     loopback_ip,
         "mgmt_ip":         mgmt_ip,
+        "mgmt_mask":       state.get("mgmt_mask", "255.255.255.0"),
         "bgp_asn":         bgp_asn,
         "underlay":        underlay,
         "protocols":       protocols,
@@ -245,9 +278,17 @@ def _build_device_context(state: dict[str, Any], layer: str, index: int) -> dict
         "bandwidth_gbps":  bandwidth,
         "endpoint_count":  ep_count,
         "uplinks":         uplinks,
+        "spine_ips":       spine_ips,
+        "bgp_evpn":        bgp_evpn,
+        "vxlan_vni_base":  vxlan_vni_base,
         "roce_enabled":    roce_enabled,
         "ecn_threshold":   ecn_threshold,
+        "pfc_queues":      pfc_queues,
         "dcqcn":           any(x in (protocols + overlay) for x in ("dcqcn", "ecn_dcqcn", "ecn")),
+        "dot1x_enabled":   dot1x_enabled,
+        "dai_enabled":     dai_enabled,
+        "dhcp_snooping":   dhcp_snooping,
+        "voice_vlan":      voice_vlan,
         "vlans":           state.get("vlans", []),
         # Policy flags (default all enabled)
         "include_security_hardening": state.get("include_security_hardening", True),

--- a/backend/tests/test_config_gen.py
+++ b/backend/tests/test_config_gen.py
@@ -89,9 +89,10 @@ def gpu_state():
 class TestBuildDeviceContext:
 
     def test_hostname_format(self, dc_state):
+        # Hostname is LAYER-NN (uppercased, zero-padded); the org name is in
+        # the config header, not the hostname.
         ctx = _build_device_context(dc_state, "dc-spine", 1)
-        assert "TESTCORP" in ctx["hostname"]
-        assert "DC_SPINE" in ctx["hostname"]
+        assert ctx["hostname"] == "DC-SPINE-01"
         assert ctx["index"] == 1
 
     def test_hostname_index_increments(self, dc_state):
@@ -174,10 +175,15 @@ class TestGenerateAllConfigs:
             assert isinstance(cfg, str), f"{hostname} config is not a string"
             assert len(cfg) > 50, f"{hostname} config is suspiciously short"
 
-    def test_empty_selected_products_returns_empty(self, dc_state):
+    def test_empty_selected_products_falls_back_to_default_sizing(self, dc_state):
+        # _derive_layers ignores selectedProducts: without an ipPlan device
+        # list it falls back to use-case sizing (2 spine + 4 leaf + fw for dc),
+        # so callers that never send selectedProducts still get configs.
         dc_state["selectedProducts"] = {}
         result = generate_all_configs(dc_state)
-        assert result == {}
+        assert len(result) >= 6
+        assert sum(1 for h in result if "SPINE" in h.upper()) == 2
+        assert sum(1 for h in result if "LEAF" in h.upper()) == 4
 
     def test_campus_config_contains_hostname(self, campus_state):
         result = generate_all_configs(campus_state)
@@ -187,14 +193,14 @@ class TestGenerateAllConfigs:
 
     def test_campus_access_config_has_vlan_section(self, campus_state):
         result = generate_all_configs(campus_state)
-        access_configs = {k: v for k, v in result.items() if "CAMPUS_ACCESS" in k}
+        access_configs = {k: v for k, v in result.items() if "CAMPUS-ACCESS" in k}
         assert len(access_configs) > 0
         for hostname, cfg in access_configs.items():
             assert "vlan" in cfg.lower(), f"No VLAN config in {hostname}"
 
     def test_dc_spine_config_has_bgp(self, dc_state):
         result = generate_all_configs(dc_state)
-        spine_configs = {k: v for k, v in result.items() if "DC_SPINE" in k}
+        spine_configs = {k: v for k, v in result.items() if "DC-SPINE" in k}
         assert len(spine_configs) > 0
         for hostname, cfg in spine_configs.items():
             assert "bgp" in cfg.lower(), f"No BGP config in {hostname}"
@@ -202,7 +208,7 @@ class TestGenerateAllConfigs:
     def test_gpu_tor_config_is_json_like(self, gpu_state):
         """SONiC TOR config should be JSON (config_db format)."""
         result = generate_all_configs(gpu_state)
-        tor_configs = {k: v for k, v in result.items() if "GPU_TOR" in k}
+        tor_configs = {k: v for k, v in result.items() if "GPU-TOR" in k}
         assert len(tor_configs) > 0
         for hostname, cfg in tor_configs.items():
             assert "{" in cfg, f"SONiC config for {hostname} doesn't look like JSON"


### PR DESCRIPTION
## Summary

The backend pytest suite had **21 standing failures on `main`**, masking any new regression. Fixing them exposed a **real production bug**: templates render with `StrictUndefined`, and `_build_device_context` stopped supplying variables they reference — so `/api/generate-configs` returned `! CONFIG GENERATION ERROR` comments **instead of configs** for NX-OS leaf, IOS-XE access, and IOS-XE distribution.

## Changes

**Production fix — `backend/config_gen.py` `_build_device_context`:**
- `spine_ips` — from the IP plan's spine entries (matched by role) or the `10.0.i.i` loopback scheme, so the leaf's BGP route-reflector sessions target the loopbacks the spine configs actually get.
- `voice_vlan` (from the VLAN list by name), `dot1x_enabled` (from the security list), `dai_enabled` / `dhcp_snooping` (default on for campus), `mgmt_mask`.
- Contract flags restored: `bgp_evpn`, `vxlan_vni_base`, `pfc_queues`, and `roce_enabled` is now true for GPU use cases per §6.5 — a GPU fabric is lossless by definition; `qos_policy` already OR'd `uc=="gpu"`.

**Test updates (behavior intentionally changed):** hostname is `DC-SPINE-01` (no org prefix); empty `selectedProducts` falls back to default use-case sizing; hostname filters use dashes.

**Environment fix:** the other 8 failures were all JWT/auth tests panicking because the web container's system `cryptography` lacks `_cffi_backend`. The session-start hook now installs `cffi` (idempotent), so fresh sessions get a working auth suite.

## Testing
- `test_config_gen.py`: 14 → **27 pass**.
- Full backend suite: 321 passed / 21 failed → **342 passed / 0 failed**.
- End-to-end smoke: NX-OS leaf now emits real RR neighbors (`neighbor 10.0.1.1` / `10.0.2.2`), campus access carries `switchport voice vlan` + 802.1X, distribution has its mgmt mask — no `CONFIG GENERATION ERROR` markers.

Follow-up noted in the tracker: `ios_xe/firewall.j2` doesn't exist, so `fw` devices still get a stub comment (pre-existing, separate item).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DiH1v2ufYHuupbP4xn6pPb)_