### PR TITLE
feat: W1 — design diff / change review engine

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -958,6 +958,22 @@ config-gen tests must keep passing; add new tests alongside).
 
 ---
 
+### W. Design diff / change review (sourced 2026-07-07)
+
+> §23 sourcing priority 4 (richer change review). H1 serializes a full design
+> (`DesignExport`: intent + requirements + BOM + configs) and imports it, but
+> there is no way to **compare two designs** — e.g. a saved baseline vs. the
+> current working design — before re-deploying. Enterprise change review needs
+> a field-level diff (what intent/requirements changed), a BOM delta
+> (added/removed/changed devices, cost delta), and a per-device config diff
+> (unified hunks) so an operator can see exactly what a redeploy will change.
+
+| # | Item | Status | Notes |
+|---|------|--------|-------|
+| W1 | Design diff engine — new `lib/design-diff.ts` (`diffDesigns(a, b)` over two `DesignExport`s → `{intentChanges, requirementChanges, bomDelta, configDelta, summary}`): field-level intent/requirements changes (added/removed/changed w/ before→after), BOM delta by device id (added/removed/changed + capex delta), per-device **LCS-based unified config diff** (added/removed/modified files w/ line-level hunks, long unchanged runs elided w/ context), `diffToMarkdown` report. Wired into Step 4 Summary tab "Compare Designs (Change Review)" card (upload a baseline JSON → summary chips + intent/requirement tables + BOM delta + colored config hunks + download .md report). Pure + 10 tests | [x] | `lib/design-diff.ts` + `test/design-diff.test.ts` (10) + `Step4NetworkDesign.tsx`; 1158 tests, tsc + build green |
+
+---
+
 ## 23. Autonomous "Start Improving" Mode (2026-06-11 →)
 
 ### Purpose

--- a/CODE_REFERENCE.md
+++ b/CODE_REFERENCE.md
@@ -964,6 +964,19 @@ generate a Markdown design report for change management/documentation.
   Import Design (file picker with validation status feedback).
 - **Tests**: 18 in `test/design-export.test.ts`.
 
+## Frontend — `lib/design-diff.ts` (Design diff / change review — W1)
+
+**Purpose:** Compare two serialized designs (`DesignExport`) so an operator can
+review exactly what a redeploy will change before committing. Pure + deterministic.
+
+**Key exports:**
+- Types: `FieldChange {field, before, after}`, `DeviceChange {id, hostname, status, changes[], priceBefore, priceAfter}`, `ConfigHunk {sign: '+'|'-'|' ', text}`, `ConfigDiff {id, status, addedLines, removedLines, hunks[]}`, `DesignDiff {intentChanges, requirementChanges, bomDelta, configDelta, summary}`.
+- `diffDesigns(a, b): DesignDiff` — a=baseline, b=candidate. Field-level intent/requirements diff (compares flat records, keys in either side), BOM delta indexed by device id (added/removed/changed on model/vendor/count/price/… + capex delta), and per-device config diff.
+- Config diff is an internal LCS (longest-common-subsequence) line differ → unified hunks with N lines of context; long unchanged runs collapse to `… N unchanged lines …` elisions.
+- `diffToMarkdown(diff): string` — full Markdown change-review report (summary, intent/requirement tables, BOM delta, ```diff``` config blocks); returns a "no changes" note for identical designs.
+- **UI**: Step 4 Summary tab "Compare Designs (Change Review)" card — upload a baseline JSON → summary chips (intent/req/device/config counts + colored CapEx delta), before/after field tables, BOM delta list, colored per-device config hunks, and a downloadable `.md` change report.
+- **Tests**: 10 in `test/design-diff.test.ts`.
+
 ## Frontend — `lib/compliance-scan.ts` (Compliance Scanner — H2)
 
 **Purpose:** Framework-aware compliance validation engine that checks the

