### PR TITLE
fix: device I/O must fail closed, not silently simulate

### DIFF
--- a/backend/jobs/deploy_job.py
+++ b/backend/jobs/deploy_job.py
@@ -200,10 +200,15 @@ def _run_pipeline(
     try:
         deploy_results = deploy_configs(configs, inventory, dry_run, deployment_id)
         deploy_ok = deploy_results.get("success", False)
+        # A refusal carries a `reason` (no device I/O, no inventory). Surface it
+        # verbatim — "Deploy encountered errors" sent operators hunting through
+        # device logs for a fault that was actually on the server.
+        reason = deploy_results.get("reason")
         _publish_event(
             r_client, deployment_id, "deploy",
             "success" if deploy_ok else "failed",
-            "Configs pushed successfully" if deploy_ok else "Deploy encountered errors",
+            "Configs pushed successfully" if deploy_ok
+            else (reason or "Deploy encountered errors"),
             {"results": deploy_results},
         )
     except Exception as exc:

--- a/backend/nornir_tasks.py
+++ b/backend/nornir_tasks.py
@@ -122,6 +122,16 @@ def _simulate_check(host: str, check: str, passed: bool = True) -> dict[str, Any
     return {"host": host, "check": check, "passed": passed, "detail": "simulated"}
 
 
+# A real inventory was supplied but the device libraries are not importable.
+# This is an ENVIRONMENT FAULT, never a simulation: silently "passing" these
+# checks told an operator their fleet had been backed up and configured when
+# nothing had been touched at all.
+NO_DEVICE_IO = (
+    "Nornir/Netmiko not installed on the server - cannot reach devices. "
+    "Install backend/requirements.txt; nothing was read from or written to this device."
+)
+
+
 # ─────────────────────────────────────────────
 # Pre-checks
 # ─────────────────────────────────────────────
@@ -175,8 +185,12 @@ def run_pre_checks(
             continue
 
         if not NORNIR_AVAILABLE:
+            # Fail CLOSED. config_backup in particular must never report a
+            # pass it did not earn - rollback restores from that file, so a
+            # phantom backup leaves the deploy with no restore target.
             for c in ["ssh_login", "version_check", "config_backup"]:
-                results.append(_simulate_check(host_name, c))
+                results.append({"host": host_name, "check": c,
+                                "passed": False, "detail": NO_DEVICE_IO})
             continue
 
         # 2–3. SSH checks via Nornir
@@ -412,11 +426,15 @@ def run_post_checks(state: dict[str, Any], inventory: dict[str, Any]) -> list[di
         platform = host_data.get("platform", "cisco_ios")
         commands = _POST_CHECK_COMMANDS.get(platform, _POST_CHECK_COMMANDS["cisco_ios"])
 
-        if not NORNIR_AVAILABLE or not _icmp_reachable(host_data.get("hostname", host_name)):
+        reachable = _icmp_reachable(host_data.get("hostname", host_name))
+        if not NORNIR_AVAILABLE or not reachable:
+            why = NO_DEVICE_IO if not NORNIR_AVAILABLE else "device unreachable on TCP/22"
             for cmd in commands:
-                results.append(_simulate_check(host_name, cmd[:40], passed=False))
+                results.append({"host": host_name, "check": cmd[:40],
+                                "passed": False, "detail": why})
             for check in ["lldp_neighbors", "ecn_thresholds", "pfc_counters", "mtu_ping_9000"]:
-                results.append(_simulate_check(host_name, check, passed=False))
+                results.append({"host": host_name, "check": check,
+                                "passed": False, "detail": why})
             continue
 
         try:
@@ -558,12 +576,17 @@ def deploy_configs(
         for host_name, config in configs.items():
             results[host_name] = {"status": "skipped", "detail": "no inventory"}
         results["success"] = False
+        results["reason"] = "No inventory supplied - there is nothing to push to."
         return results
 
     if not NORNIR_AVAILABLE:
+        # Previously this returned success=True with every host "simulated",
+        # so an operator who explicitly asked for a real push (dry_run=False)
+        # got a green deployment and an unchanged fleet.
         for host_name in configs:
-            results[host_name] = {"status": "simulated", "detail": "Nornir not installed"}
-        results["success"] = True
+            results[host_name] = {"status": "no_device_io", "detail": NO_DEVICE_IO}
+        results["success"] = False
+        results["reason"] = NO_DEVICE_IO
         return results
 
     for host_name, config in configs.items():

--- a/backend/tests/test_device_io_fails_closed.py
+++ b/backend/tests/test_device_io_fails_closed.py
@@ -1,0 +1,112 @@
+"""
+Device I/O must fail CLOSED.
+
+The bug these tests pin: when Nornir/Netmiko were not importable on the
+server, `deploy_configs` marked every host "simulated" and still returned
+`success: True`, and `run_pre_checks` reported ssh_login / version_check /
+config_backup as PASSED. An operator who explicitly asked for a real push
+(dry_run=False) against real inventory therefore saw a green deployment, a
+config backup that was never written, and an unchanged fleet.
+
+Simulation is a legitimate mode — but only when there is no inventory to act
+on. The moment real inventory is supplied, a missing device library is an
+environment fault and must be reported as one.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import nornir_tasks as nt
+
+
+INVENTORY = {
+    "leaf-01": {"hostname": "10.0.0.11", "platform": "nxos"},
+    "leaf-02": {"hostname": "10.0.0.12", "platform": "nxos"},
+}
+CONFIGS = {"leaf-01": "hostname leaf-01\n", "leaf-02": "hostname leaf-02\n"}
+
+
+@pytest.fixture
+def no_device_io(monkeypatch):
+    """Simulate a server where the device libraries failed to install."""
+    monkeypatch.setattr(nt, "NORNIR_AVAILABLE", False)
+
+
+# ── deploy ────────────────────────────────────────────────────────────────
+
+def test_deploy_refuses_when_device_io_unavailable(no_device_io):
+    res = nt.deploy_configs(CONFIGS, INVENTORY, dry_run=False)
+
+    assert res["success"] is False, "a push that touched nothing reported success"
+    assert "reason" in res and "Nornir" in res["reason"]
+    for host in CONFIGS:
+        assert res[host]["status"] == "no_device_io"
+        assert res[host]["status"] != "simulated"
+
+
+def test_deploy_refuses_without_inventory_and_says_why():
+    res = nt.deploy_configs(CONFIGS, {}, dry_run=False)
+    assert res["success"] is False
+    assert "inventory" in res["reason"].lower()
+
+
+def test_dry_run_still_succeeds_without_touching_anything(no_device_io):
+    """dry_run is an explicit request to validate only — it is not a failure."""
+    res = nt.deploy_configs(CONFIGS, INVENTORY, dry_run=True)
+    assert res["success"] is True
+    for host in CONFIGS:
+        assert res[host]["status"] == "dry_run"
+
+
+# ── pre-checks ────────────────────────────────────────────────────────────
+
+def test_pre_checks_never_claim_a_backup_they_did_not_take(no_device_io, monkeypatch):
+    # Reachability is a plain TCP probe and works without Nornir, so make the
+    # hosts reachable — that is exactly the path that used to fake a backup.
+    monkeypatch.setattr(nt, "_icmp_reachable", lambda *a, **k: True)
+
+    results = nt.run_pre_checks({}, INVENTORY, deployment_id="t1")
+    backups = [r for r in results if r["check"] == "config_backup"]
+
+    assert backups, "no config_backup check was emitted"
+    for r in backups:
+        assert r["passed"] is False, (
+            "config_backup passed with no device I/O — rollback would have had "
+            "no restore target"
+        )
+        assert "Nornir" in r["detail"]
+
+    for r in results:
+        if r["check"] in ("ssh_login", "version_check"):
+            assert r["passed"] is False
+
+
+def test_pre_checks_still_simulate_when_there_is_no_inventory():
+    """Demo mode is intentional: nothing real was claimed, nothing was touched."""
+    results = nt.run_pre_checks({}, {})
+    assert results and all(r["passed"] for r in results)
+    assert all(r["host"] == "demo-device" for r in results)
+
+
+# ── post-checks ───────────────────────────────────────────────────────────
+
+def test_post_checks_distinguish_env_fault_from_unreachable(no_device_io, monkeypatch):
+    monkeypatch.setattr(nt, "_icmp_reachable", lambda *a, **k: True)
+    results = nt.run_post_checks({"uc": "dc"}, INVENTORY)
+
+    assert results and all(r["passed"] is False for r in results)
+    # the detail must name the server-side fault, not say "simulated"
+    assert all("Nornir" in r["detail"] for r in results)
+    assert not any(r["detail"] == "simulated" for r in results)
+
+
+def test_post_checks_say_unreachable_when_that_is_the_real_cause(monkeypatch):
+    monkeypatch.setattr(nt, "NORNIR_AVAILABLE", True)
+    monkeypatch.setattr(nt, "_icmp_reachable", lambda *a, **k: False)
+
+    results = nt.run_post_checks({"uc": "dc"}, INVENTORY)
+    assert results and all(r["passed"] is False for r in results)
+    assert all("unreachable" in r["detail"] for r in results)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -210,11 +210,13 @@ Day-0 templates exist for all 12 platforms.
 
 1. `DeployRequest.dry_run` defaults to `true`. Nothing is pushed unless the
    caller explicitly sends `false`.
-2. **A deploy can report success while touching nothing.** If Nornir is not
-   importable, `deploy_configs` marks every host `"simulated"` and still sets
-   `success: True`; pre-checks do the same when given no inventory. In a
-   container where the netmiko install silently failed, an operator gets a
-   green deployment and an unchanged fleet.
+2. ~~A deploy can report success while touching nothing.~~ **Fixed.** Device
+   I/O now fails *closed*: with real inventory supplied, a missing Nornir is
+   an environment fault, not a simulation. `deploy_configs` returns
+   `success: False` with a `reason`, pre-checks mark `config_backup` FAILED
+   rather than claiming a backup that was never written, and the deploy event
+   surfaces the reason verbatim. Simulation still happens when there is no
+   inventory at all — that is demo mode, and it claims nothing.
 3. None of the device-facing path is verified against real hardware by the
    test suite. It is dependency-complete and unit-tested, which is not the
    same as proven against a real chassis.


### PR DESCRIPTION
The bug I flagged while answering "can it log into live devices?" — worth fixing properly, because the failure mode is silent and points the operator at the wrong system.

## What went wrong

When Nornir/Netmiko were not importable on the server, with **real inventory supplied** and **`dry_run=False`**:

```python
if not NORNIR_AVAILABLE:
    for host_name in configs:
        results[host_name] = {"status": "simulated", "detail": "Nornir not installed"}
    results["success"] = True     # ← green deploy, zero devices touched
```

`run_pre_checks` did the same, marking `ssh_login`, `version_check` **and `config_backup`** as PASSED.

The phantom backup is the worst part. `_initiate_rollback` restores from that file — so the deploy reported a clean backup, pushed nothing, and had no restore target if anything had gone wrong.

## The distinction that fixes it

Simulation is a legitimate mode, but **only when there is no inventory to act on**. The moment real inventory is supplied, a missing device library is an environment fault and must be reported as one.

| Situation | Before | After |
|---|---|---|
| `dry_run=True` | success, `"dry_run"` | unchanged — an explicit request to validate only |
| No inventory | `success: False` | unchanged, plus a `reason` |
| **Real inventory, no Nornir** | **`success: True`, `"simulated"`** | **`success: False`, `"no_device_io"` + `reason`** |
| Pre-checks, real inventory, no Nornir | **all PASSED** | **all FAILED**, reason as detail |
| Post-checks, unreachable device | failed, detail `"simulated"` | failed, detail names the actual cause |

`deploy_job` now surfaces the reason verbatim instead of "Deploy encountered errors" — which sent operators hunting through device logs for a fault that was on the server.

## Verification

7 new tests in `test_device_io_fails_closed.py`. Reverting either half of the fix trips them:

```
assert res["success"] is False, "a push that touched nothing reported success"
E   assert True is False

AssertionError: config_backup passed with no device I/O — rollback would have
had no restore target
```

Two tests deliberately pin the behaviour that should *not* change: `dry_run` still succeeds, and no-inventory still simulates.

Backend suite **346 → 353 passed**. Frontend untouched at 1,323.

`docs/ARCHITECTURE.md` updated — the sharp-edges list now records this as fixed rather than outstanding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DiH1v2ufYHuupbP4xn6pPb

---
_Generated by [Claude Code](https://claude.ai/code/session_01DiH1v2ufYHuupbP4xn6pPb)_