### PR TITLE
fix: Y1 — overlay-establishment parity (2nd-pass audit criticals)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1015,6 +1015,73 @@ config-gen tests must keep passing; add new tests alongside).
 
 ---
 
+### Y. Production-grade hardening, 2nd-pass audit (sourced 2026-07-11)
+
+> Second architect review of the post-group-X output (same dump-and-review
+> method; scenarios in `frontend/src/test/_dump.test.ts` pattern, dumps under
+> scratchpad/audit2). **All group-X fixes held**; these are the next tier.
+> Key theme: **fix-parity** — each first-audit fix landed on some vendors only.
+>
+> **Remaining findings (by area, severity from review):**
+> - **NX-OS DC**: DC-4 spine configures Ethernet1/37-50 on a 36-port 9336C
+>   (port overflow) + leaves wire uplinks only to spines 1-4 but BGP-peer all
+>   6 (spines 5-6 dark) — link *distribution* must round-robin across all
+>   spines & respect spine port count; DC-6 93180YC-FX uplinks emitted on 25G
+>   server ports Eth1/45-48 instead of the 100G ports Eth1/49-54 (uplink ports
+>   should use the SKU's real uplink port range); DC-7 no server-facing vPC
+>   member ports (day-N note at minimum); MINORs: `version 10.3(x)` artifact,
+>   `$(date -u …)` unrendered banner, dead CONNECTED-TO-ISIS tag-100 map,
+>   unused spine features, missing advertise-pip/virtual-rmac.
+> - **Campus IOS-XE**: C-1 mgmt plane sourced from `Vlan99` SVI that is never
+>   created (both dist+access unmanageable — add `interface Vlan99` w/ mgmt
+>   IP); C-3 access MEC (both uplinks in one LACP Po) toward two standalone
+>   C9500s requires StackWise Virtual on the dist pair (or split uplinks+STP);
+>   C-4 access uplink trunk missing `ip dhcp snooping trust` (all client DHCP
+>   dropped); C-5 OSPF area auth enabled with no md5 keys on any interface;
+>   C-6 no dot1x at all despite A3 scope; C-7 verify STP 4096/8192 split;
+>   dist still has no downlink trunks to access / uplink-to-core.
+> - **Arista**: A-M1 no tenant gateway (no Vlan10 SVI `ip address virtual`,
+>   no L3VNI/VRF — NX-OS got this in X1, Arista parity missing); A-M2 MLAG
+>   pair should share one ASN + iBGP across Vlan4094; A-M3 firewall↔fabric
+>   integration absent (24 cables land on unconfigured spine ports); MINORs:
+>   `dns server` → `ip name-server`, snmp user syntax, MLAG pair-id derived
+>   from global idx (fragile), no host-port config.
+> - **Juniper**: J-C1 fabric interfaces have `family iso` but NO `family
+>   inet` address → underlay carries no IPv4 (BGP can never establish);
+>   J-C2 spine configures only et-0/0/0-1 for 26 leaves / leaf only 2 uplink
+>   ports for 4 spines (topology-driven port counts missing — Arista/NX-OS
+>   have `closFabricLinks`, Juniper doesn't); J-C3 leaf missing global
+>   `set routing-options autonomous-system`; J-M1 spine local-as == global AS
+>   (remove); J-M2 SRX still emits bare `!` lines (X4 post-pass not applied);
+>   J-M3 SRX zones bind nonexistent ge- interfaces + cluster has no fab/reth;
+>   J-M4 no ESI-LAG / IRB gateway; MINOR: isis auth-key without
+>   authentication-type md5.
+> - **NVIDIA Cumulus**: N-C1 RoCE/PFC/ECN is ALL COMMENTS (traffic.conf
+>   lines commented; only a software fq_codel qdisc on swp1) — GPU fabric is
+>   lossy, violates §6.5; N-C2 `router bgp <CHANGE-ME-asn>` + placeholder
+>   loopbacks (all other vendors auto-assign; identical placeholder on both
+>   roles → same-ASN eBGP = zero sessions); N-C3 spine `neighbor swp1-swp64
+>   interface peer-group` is invalid FRR range syntax; N-C4 leaf peers only
+>   swp63-64 (2 spines) vs BOM's 8; N-M1 bare `route-reflector-client` line
+>   on eBGP; N-M2 deprecated NCLU `net add` cmds on Cumulus 5.x (NVUE);
+>   N-M3 `auto swp1-64` invalid ifupdown2 range + broken mgmt VRF stanza;
+>   N-M4 EVPN with zero VNIs. Generator likely needs a full NVUE rewrite.
+> - **FTD manifest**: byte-identical across DC and campus (no design-specific
+>   INSIDE-NETS/subnets); fabric-side firewall handoff ports unconfigured on
+>   leaf/dist (ties to A-M3).
+
+| # | Item | Status | Notes |
+|---|------|--------|-------|
+| Y1 | Overlay-establishment parity criticals — (1) **NX-OS**: `ebgp-multihop 2` on BOTH peer templates (loopback eBGP never established — same class as X4's Juniper fix); spine **NH-UNCHANGED** route-map out on the EVPN AF (`set ip next-hop unchanged` — spine is not a VTEP; without it leaves tunnel to the spine loopback and blackhole); **explicit fabric-wide RTs `65000:<vni>`** replacing `route-target auto` (auto derives ASN:VNI — with unique per-leaf eBGP ASNs no leaf imports any other leaf); eBGP ECMP (`maximum-paths 64` not `ibgp`, `bestpath as-path multipath-relax` — needed for the vPC VIP advertised from 2 ASNs); LOOPBACKS prefix-list now covers the VTEP 10.254/16 range. (2) **Arista**: `ip routing` (+`ip routing vrf MGMT`) — EOS is L2-only by default, fabric didn't forward; `vrf instance MGMT` created + `Management1` joined to it (route/eAPI referenced a nonexistent VRF); leaf gains its missing `interface Management1` block entirely; `ebgp-multihop 3` on both peer groups; leaf `maximum-paths 64 ecmp 64` (was 4 on a 6-spine fabric). (3) **Campus**: dist gains `interface Loopback0` (10.255.3.x router-id, in OSPF — clears the V-12 warn) and a REAL peer-link Port-channel + 2 TenGig members (was commented, C-2 class). 7 new tests; 2 auto-RT tests rewritten (they asserted the DC-2 bug) | [x] | `configgen.ts` (nxos spine/leaf, arista spine/leaf, iosxeCampusConfig); `configgen.test.ts` 129→136; 1189 tests, tsc + build green |
+| Y2 | NX-OS wiring honesty: round-robin leaf uplinks across ALL spines (spines 5-6 currently dark), cap spine downlink ports at SKU port count (Eth1/37-50 emitted on a 36-port box), leaf uplinks on the SKU's real uplink-port range (93180: Eth1/49-54, not 25G server ports) | [ ] | `configgen.ts` `closFabricLinks`/`renderNxosFabricLinks` + spine port math |
+| Y3 | Campus deployability: create `interface Vlan99` mgmt SVI (C-1), dist↔access downlink trunks + StackWise Virtual (or split uplinks) for the access MEC (C-3), `ip dhcp snooping trust` on access uplinks (C-4), OSPF md5 keys (C-5), dot1x per A3 scope (C-6) | [ ] | `configgen.ts` `iosxeCampusConfig` |
+| Y4 | Arista tenant gateway parity (Vlan10 SVI `ip address virtual` + L3VNI/VRF like NX-OS X1) + MLAG pair single-ASN + peer-link iBGP + `ip name-server` fix | [ ] | `configgen.ts` `aristaLeafConfig` |
+| Y5 | Juniper: `family inet` addresses on fabric interfaces (underlay carries no IPv4 — reuse `closFabricLinks` for topology-driven ports/IPs), global `autonomous-system` on leaf, drop spine redundant local-as, SRX `!`→`#` + real interfaces/reth/fab, isis `authentication-type md5` | [ ] | `configgen.ts` juniper spine/leaf/srx |
+| Y6 | NVIDIA Cumulus rewrite to NVUE (5.x): real `nv set qos roce` lossless config (N-C1 — GPU fabric currently lossy, §6.5 violation), auto ASN/loopback assignment, valid per-port FRR neighbors from the BOM (all spines), drop NCLU/`net add`, valid interface stanzas, drop empty EVPN or add VNIs | [ ] | `configgen.ts` cumulus generators |
+| Y7 | Firewall↔fabric integration: emit FW-facing spine/dist ports + design-specific FTD INSIDE-NETS (manifest currently byte-identical across use cases) | [ ] | `configgen.ts` spine/dist + `ciscoFtdFirewallConfig` |
+
+---
+
 ## 23. Autonomous "Start Improving" Mode (2026-06-11 →)
 
 ### Purpose

--- a/frontend/src/lib/configgen.ts
+++ b/frontend/src/lib/configgen.ts
@@ -230,9 +230,10 @@ ${nxosIsisIpv6AddressFamily(ipv6Underlay, true)}  log-adjacency-changes
 ! ── BGP / EVPN OVERLAY ───────────────────────────────────────────────────────
 router bgp ${spineAsn}
   router-id ${routerId}
+  bestpath as-path multipath-relax
   log-neighbor-changes
   address-family ipv4 unicast
-    maximum-paths ibgp 64
+    maximum-paths 64
     redistribute direct route-map CONNECTED-TO-BGP
   address-family l2vpn evpn
     retain route-target all
@@ -240,14 +241,19 @@ router bgp ${spineAsn}
   ! eBGP EVPN spine — peer template holds the common config; each leaf
   ! neighbor sets its own remote-as (unique leaf ASN). No route-reflector-
   ! client (that is iBGP-only; this is an eBGP Clos fabric per RFC 7938).
+  ! ebgp-multihop: loopback-to-loopback eBGP is 2 hops (Y1).
+  ! NH-UNCHANGED: the spine must NOT rewrite the EVPN next-hop to itself —
+  ! it is not a VTEP; leaves must tunnel directly to the remote VTEP (Y1).
   template peer LEAF-PEER
     update-source loopback0
+    ebgp-multihop 2
     timers 3 9
     bfd
     address-family ipv4 unicast
       soft-reconfiguration inbound always
     address-family l2vpn evpn
       send-community both
+      route-map NH-UNCHANGED out
   !
   ! ── Leaf eBGP peers (auto-generated from the fabric) ──────────────────────
 ${spineBgpNeighbors}
@@ -281,7 +287,10 @@ route-map CONNECTED-TO-ISIS permit 10
   match tag 100
 route-map CONNECTED-TO-BGP  permit 10
   match ip address prefix-list LOOPBACKS
+route-map NH-UNCHANGED permit 10
+  set ip next-hop unchanged
 ip prefix-list LOOPBACKS seq 5 permit 10.255.0.0/16 ge 32
+ip prefix-list LOOPBACKS seq 10 permit 10.254.0.0/16 ge 32
 `
 }
 
@@ -538,7 +547,10 @@ vrf context TENANT-A
   vni 50000
   rd auto
   address-family ipv4 unicast
-    route-target both auto evpn${dciL3RtLines}
+    ! Explicit fabric-wide RTs (65000:<vni>) — auto-RT derives ASN:VNI, and
+    ! with unique per-leaf eBGP ASNs no leaf would import any other leaf (Y1).
+    route-target import 65000:50000 evpn
+    route-target export 65000:50000 evpn${dciL3RtLines}
 !
 vlan 10
   name SERVERS
@@ -589,17 +601,19 @@ ${nxosIsisIpv6AddressFamily(ipv6Underlay)}  log-adjacency-changes
 ! ── BGP / EVPN ───────────────────────────────────────────────────────────────
 router bgp ${leafAsn}
   router-id ${routerId}
+  bestpath as-path multipath-relax
   log-neighbor-changes
   address-family ipv4 unicast
     network ${routerId}/32
     network ${vtepIp}/32
     network ${vpcVtepVip}/32
-    maximum-paths ibgp 64
+    maximum-paths 64
   address-family l2vpn evpn
   !
   template peer SPINE-PEER
     remote-as 65000
     update-source loopback0
+    ebgp-multihop 2
     timers 3 9
     bfd
     address-family ipv4 unicast
@@ -623,8 +637,8 @@ interface nve1
 evpn
   vni 10010 l2
     rd auto
-    route-target import auto
-    route-target export auto${dciL2RtLines}
+    route-target import 65000:10010
+    route-target export 65000:10010${dciL2RtLines}
 !
 ! ── UPLINKS (topology-driven from BOM port-math) ─────────────────────────────
 ${fabricLinks}
@@ -1033,14 +1047,20 @@ management ssh
   idle-timeout 10
   authentication mode password
 !
-! ── MANAGEMENT INTERFACE ─────────────────────────────────────────────────────
+! ── MANAGEMENT INTERFACE (OOB, dedicated VRF) ───────────────────────────────
+vrf instance MGMT
+!
 interface Management1
   description OOB-MANAGEMENT
+  vrf MGMT
   ip address <CHANGE-ME-mgmt-ip>/24
 !
 ip route vrf MGMT 0.0.0.0/0 <CHANGE-ME-oob-gateway>
 !
 ! ── ROUTING: IS-IS underlay (single protocol — no OSPF) ─────────────────────
+! EOS defaults to L2-only — without ip routing the box will not forward (Y1).
+ip routing
+ip routing vrf MGMT
 service routing protocols model multi-agent
 !
 router isis UNDERLAY
@@ -1073,6 +1093,7 @@ router bgp ${asn}
   neighbor LEAF-PEER peer group
   neighbor LEAF-PEER update-source Loopback0
   neighbor LEAF-PEER bfd
+  neighbor LEAF-PEER ebgp-multihop 3
   neighbor LEAF-PEER send-community extended
   neighbor LEAF-PEER maximum-routes 12000
   ! ── Leaf eBGP peers (auto-generated from the fabric) ──────────────────────
@@ -1155,6 +1176,20 @@ ntp server <CHANGE-ME-ntp-primary> prefer iburst
 ntp server <CHANGE-ME-ntp-secondary> iburst
 ntp source Management1
 !
+! ── MANAGEMENT INTERFACE (OOB, dedicated VRF) ───────────────────────────────
+vrf instance MGMT
+!
+interface Management1
+  description OOB-MANAGEMENT
+  vrf MGMT
+  ip address <CHANGE-ME-mgmt-ip>/24
+!
+ip route vrf MGMT 0.0.0.0/0 <CHANGE-ME-oob-gateway>
+!
+! EOS defaults to L2-only — without ip routing the box will not forward (Y1).
+ip routing
+ip routing vrf MGMT
+!
 ! ── IS-IS UNDERLAY (single protocol) ────────────────────────────────────────
 router isis UNDERLAY
   net 49.0001.${isisNet}.00
@@ -1184,13 +1219,14 @@ vlan 10
 router bgp ${leafAsn}
   router-id ${routerId}
   no bgp default ipv4-unicast
-  maximum-paths 4
+  maximum-paths 64 ecmp 64
   !
   ! eBGP EVPN leaf — flat EOS peer-group syntax; all spines share ASN 65000.
   neighbor SPINE-PEER peer group
   neighbor SPINE-PEER remote-as 65000
   neighbor SPINE-PEER update-source Loopback0
   neighbor SPINE-PEER bfd
+  neighbor SPINE-PEER ebgp-multihop 3
   neighbor SPINE-PEER send-community extended
   neighbor SPINE-PEER maximum-routes 12000
   ! ── Spine eBGP peers (auto-generated from the fabric) ─────────────────────
@@ -2238,6 +2274,13 @@ ${hasVoice ? `vlan 20
   if (isDist) {
     const stpPriority = isPrimary ? 4096 : 8192
     const hsrpPriority = isPrimary ? 110 : 90
+    // Deterministic router-id loopback (campus dist range 10.255.3.x) — V-12
+    // flagged OSPF routers with no loopback interface.
+    const lo0ip = `10.255.3.${idx + 1}`
+    // Peer-link members on the two ports just below the uplinks (same
+    // convention as the DC vPC/MLAG peer-links, X7).
+    const plPort1 = Math.max(1, (dev.ports || 48) - (dev.uplinks || 0) - 1)
+    const plPort2 = plPort1 + 1
     const igmpBlock = needsIgmp ? `
 ! ── IGMP SNOOPING / QUERIER (voice/video app types present) ──────────────────
 ip igmp snooping
@@ -2290,19 +2333,35 @@ interface Vlan10
 ${voiceSvi}!
 track 1 interface <CHANGE-ME-uplink-to-core> line-protocol
 !
+! ── LOOPBACK (router-id) ─────────────────────────────────────────────────────
+interface Loopback0
+  description ROUTER-ID
+  ip address ${lo0ip} 255.255.255.255
+!
 ! ── UNDERLAY: OSPF only (no IS-IS on campus) ─────────────────────────────────
 router ospf 1
-  router-id <CHANGE-ME-router-id>
+  router-id ${lo0ip}
   passive-interface default
   no passive-interface <CHANGE-ME-uplink-to-core>
+  network ${lo0ip} 0.0.0.0 area 0
   network <CHANGE-ME-vlan10-ip> <CHANGE-ME-wildcard> area 0
   area 0 authentication message-digest
 !
 ! ── PEER LINK to ${peerHostname} (L2 trunk for SVI / HSRP heartbeat) ─────────
-! interface Port-channel${pairId}
-!   description PEER-LINK to ${peerHostname}
-!   switchport mode trunk
-!   switchport trunk allowed vlan 10,20,99
+interface Port-channel${pairId}
+  description PEER-LINK to ${peerHostname}
+  switchport mode trunk
+  switchport trunk allowed vlan 10,20,99
+!
+interface TenGigabitEthernet1/0/${plPort1}
+  description PEER-LINK member 1 to ${peerHostname}
+  switchport mode trunk
+  channel-group ${pairId} mode active
+!
+interface TenGigabitEthernet1/0/${plPort2}
+  description PEER-LINK member 2 to ${peerHostname}
+  switchport mode trunk
+  channel-group ${pairId} mode active
 !
 ${igmpBlock}
 `

--- a/frontend/src/test/configgen.test.ts
+++ b/frontend/src/test/configgen.test.ts
@@ -606,19 +606,23 @@ describe('Multisite EVPN DCI route-targets (Enterprise upgrade A7)', () => {
     expect(generateConfig(aristaLeaf(), 0, 'dc')).not.toContain('65100:')
   })
 
-  it('multisite NX-OS leaf: DCI RTs on L3VNI VRF and L2VNI MAC-VRF alongside auto RTs', () => {
+  it('multisite NX-OS leaf: DCI RTs on L3VNI VRF and L2VNI MAC-VRF alongside site RTs', () => {
     const cfg = generateConfig(nxosLeaf(), 0, 'multisite')
-    expect(cfg).toContain('route-target both auto evpn')
+    // Explicit fabric-wide site RTs (Y1: auto-RT derives ASN:VNI, which never
+    // matches across unique per-leaf eBGP ASNs)
+    expect(cfg).toContain('route-target import 65000:50000 evpn')
+    expect(cfg).toContain('route-target export 65000:50000 evpn')
     expect(cfg).toContain('route-target import 65100:50000 evpn')
     expect(cfg).toContain('route-target export 65100:50000 evpn')
     expect(cfg).toContain('route-target import 65100:10010')
     expect(cfg).toContain('route-target export 65100:10010')
   })
 
-  it('NX-OS leaf always has an EVPN MAC-VRF block with auto RTs and correct NVE VNI roles', () => {
+  it('NX-OS leaf always has an EVPN MAC-VRF block with fabric-wide RTs and correct NVE VNI roles', () => {
     const cfg = generateConfig(nxosLeaf(), 0, 'dc')
     expect(cfg).toContain('vni 10010 l2')
-    expect(cfg).toContain('route-target import auto')
+    expect(cfg).toContain('route-target import 65000:10010')
+    expect(cfg).not.toContain('route-target import auto')
     // L2VNI gets ingress-replication; L3VNI gets associate-vrf (CLAUDE.md §10)
     expect(cfg).toMatch(/member vni 10010\n\s+ingress-replication protocol bgp/)
     expect(cfg).toContain('member vni 50000 associate-vrf')
@@ -1222,5 +1226,70 @@ describe('vPC / MLAG peer-link data plane (group X7)', () => {
     // SHARED anycast VTEP: both members use the same Loopback1 IP (audit A-M4)
     expect(c1).toMatch(/interface Loopback1[\s\S]*?ip address 10\.254\.0\.1\/32/)
     expect(c2).toMatch(/interface Loopback1[\s\S]*?ip address 10\.254\.0\.1\/32/)
+  })
+})
+
+// ── Y1: overlay-establishment parity (2nd-pass audit) ───────────────────────────
+
+describe('eBGP overlay establishment parity (group Y1)', () => {
+  function nxFabric() {
+    const devices: BOMDevice[] = [
+      makeDevice({ id: 's1', hostname: 'DC-SPINE-A01', vendor: 'Cisco', subLayer: 'spine', role: 'spine' }),
+      makeDevice({ id: 'l1', hostname: 'DC-LEAF-A01', vendor: 'Cisco', subLayer: 'leaf', role: 'leaf' }),
+    ]
+    return generateAllConfigs(devices, 'dc')
+  }
+
+  it('NX-OS: ebgp-multihop on both peer templates (loopback eBGP never established without it)', () => {
+    const c = nxFabric()
+    expect(c['s1']).toMatch(/template peer LEAF-PEER[\s\S]*?ebgp-multihop 2/)
+    expect(c['l1']).toMatch(/template peer SPINE-PEER[\s\S]*?ebgp-multihop 2/)
+  })
+
+  it('NX-OS spine preserves the EVPN next-hop (NH-UNCHANGED out) — spine is not a VTEP', () => {
+    const c = nxFabric()
+    expect(c['s1']).toMatch(/address-family l2vpn evpn\n\s+send-community both\n\s+route-map NH-UNCHANGED out/)
+    expect(c['s1']).toMatch(/route-map NH-UNCHANGED permit 10\n\s+set ip next-hop unchanged/)
+  })
+
+  it('NX-OS: eBGP ECMP (maximum-paths 64 + as-path multipath-relax), not ibgp-only', () => {
+    const c = nxFabric()
+    for (const cfg of [c['s1'], c['l1']]) {
+      expect(cfg).toMatch(/maximum-paths 64/)
+      expect(cfg).not.toMatch(/maximum-paths ibgp/)
+      expect(cfg).toMatch(/bestpath as-path multipath-relax/)
+    }
+  })
+
+  it('NX-OS: LOOPBACKS prefix-list covers the VTEP range 10.254/16', () => {
+    const c = nxFabric()
+    expect(c['s1']).toMatch(/ip prefix-list LOOPBACKS seq 10 permit 10\.254\.0\.0\/16 ge 32/)
+  })
+
+  it('Arista: ip routing enabled (EOS is L2-only by default) + MGMT VRF actually exists', () => {
+    const spine = generateConfig(makeDevice({ hostname: 'DC-SPINE-A01', vendor: 'Arista', subLayer: 'spine', role: 'spine' }), 0, 'dc')
+    const leaf = generateConfig(makeDevice({ hostname: 'DC-LEAF-A01', vendor: 'Arista', subLayer: 'leaf', role: 'leaf' }), 0, 'dc')
+    for (const cfg of [spine, leaf]) {
+      expect(cfg).toMatch(/^ip routing$/m)
+      expect(cfg).toMatch(/^vrf instance MGMT$/m)
+      expect(cfg).toMatch(/interface Management1\n\s+description OOB-MANAGEMENT\n\s+vrf MGMT/)
+    }
+  })
+
+  it('Arista: ebgp-multihop on both peer groups + full-width leaf ECMP', () => {
+    const spine = generateConfig(makeDevice({ hostname: 'DC-SPINE-A01', vendor: 'Arista', subLayer: 'spine', role: 'spine' }), 0, 'dc')
+    const leaf = generateConfig(makeDevice({ hostname: 'DC-LEAF-A01', vendor: 'Arista', subLayer: 'leaf', role: 'leaf' }), 0, 'dc')
+    expect(spine).toMatch(/neighbor LEAF-PEER ebgp-multihop 3/)
+    expect(leaf).toMatch(/neighbor SPINE-PEER ebgp-multihop 3/)
+    expect(leaf).toMatch(/maximum-paths 64 ecmp 64/)
+  })
+
+  it('campus distribution now has a loopback + real peer-link (V-12 / C-2)', () => {
+    const dist = generateConfig(makeDevice({ hostname: 'IAD-DIST-A01', vendor: 'Cisco', subLayer: 'distribution', role: 'distribution', ports: 48, uplinks: 4 }), 0, 'campus')
+    expect(dist).toMatch(/interface Loopback0\n\s+description ROUTER-ID\n\s+ip address 10\.255\.3\.1 255\.255\.255\.255/)
+    expect(dist).toMatch(/router ospf 1\n\s+router-id 10\.255\.3\.1/)
+    expect(dist).toMatch(/^interface Port-channel1$/m)
+    expect(dist).not.toMatch(/^! interface Port-channel/m)
+    expect(dist).toMatch(/interface TenGigabitEthernet1\/0\/43[\s\S]*?channel-group 1 mode active/)
   })
 })


### PR DESCRIPTION
## Context

A **second-pass architect audit** of the post-group-X output (fresh dumps, same review method) confirmed all group-X fixes held — and identified the next tier. The dominant theme: **fix-parity gaps**, where each first-audit fix landed on some vendors but not others. The full audit is recorded as tracker **group Y** (Y2–Y7 scoped with severities); this PR lands Y1, the "fabric dead on arrival" criticals.

## Changes

**NX-OS**
- `ebgp-multihop 2` on both peer templates — loopback-to-loopback eBGP never establishes without it (the exact class of bug X4 fixed for Juniper; the NX-OS side was missed).
- Spine **`NH-UNCHANGED` route-map out** on the EVPN address-family (`set ip next-hop unchanged`) — the spine is not a VTEP; by default it rewrites the EVPN next-hop to itself, so leaves would tunnel VXLAN to a spine loopback and blackhole everything.
- **Explicit fabric-wide route-targets `65000:<vni>`** replacing `route-target … auto` — auto-RT derives `ASN:VNI`, and with unique per-leaf eBGP ASNs no leaf ever imports another leaf's routes. EVPN would carry zero usable state even with sessions up.
- Real eBGP ECMP: `maximum-paths 64` (was `ibgp`-only on an eBGP fabric) + `bestpath as-path multipath-relax` (the vPC anycast VIP is advertised from two different ASNs).
- `LOOPBACKS` prefix-list now covers the VTEP `10.254/16` range.

**Arista**
- **`ip routing`** (+ `ip routing vrf MGMT`) — EOS defaults to L2-only; the fabric ran IS-IS/BGP in the control plane but did not forward a single packet.
- `vrf instance MGMT` actually created and `Management1` joined to it (the static route and eAPI referenced a VRF that never existed); the leaf gains its entirely missing `interface Management1` block.
- `ebgp-multihop 3` on both peer groups; leaf `maximum-paths 64 ecmp 64` (was 4 on a 6-spine fabric).

**Campus IOS-XE**
- Distribution gains `interface Loopback0` (deterministic `10.255.3.x` router-id, advertised in OSPF) — clears the standing V-12 validator warning.
- Real inter-distribution peer-link Port-channel + two TenGig members (was commented out — same defect class the first audit flagged on NX-OS vPC).

## Testing
- 7 new tests (NX-OS multihop / NH-unchanged / ECMP / prefix-list, Arista ip-routing + MGMT VRF + multihop + ECMP, campus loopback + real peer-link); 2 tests rewritten that had asserted the auto-RT bug.
- Full suite **1,189 tests** pass, `tsc --noEmit` clean, `npm run build` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DiH1v2ufYHuupbP4xn6pPb)_