--- a/frontend/src/lib/design-diff.ts
+++ b/frontend/src/lib/design-diff.ts
@@ -1,0 +1,269 @@
+// ── Design diff / change review (group W) ─────────────────────────────────────
+//
+// Compares two serialized designs (DesignExport, from lib/design-export.ts) so
+// an operator can review exactly what a redeploy will change: which intent /
+// requirement fields changed, which devices were added/removed/re-sized (with
+// the capex delta), and a per-device unified config diff. Pure + deterministic.
+
+import type { DesignExport } from '@/lib/design-export'
+import type { BOMDevice } from '@/types'
+
+export interface FieldChange {
+  field: string
+  before: string
+  after: string
+}
+
+export interface DeviceChange {
+  id: string
+  hostname: string
+  status: 'added' | 'removed' | 'changed'
+  /** Field-level changes for a 'changed' device (model/vendor/count/price/…). */
+  changes: FieldChange[]
+  priceBefore: number
+  priceAfter: number
+}
+
+export interface ConfigHunk {
+  /** '+' added line, '-' removed line, ' ' context. */
+  sign: '+' | '-' | ' '
+  text: string
+}
+
+export interface ConfigDiff {
+  id: string
+  status: 'added' | 'removed' | 'modified'
+  addedLines: number
+  removedLines: number
+  hunks: ConfigHunk[]
+}
+
+export interface DesignDiff {
+  intentChanges: FieldChange[]
+  requirementChanges: FieldChange[]
+  bomDelta: DeviceChange[]
+  configDelta: ConfigDiff[]
+  summary: {
+    intentChanged: number
+    requirementsChanged: number
+    devicesAdded: number
+    devicesRemoved: number
+    devicesChanged: number
+    capexBefore: number
+    capexAfter: number
+    capexDelta: number
+    configsAdded: number
+    configsRemoved: number
+    configsModified: number
+    hasChanges: boolean
+  }
+}
+
+const fmt = (v: unknown): string => {
+  if (v === undefined || v === null) return ''
+  if (Array.isArray(v)) return v.join(', ')
+  if (typeof v === 'object') return JSON.stringify(v)
+  return String(v)
+}
+
+/** Field-level diff of two flat records. Keys present in either side are compared. */
+function diffRecord(a: Record<string, unknown>, b: Record<string, unknown>): FieldChange[] {
+  const keys = [...new Set([...Object.keys(a || {}), ...Object.keys(b || {})])].sort()
+  const out: FieldChange[] = []
+  for (const k of keys) {
+    const before = fmt(a?.[k])
+    const after = fmt(b?.[k])
+    if (before !== after) out.push({ field: k, before, after })
+  }
+  return out
+}
+
+function indexDevices(devs: BOMDevice[]): Map<string, BOMDevice> {
+  const m = new Map<string, BOMDevice>()
+  for (const d of devs) m.set(d.id || d.hostname, d)
+  return m
+}
+
+const DEVICE_FIELDS: (keyof BOMDevice)[] = ['hostname', 'vendor', 'model', 'role', 'subLayer', 'count', 'speed', 'ports', 'uplinks', 'unitPrice']
+
+function diffDevices(a: BOMDevice[], b: BOMDevice[]): DeviceChange[] {
+  const ai = indexDevices(a)
+  const bi = indexDevices(b)
+  const ids = [...new Set([...ai.keys(), ...bi.keys()])].sort()
+  const out: DeviceChange[] = []
+
+  for (const id of ids) {
+    const da = ai.get(id)
+    const db = bi.get(id)
+    if (da && !db) {
+      out.push({ id, hostname: da.hostname, status: 'removed', changes: [], priceBefore: da.totalPrice ?? 0, priceAfter: 0 })
+    } else if (!da && db) {
+      out.push({ id, hostname: db.hostname, status: 'added', changes: [], priceBefore: 0, priceAfter: db.totalPrice ?? 0 })
+    } else if (da && db) {
+      const changes: FieldChange[] = []
+      for (const f of DEVICE_FIELDS) {
+        const before = fmt(da[f]); const after = fmt(db[f])
+        if (before !== after) changes.push({ field: String(f), before, after })
+      }
+      if (changes.length) {
+        out.push({ id, hostname: db.hostname, status: 'changed', changes, priceBefore: da.totalPrice ?? 0, priceAfter: db.totalPrice ?? 0 })
+      }
+    }
+  }
+  return out
+}
+
+/**
+ * Minimal line-level diff (LCS) between two config texts → unified hunks with
+ * a few lines of surrounding context. Deterministic; no external deps.
+ */
+function diffConfigText(before: string, after: string, context = 2): { hunks: ConfigHunk[]; added: number; removed: number } {
+  const a = before.split('\n')
+  const b = after.split('\n')
+  const n = a.length, m = b.length
+
+  // LCS length table
+  const lcs: number[][] = Array.from({ length: n + 1 }, () => new Array(m + 1).fill(0))
+  for (let i = n - 1; i >= 0; i--) {
+    for (let j = m - 1; j >= 0; j--) {
+      lcs[i][j] = a[i] === b[j] ? lcs[i + 1][j + 1] + 1 : Math.max(lcs[i + 1][j], lcs[i][j + 1])
+    }
+  }
+
+  // Backtrack into a raw op list
+  const raw: ConfigHunk[] = []
+  let i = 0, j = 0
+  let added = 0, removed = 0
+  while (i < n && j < m) {
+    if (a[i] === b[j]) { raw.push({ sign: ' ', text: a[i] }); i++; j++ }
+    else if (lcs[i + 1][j] >= lcs[i][j + 1]) { raw.push({ sign: '-', text: a[i] }); removed++; i++ }
+    else { raw.push({ sign: '+', text: b[j] }); added++; j++ }
+  }
+  while (i < n) { raw.push({ sign: '-', text: a[i] }); removed++; i++ }
+  while (j < m) { raw.push({ sign: '+', text: b[j] }); added++; j++ }
+
+  // Collapse long runs of unchanged context into elisions.
+  const hunks: ConfigHunk[] = []
+  for (let k = 0; k < raw.length; k++) {
+    if (raw[k].sign !== ' ') { hunks.push(raw[k]); continue }
+    // count the context run
+    let end = k
+    while (end < raw.length && raw[end].sign === ' ') end++
+    const runLen = end - k
+    const nearStart = hunks.some(h => h.sign !== ' ')  // keep trailing context only after a change
+    if (runLen <= context * 2) {
+      for (let x = k; x < end; x++) hunks.push(raw[x])
+    } else {
+      // keep `context` after the previous change, elide, keep `context` before the next
+      if (nearStart) for (let x = k; x < k + context; x++) hunks.push(raw[x])
+      if (end < raw.length) {
+        hunks.push({ sign: ' ', text: `… ${runLen - (nearStart ? context : 0) - context} unchanged lines …` })
+        for (let x = end - context; x < end; x++) hunks.push(raw[x])
+      }
+    }
+    k = end - 1
+  }
+  return { hunks, added, removed }
+}
+
+function diffConfigs(a: Record<string, string>, b: Record<string, string>): ConfigDiff[] {
+  const ids = [...new Set([...Object.keys(a || {}), ...Object.keys(b || {})])].sort()
+  const out: ConfigDiff[] = []
+  for (const id of ids) {
+    const ca = a?.[id]; const cb = b?.[id]
+    if (ca !== undefined && cb === undefined) {
+      out.push({ id, status: 'removed', addedLines: 0, removedLines: ca.split('\n').length, hunks: [] })
+    } else if (ca === undefined && cb !== undefined) {
+      out.push({ id, status: 'added', addedLines: cb.split('\n').length, removedLines: 0, hunks: [] })
+    } else if (ca !== undefined && cb !== undefined && ca !== cb) {
+      const { hunks, added, removed } = diffConfigText(ca, cb)
+      out.push({ id, status: 'modified', addedLines: added, removedLines: removed, hunks })
+    }
+  }
+  return out
+}
+
+/** Compare a baseline design (a) against a candidate design (b). */
+export function diffDesigns(a: DesignExport, b: DesignExport): DesignDiff {
+  const intentChanges = diffRecord(a.intent as Record<string, unknown>, b.intent as Record<string, unknown>)
+  const requirementChanges = diffRecord(a.requirements as Record<string, unknown>, b.requirements as Record<string, unknown>)
+  const bomDelta = diffDevices(a.bom?.devices ?? [], b.bom?.devices ?? [])
+  const configDelta = diffConfigs(a.configs ?? {}, b.configs ?? {})
+
+  const capexBefore = (a.bom?.devices ?? []).reduce((s, d) => s + (d.totalPrice ?? 0), 0)
+  const capexAfter = (b.bom?.devices ?? []).reduce((s, d) => s + (d.totalPrice ?? 0), 0)
+
+  const summary = {
+    intentChanged: intentChanges.length,
+    requirementsChanged: requirementChanges.length,
+    devicesAdded: bomDelta.filter(d => d.status === 'added').length,
+    devicesRemoved: bomDelta.filter(d => d.status === 'removed').length,
+    devicesChanged: bomDelta.filter(d => d.status === 'changed').length,
+    capexBefore,
+    capexAfter,
+    capexDelta: capexAfter - capexBefore,
+    configsAdded: configDelta.filter(c => c.status === 'added').length,
+    configsRemoved: configDelta.filter(c => c.status === 'removed').length,
+    configsModified: configDelta.filter(c => c.status === 'modified').length,
+    hasChanges: false,
+  }
+  summary.hasChanges =
+    intentChanges.length + requirementChanges.length + bomDelta.length + configDelta.length > 0
+
+  return { intentChanges, requirementChanges, bomDelta, configDelta, summary }
+}
+
+/** Render a diff as a Markdown change-review report. */
+export function diffToMarkdown(diff: DesignDiff): string {
+  const usd = (n: number) => `$${Math.round(n).toLocaleString()}`
+  const L: string[] = ['# Design Change Review', '']
+
+  if (!diff.summary.hasChanges) {
+    L.push('_No changes — the two designs are identical._', '')
+    return L.join('\n')
+  }
+
+  const s = diff.summary
+  L.push('## Summary', '')
+  L.push(`- Intent fields changed: **${s.intentChanged}**`)
+  L.push(`- Requirement fields changed: **${s.requirementsChanged}**`)
+  L.push(`- Devices: **+${s.devicesAdded} / -${s.devicesRemoved} / ~${s.devicesChanged}**`)
+  L.push(`- Configs: **+${s.configsAdded} / -${s.configsRemoved} / ~${s.configsModified}**`)
+  L.push(`- CapEx: ${usd(s.capexBefore)} → ${usd(s.capexAfter)} (**${s.capexDelta >= 0 ? '+' : ''}${usd(s.capexDelta)}**)`)
+  L.push('')
+
+  const fieldTable = (title: string, rows: FieldChange[]) => {
+    if (!rows.length) return
+    L.push(`## ${title}`, '', '| Field | Before | After |', '|---|---|---|')
+    for (const c of rows) L.push(`| ${c.field} | ${c.before || '—'} | ${c.after || '—'} |`)
+    L.push('')
+  }
+  fieldTable('Intent changes', diff.intentChanges)
+  fieldTable('Requirement changes', diff.requirementChanges)
+
+  if (diff.bomDelta.length) {
+    L.push('## BOM delta', '')
+    for (const d of diff.bomDelta) {
+      const tag = d.status === 'added' ? '➕' : d.status === 'removed' ? '➖' : '✏️'
+      L.push(`### ${tag} ${d.hostname} (${d.status})`)
+      for (const c of d.changes) L.push(`- ${c.field}: ${c.before} → ${c.after}`)
+      if (d.status !== 'changed') L.push(`- price: ${usd(d.priceBefore)} → ${usd(d.priceAfter)}`)
+      L.push('')
+    }
+  }
+
+  if (diff.configDelta.length) {
+    L.push('## Config delta', '')
+    for (const c of diff.configDelta) {
+      L.push(`### ${c.id} (${c.status}, +${c.addedLines}/-${c.removedLines})`)
+      if (c.hunks.length) {
+        L.push('```diff')
+        for (const h of c.hunks) L.push(`${h.sign}${h.text}`)
+        L.push('```')
+      }
+      L.push('')
+    }
+  }
+
+  return L.join('\n')
+}

--- a/frontend/src/pages/Step4NetworkDesign.tsx
+++ b/frontend/src/pages/Step4NetworkDesign.tsx
@@ -10,7 +10,8 @@ import { formatUSD, cn } from '@/lib/utils'
 import { haPairInfo, DCI_RT_ASN } from '@/lib/configgen'
 import { genIPBlocks, genIPRows, genVLANs, genVNIs, buildNetBoxIpamExport } from '@/lib/ipam'
 import { buildNetBoxDcimExport } from '@/lib/netbox-dcim'
-import { downloadDesignJSON, downloadDesignMarkdown, validateDesignImport, applyDesignImport } from '@/lib/design-export'
+import { downloadDesignJSON, downloadDesignMarkdown, validateDesignImport, applyDesignImport, serializeDesign } from '@/lib/design-export'
+import { diffDesigns, diffToMarkdown, type DesignDiff } from '@/lib/design-diff'
 import { computeCapacityPlan } from '@/lib/capacity-planning'
 import { buildContainerlabTopology, topologyToYAML } from '@/lib/containerlab'
 import type { DesignExport } from '@/lib/design-export'
@@ -698,6 +699,8 @@ export function Step4NetworkDesign() {
   const [summaryCopied, setSummaryCopied] = useState(false)
   const [mermaidCopied, setMermaidCopied] = useState(false)
   const [importStatus, setImportStatus] = useState<{ type: 'success' | 'error'; message: string } | null>(null)
+  const [designDiff, setDesignDiff] = useState<DesignDiff | null>(null)
+  const [diffError, setDiffError] = useState<string | null>(null)
   const svgRef = useRef<HTMLDivElement>(null)
   const lldRef = useRef<HTMLDivElement>(null)
 
@@ -1861,6 +1864,168 @@ export function Step4NetworkDesign() {
             <p className="text-xs text-gray-500 mt-2">
               Export your full design as JSON (re-importable) or as a Markdown report for documentation and change management reviews.
             </p>
+          </Card>
+
+          {/* W1: Compare Designs (change review) */}
+          <Card>
+            <h3 className="text-sm font-semibold text-gray-300 mb-1">Compare Designs (Change Review)</h3>
+            <p className="text-xs text-gray-500 mb-3">
+              Upload a previously-exported design JSON as the <strong>baseline</strong> — see exactly what changed
+              vs. the current working design (intent, requirements, BOM, per-device configs) before you redeploy.
+            </p>
+            <div className="flex flex-wrap gap-3 mb-3">
+              <label className="flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg border border-cyan-500/40 bg-cyan-600/20 text-cyan-300 text-sm font-medium hover:bg-cyan-600/30 transition-colors cursor-pointer">
+                Upload Baseline JSON
+                <input
+                  type="file"
+                  accept=".json"
+                  className="hidden"
+                  onChange={e => {
+                    const file = e.target.files?.[0]
+                    if (!file) return
+                    const reader = new FileReader()
+                    reader.onload = () => {
+                      try {
+                        const baseline = JSON.parse(reader.result as string)
+                        const check = validateDesignImport(baseline)
+                        if (!check.ok) { setDiffError(check.error!); setDesignDiff(null); return }
+                        const current = serializeDesign(useAppStore.getState() as AppState)
+                        setDesignDiff(diffDesigns(baseline as DesignExport, current))
+                        setDiffError(null)
+                      } catch {
+                        setDiffError('Failed to parse JSON file'); setDesignDiff(null)
+                      }
+                    }
+                    reader.readAsText(file)
+                    e.target.value = ''
+                  }}
+                />
+              </label>
+              {designDiff && (
+                <button
+                  onClick={() => {
+                    const md = diffToMarkdown(designDiff)
+                    const blob = new Blob([md], { type: 'text/markdown' })
+                    const url = URL.createObjectURL(blob)
+                    const a = document.createElement('a')
+                    a.href = url; a.download = `change-review-${siteCode || useCase || 'design'}.md`; a.click()
+                    URL.revokeObjectURL(url)
+                  }}
+                  className="flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg border border-white/15 bg-white/5 text-gray-300 text-sm font-medium hover:bg-white/10 transition-colors cursor-pointer"
+                >
+                  ↓ Change Report (.md)
+                </button>
+              )}
+            </div>
+
+            {diffError && (
+              <div className="p-3 rounded-lg text-sm border bg-red-900/30 border-red-700/50 text-red-300">{diffError}</div>
+            )}
+
+            {designDiff && !designDiff.summary.hasChanges && (
+              <div className="p-3 rounded-lg text-sm border bg-green-900/30 border-green-700/50 text-green-300">
+                No changes — the baseline and current design are identical.
+              </div>
+            )}
+
+            {designDiff && designDiff.summary.hasChanges && (
+              <div className="space-y-4">
+                {/* Summary chips */}
+                <div className="flex flex-wrap gap-2 text-xs">
+                  <span className="px-2 py-1 rounded bg-white/5 border border-white/10 text-gray-300">
+                    Intent: {designDiff.summary.intentChanged}
+                  </span>
+                  <span className="px-2 py-1 rounded bg-white/5 border border-white/10 text-gray-300">
+                    Requirements: {designDiff.summary.requirementsChanged}
+                  </span>
+                  <span className="px-2 py-1 rounded bg-emerald-500/10 border border-emerald-500/20 text-emerald-300">
+                    Devices +{designDiff.summary.devicesAdded} / -{designDiff.summary.devicesRemoved} / ~{designDiff.summary.devicesChanged}
+                  </span>
+                  <span className="px-2 py-1 rounded bg-blue-500/10 border border-blue-500/20 text-blue-300">
+                    Configs +{designDiff.summary.configsAdded} / -{designDiff.summary.configsRemoved} / ~{designDiff.summary.configsModified}
+                  </span>
+                  <span className={cn(
+                    'px-2 py-1 rounded border',
+                    designDiff.summary.capexDelta > 0 ? 'bg-red-500/10 border-red-500/20 text-red-300'
+                      : designDiff.summary.capexDelta < 0 ? 'bg-green-500/10 border-green-500/20 text-green-300'
+                      : 'bg-white/5 border-white/10 text-gray-300',
+                  )}>
+                    CapEx {designDiff.summary.capexDelta >= 0 ? '+' : ''}{formatUSD(designDiff.summary.capexDelta)}
+                  </span>
+                </div>
+
+                {/* Field change tables */}
+                {[
+                  { title: 'Intent changes', rows: designDiff.intentChanges },
+                  { title: 'Requirement changes', rows: designDiff.requirementChanges },
+                ].filter(s => s.rows.length > 0).map(section => (
+                  <div key={section.title}>
+                    <div className="text-xs font-bold text-blue-400 uppercase tracking-wider mb-2">{section.title}</div>
+                    <div className="overflow-x-auto">
+                      <table className="w-full text-xs">
+                        <thead><tr className="border-b border-white/10 text-gray-400">
+                          <th className="px-2 py-1 text-left">Field</th><th className="px-2 py-1 text-left">Before</th><th className="px-2 py-1 text-left">After</th>
+                        </tr></thead>
+                        <tbody>
+                          {section.rows.map(c => (
+                            <tr key={c.field} className="border-b border-white/5">
+                              <td className="px-2 py-1 text-gray-300 font-mono">{c.field}</td>
+                              <td className="px-2 py-1 text-red-300/80 font-mono">{c.before || '—'}</td>
+                              <td className="px-2 py-1 text-green-300/80 font-mono">{c.after || '—'}</td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  </div>
+                ))}
+
+                {/* BOM delta */}
+                {designDiff.bomDelta.length > 0 && (
+                  <div>
+                    <div className="text-xs font-bold text-blue-400 uppercase tracking-wider mb-2">BOM delta</div>
+                    <div className="space-y-1">
+                      {designDiff.bomDelta.map(d => (
+                        <div key={d.id} className="text-xs text-gray-300">
+                          <span className={cn('font-mono',
+                            d.status === 'added' ? 'text-emerald-400' : d.status === 'removed' ? 'text-red-400' : 'text-yellow-400')}>
+                            {d.status === 'added' ? '＋' : d.status === 'removed' ? '－' : '~'} {d.hostname}
+                          </span>
+                          {d.status === 'changed'
+                            ? <span className="text-gray-500"> — {d.changes.map(c => `${c.field}: ${c.before}→${c.after}`).join(', ')}</span>
+                            : <span className="text-gray-500"> — {formatUSD(d.status === 'added' ? d.priceAfter : d.priceBefore)}</span>}
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+                {/* Config delta (unified diff) */}
+                {designDiff.configDelta.length > 0 && (
+                  <div>
+                    <div className="text-xs font-bold text-blue-400 uppercase tracking-wider mb-2">Config delta</div>
+                    <div className="space-y-3">
+                      {designDiff.configDelta.map(c => (
+                        <div key={c.id}>
+                          <div className="text-xs text-gray-400 mb-1 font-mono">
+                            {c.id} <span className={cn(c.status === 'added' ? 'text-emerald-400' : c.status === 'removed' ? 'text-red-400' : 'text-yellow-400')}>({c.status}, +{c.addedLines}/-{c.removedLines})</span>
+                          </div>
+                          {c.hunks.length > 0 && (
+                            <pre className="bg-black/40 border border-white/10 rounded-lg p-3 text-[11px] font-mono overflow-x-auto whitespace-pre leading-relaxed">
+                              {c.hunks.map((h, i) => (
+                                <div key={i} className={h.sign === '+' ? 'text-green-400' : h.sign === '-' ? 'text-red-400' : 'text-gray-500'}>
+                                  {h.sign}{h.text}
+                                </div>
+                              ))}
+                            </pre>
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </div>
+            )}
           </Card>
 
           {/* Printable text version */}

--- a/frontend/src/test/design-diff.test.ts
+++ b/frontend/src/test/design-diff.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect } from 'vitest'
+import { diffDesigns, diffToMarkdown } from '@/lib/design-diff'
+import type { DesignExport } from '@/lib/design-export'
+import type { BOMDevice } from '@/types'
+
+function dev(p: Partial<BOMDevice>): BOMDevice {
+  return {
+    id: p.id || 'd', hostname: p.hostname || 'H', role: 'leaf', subLayer: 'leaf',
+    model: 'N9K', vendor: 'Cisco', count: 1, unitPrice: 1000, totalPrice: 1000,
+    speed: '100G', ports: 48, features: [], ...p,
+  }
+}
+
+function design(over: Partial<DesignExport> = {}): DesignExport {
+  const base = {
+    _magic: 'NDAI_DESIGN',
+    _version: 1,
+    _exportedAt: '2026-07-07T00:00:00Z',
+    intent: {
+      useCase: 'dc', appTypes: [], scale: 'medium', redundancy: 'dual',
+      siteName: 'Ashburn', siteCode: 'IAD', orgName: 'Acme', orgSize: 'large',
+      budgetTier: 'enterprise', vendorPrefs: ['Cisco'], industry: 'tech',
+      primaryContact: 'a@b.c', compliance: [],
+    },
+    requirements: {
+      trafficPattern: 'ew', totalEndpoints: 500, bandwidthPerServer: '25G',
+      oversubscription: 3, underlayProtocol: 'isis', overlayProtocols: ['vxlan_evpn'],
+      protoFeatures: [], firewallModel: 'perimeter', redundancyModel: 'dual',
+      numSites: 1, vpnType: 'ipsec', nacOptions: [], additionalNotes: '',
+      cloudProviders: [], dcTopology: 'clos', coloProvider: '', dcEdgeVendor: '',
+      bgpAsn: '65000', orgCidr: '10.0.0.0/8', aviatrixOptions: [],
+    },
+    bom: {
+      devices: [dev({ id: 's1', hostname: 'IAD-SPINE-01', role: 'spine', subLayer: 'spine' }),
+                dev({ id: 'l1', hostname: 'IAD-LEAF-01' })],
+      cabling: [], optics: [],
+    },
+    configs: { s1: 'hostname IAD-SPINE-01\nrouter bgp 65000\n', l1: 'hostname IAD-LEAF-01\n' },
+  } as unknown as DesignExport
+  return { ...base, ...over }
+}
+
+describe('diffDesigns — no changes', () => {
+  it('reports identical designs as unchanged', () => {
+    const d = diffDesigns(design(), design())
+    expect(d.summary.hasChanges).toBe(false)
+    expect(d.intentChanges).toEqual([])
+    expect(d.bomDelta).toEqual([])
+    expect(d.configDelta).toEqual([])
+  })
+})
+
+describe('diffDesigns — intent & requirements', () => {
+  it('detects an intent field change with before→after', () => {
+    const b = design()
+    b.intent = { ...b.intent, scale: 'large' }
+    const d = diffDesigns(design(), b)
+    const c = d.intentChanges.find(x => x.field === 'scale')
+    expect(c).toEqual({ field: 'scale', before: 'medium', after: 'large' })
+    expect(d.summary.intentChanged).toBe(1)
+    expect(d.summary.hasChanges).toBe(true)
+  })
+
+  it('detects a requirements change', () => {
+    const b = design()
+    b.requirements = { ...b.requirements, totalEndpoints: 1000, oversubscription: 4 }
+    const d = diffDesigns(design(), b)
+    expect(d.summary.requirementsChanged).toBe(2)
+    expect(d.requirementChanges.map(c => c.field).sort()).toEqual(['oversubscription', 'totalEndpoints'])
+  })
+})
+
+describe('diffDesigns — BOM delta', () => {
+  it('detects added, removed and changed devices with capex delta', () => {
+    const b = design()
+    b.bom = {
+      devices: [
+        dev({ id: 's1', hostname: 'IAD-SPINE-01', role: 'spine', subLayer: 'spine' }), // unchanged
+        dev({ id: 'l1', hostname: 'IAD-LEAF-01', count: 2, totalPrice: 2000 }),         // changed
+        dev({ id: 'l2', hostname: 'IAD-LEAF-02', totalPrice: 1500 }),                   // added
+      ],
+      cabling: [], optics: [],
+    }
+    const d = diffDesigns(design(), b)
+    expect(d.summary.devicesAdded).toBe(1)
+    expect(d.summary.devicesRemoved).toBe(0)
+    expect(d.summary.devicesChanged).toBe(1)
+
+    const changed = d.bomDelta.find(x => x.id === 'l1')!
+    expect(changed.status).toBe('changed')
+    expect(changed.changes.some(c => c.field === 'count' && c.before === '1' && c.after === '2')).toBe(true)
+
+    // baseline capex 2000 (s1+l1), candidate 1000+2000+1500 = 4500
+    expect(d.summary.capexBefore).toBe(2000)
+    expect(d.summary.capexAfter).toBe(4500)
+    expect(d.summary.capexDelta).toBe(2500)
+  })
+
+  it('detects a removed device', () => {
+    const b = design()
+    b.bom = { devices: [dev({ id: 's1', hostname: 'IAD-SPINE-01', role: 'spine', subLayer: 'spine' })], cabling: [], optics: [] }
+    const d = diffDesigns(design(), b)
+    expect(d.summary.devicesRemoved).toBe(1)
+    expect(d.bomDelta.find(x => x.id === 'l1')!.status).toBe('removed')
+  })
+})
+
+describe('diffDesigns — config delta', () => {
+  it('detects an added and removed config file', () => {
+    const b = design()
+    b.configs = { s1: b.configs.s1, l2: 'hostname IAD-LEAF-02\n' } // l1 removed, l2 added
+    const d = diffDesigns(design(), b)
+    expect(d.summary.configsAdded).toBe(1)
+    expect(d.summary.configsRemoved).toBe(1)
+    expect(d.configDelta.find(c => c.id === 'l2')!.status).toBe('added')
+    expect(d.configDelta.find(c => c.id === 'l1')!.status).toBe('removed')
+  })
+
+  it('produces a line-level hunk for a modified config', () => {
+    const b = design()
+    b.configs = { ...b.configs, s1: 'hostname IAD-SPINE-01\nrouter bgp 65001\nbfd\n' }
+    const d = diffDesigns(design(), b)
+    const cd = d.configDelta.find(c => c.id === 's1')!
+    expect(cd.status).toBe('modified')
+    expect(cd.addedLines).toBeGreaterThan(0)
+    const signs = cd.hunks.map(h => h.sign)
+    expect(signs).toContain('+')
+    expect(signs).toContain('-')
+    // the changed ASN must appear
+    expect(cd.hunks.some(h => h.sign === '+' && h.text.includes('65001'))).toBe(true)
+    expect(cd.hunks.some(h => h.sign === '-' && h.text.includes('65000'))).toBe(true)
+  })
+
+  it('elides long unchanged runs in a large config', () => {
+    const a = design()
+    const big = Array.from({ length: 50 }, (_, i) => `line ${i}`).join('\n')
+    a.configs = { ...a.configs, s1: big }
+    const b = design()
+    b.configs = { ...b.configs, s1: big.replace('line 25', 'line 25 CHANGED') }
+    const d = diffDesigns(a, b)
+    const cd = d.configDelta.find(c => c.id === 's1')!
+    expect(cd.hunks.some(h => /unchanged lines/.test(h.text))).toBe(true)
+    // context around the change is preserved
+    expect(cd.hunks.some(h => h.sign === '+' && h.text.includes('CHANGED'))).toBe(true)
+  })
+})
+
+describe('diffToMarkdown', () => {
+  it('renders "no changes" for identical designs', () => {
+    const md = diffToMarkdown(diffDesigns(design(), design()))
+    expect(md).toContain('No changes')
+  })
+
+  it('renders a full report with summary, tables and diff blocks', () => {
+    const b = design()
+    b.intent = { ...b.intent, scale: 'large' }
+    b.bom = { devices: [...b.bom.devices, dev({ id: 'l2', hostname: 'IAD-LEAF-02', totalPrice: 1500 })], cabling: [], optics: [] }
+    b.configs = { ...b.configs, s1: 'hostname IAD-SPINE-01\nrouter bgp 65001\n' }
+    const md = diffToMarkdown(diffDesigns(design(), b))
+    expect(md).toContain('# Design Change Review')
+    expect(md).toContain('## Summary')
+    expect(md).toContain('Intent changes')
+    expect(md).toContain('BOM delta')
+    expect(md).toContain('```diff')
+    expect(md).toContain('CapEx')
+  })
+})


### PR DESCRIPTION
## Summary

Enterprise change review — the last piece of the design-export story. H1 (`lib/design-export.ts`) could serialize a full design to JSON and re-import it, but there was no way to **compare two designs** — e.g. a saved baseline vs. the current working design — before redeploying. This adds a field-level + BOM + config diff engine.

## Changes

- **New `frontend/src/lib/design-diff.ts`** (pure, deterministic):
  - `diffDesigns(a, b)` over two `DesignExport`s → `{ intentChanges, requirementChanges, bomDelta, configDelta, summary }`.
    - **Intent / requirement diff** — field-level before→after for every changed key.
    - **BOM delta** — indexed by device id: added / removed / changed (on model, vendor, count, price, ports, …) with a total **CapEx delta**.
    - **Config diff** — an internal LCS (longest-common-subsequence) line differ producing unified `+`/`-`/context hunks; long unchanged runs collapse to `… N unchanged lines …` elisions with surrounding context.
  - `diffToMarkdown(diff)` — full change-review report (summary, before/after tables, ```diff``` config blocks); "no changes" note for identical designs.
- **`Step4NetworkDesign.tsx`** — new "Compare Designs (Change Review)" card in the Summary tab: upload a baseline JSON → summary chips (intent/requirement/device/config counts + colored CapEx delta), before/after field tables, BOM delta list, colored per-device config hunks, and a downloadable `.md` change report.

## Testing
- 10 tests in `test/design-diff.test.ts` (no-change, intent/requirement changes, BOM add/remove/change with CapEx math, config add/remove/modify with line hunks, long-run elision, Markdown report).
- Full suite: **1,158 tests** pass, `tsc --noEmit` clean, `npm run build` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DiH1v2ufYHuupbP4xn6pPb)_