### PR TITLE
fix: AD1 — the O-RAN fronthaul was broken by construction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1161,6 +1161,60 @@ config-gen tests must keep passing; add new tests alongside).
 "Two bugs found while building it: SVG `<marker>` content does not resolve `currentColor` (it inherits from `<defs>`, not the referencing element) so the arrowheads were invisible — now explicit fills; and the fabric caption rendered the raw store enum `vxlan_evpn`, which a new `overlayLabel()` helper now formats as `VXLAN/EVPN` in all three places it appeared. 6 tests | [x] | `HLDTopologyDiagram.tsx`; `HLDTopologyDiagram.test.tsx` 20→26; 1354 tests |
 | AC2 | **Tier bifurcation applied to every remaining builder** — campus (CORE / DISTRIBUTION / ACCESS / END USERS + a `CAMPUS LAN` region captioned with the IGP and FHRP), GPU (SPINE / ToR / GPU COMPUTE / STORAGE + `LOSSLESS FABRIC` captioned RoCEv2 · PFC pri-3 · ECN/DCQCN, and an EAST–WEST RDMA rail), WAN (SERVICE PROVIDER / HUB / WAN EDGE / BRANCH + `WAN OVERLAY`), O-RAN (5GC / O-CU / FRONTHAUL SW / O-DU / O-RU + a `FRONTHAUL` region captioned eCPRI 7.2x · PTP G.8275.1). All eight use cases are now covered, since multisite/multicloud/aviatrix route through the DC builder. **The BORDER LEAF callout is gated to `dc`/`multisite`** — multicloud and aviatrix reuse that builder but have no on-prem border pair, so the callout would name devices their design does not contain. New tests: a per-use-case tier/region matrix, every use case draws at least one traffic axis, and a sweep asserting **no builder leaks a raw store enum** (`vxlan_evpn`) into any caption | [x] | `HLDTopologyDiagram.tsx`; `HLDTopologyDiagram.test.tsx` 26→32; 1361 tests, tsc + build green |
 
+### AD. Non-DC config correctness — 5th-pass audit (sourced 2026-08-22)
+
+> Audits 1–3 (groups X/Y/Z) reviewed DC / GPU / campus **configs**. Group AA
+> reviewed the non-DC use cases' **BOM and cabling** but never the configs
+> those designs generate. This pass dumps WAN, multisite, multicloud, Aviatrix
+> and O-RAN artifacts and reviews them the way an architect would.
+>
+> Both structural themes from the 3rd-pass audit recur, in new places:
+> **fix-parity** (the Z5 "identity is tier-scoped" fix never reached the
+> O-RAN or SD-WAN generators) and **BOM↔config disagreement** (the fronthaul
+> switch hardcodes a VLAN the radios attached to it never learn).
+>
+> **Findings:**
+> - **CRIT (O-5)** `oranFronthaulConfig` sets the eCPRI VLAN to `idx + 100`
+>   — the GLOBAL device index. In a 41-device design the two fronthaul
+>   switches at one cell site came out as VLAN **134** and **135**, so a
+>   radio homed to one switch and its DU reached via the other are on
+>   different fronthaul VLANs. The defining link of the architecture is
+>   broken by construction.
+> - **CRIT (W-1)** `sdwanEdgeConfig` emits **vEdge / Viptela OS** CLI
+>   (top-level `vpn 0`, `system-ip`, `omp`) but the header claims IOS-XE
+>   SD-WAN, and two of the three SD-WAN SKUs — the ASR 1002-HX (the default
+>   WAN edge) and the Catalyst 8300 (the new AA2 cloud on-ramp) — are cEdges
+>   running IOS-XE, where that syntax does not exist.
+> - **MAJOR (O-3)** all 24 O-RUs in the dump were byte-identical apart from
+>   the hostname: no `ru-id`, no cell identity, and **no PCI**. PCI planning
+>   is the defining O-RU parameter and PCI collision is the classic 5G RAN
+>   outage.
+> - **MAJOR (O-4)** the O-RU and O-DU carry `<CHANGE-ME-ecpri-vlan>` while
+>   the switch they attach to hardcodes a concrete VLAN — the two ends of
+>   the fronthaul disagree.
+> - **MAJOR (O-1/O-2)** `gnb-cu-id`, `gnb-du-id` and the midhaul router-id /
+>   IS-IS NET all derive from the global device index (DU ids started at 3
+>   because two CUs preceded them); every DU shares one `<CHANGE-ME-du-f1c-ip>`
+>   and points at one `<CHANGE-ME-cu-f1c-ip>` although the design has two CUs.
+> - **MAJOR (W-2/W-3/W-4)** the SD-WAN edge configures NTP and syslog twice,
+>   in two dialects, with different placeholders (AA1 added the `system`-block
+>   services without removing the trailing ones); opens the top-level `policy`
+>   container three times; and mixes vEdge `policy / zone-based-fw` with
+>   IOS-XE `zone security` / `zone-pair` in one file.
+> - **MINOR (W-8)** OMP advertises `ospf external` with no OSPF anywhere.
+> - **MINOR (M-1)** the validator classifies multicloud/aviatrix as a
+>   VXLAN/EVPN fabric, so a clean design reports a hard V-03 FAIL
+>   ("requires BGP for EVPN/VXLAN"). Latent until AA2 gave those designs
+>   configs to validate.
+
+| # | Item | Status | Notes |
+|---|------|--------|-------|
+| AD1 | **O-RAN fronthaul coherence + cell identity** (O-1..O-5) — (1) **the critical one**: the eCPRI VLAN was `idx + 100`, the switch's GLOBAL device index, so the two fronthaul switches at one site came out as VLAN **134 and 135** while the radios and DUs carried `<CHANGE-ME-ecpri-vlan>` — the fronthaul was broken by construction and neither end reconciled the other. New exported `ORAN_FRONTHAUL_VLAN`/`ORAN_PTP_VLAN`/`ORAN_MGMT_VLAN`/`ORAN_PTP_DOMAIN` fabric constants, used by the switch, the O-RU and the O-DU (and the 6 sites that hardcoded `domain 24`, so a PTP-domain split cannot happen the same way). (2) **Cell identity**: all 24 O-RUs were byte-identical apart from the hostname — now `ru-id`, a derived `cell-id`, `served-by <its DU>`, and a **PCI** (`oranPci`, consecutive so neighbours differ mod 3, which is what sets the SSB shift). (3) **Tier-scoped identity** (Z5 parity — the fix never reached these generators): `gnb-cu-id`, `gnb-du-id` and the midhaul router-id/IS-IS NET came from the global index, so DU ids started at 3 and the midhaul routers were numbered 37/38. (4) **Real addressing** via `ipAdd` for CU/DU F1-C/F1-U, RU fronthaul + mgmt, and the switch mgmt SVI — every DU used to share one `<CHANGE-ME-du-f1c-ip>` and point at one `<CHANGE-ME-cu-f1c-ip>` despite two CUs; DUs now home round-robin to a **real** CU address. (5) Writing the invariant surfaced a further truth: past **1008 radios** the PCI space must wrap. Reuse is correct, silent reuse is not — the reusing radio now says so and `validateBOM` raises it at design time. New permanent e2e invariant `assertOranFabricInvariants` (one fronthaul VLAN fleet-wide, unique in-range PCIs or explicit spaced reuse, every DU homed to an address a CU owns). 9 new tests | [x] | `configgen.ts` O-RAN generators + `bom.ts` `validateBOM` + `oran.test.ts` (34→43) + `e2e-journey.test.ts`; 1387 tests, tsc + build green |
+| AD2 | SD-WAN dialect correctness (W-1..W-4, W-8) | [ ] | `configgen.ts` `sdwanEdgeConfig` |
+| AD3 | Validator use-case classification for multicloud/aviatrix (M-1) | [ ] | `config-validator.ts` |
+
+---
+
 ---
 
 ## 23. Autonomous "Start Improving" Mode (2026-06-11 →)

--- a/frontend/src/lib/bom.ts
+++ b/frontend/src/lib/bom.ts
@@ -1165,6 +1165,22 @@ export function validateBOM(
   const uc = state.useCase ?? 'dc'
   const endpoints = state.totalEndpoints ?? 0
 
+  // ── O-RAN radio plan ──
+  // PCI is a 0..1007 identifier (TS 38.211). Past that the plan must reuse,
+  // which is normal in a large deployment but must be a decision, not a
+  // surprise: a PCI collision between cells that can see each other is the
+  // classic 5G RAN outage and is close to invisible once deployed.
+  if (uc === 'oran') {
+    const radios = devices.filter(d => d.subLayer === 'oran-ru').length
+    if (radios > 1008) {
+      issues.push({
+        severity: 'warning',
+        category: 'capacity',
+        message: `${radios} radios exceed the 1008-wide PCI space, so PCIs repeat every 1008 cells. Confirm reusing cells are geographically separated and do not appear in each other's neighbour lists.`,
+      })
+    }
+  }
+
   // ── Budget tier validation ──
   const tier = state.budgetTier
   if (tier && tier in BUDGET_BANDS) {

--- a/frontend/src/lib/configgen.ts
+++ b/frontend/src/lib/configgen.ts
@@ -5172,8 +5172,48 @@ function isIosXrPlatform(dev: BOMDevice): boolean {
 
 // ── O-RAN / Private 5G config generators (G-A10) ─────────────────────────────
 
-function oranCuConfig(dev: BOMDevice, idx: number): string {
-  const cuId = idx + 1
+/**
+ * O-RAN fronthaul is a SHARED broadcast domain, so its VLAN is a property of
+ * the fabric, not of any one switch. `oranFronthaulConfig` used to derive it
+ * from the GLOBAL device index (`idx + 100`), so in a 41-device design the two
+ * fronthaul switches at one cell site came out as VLAN 134 and 135 — a radio
+ * homed to one and its DU reached via the other could never exchange eCPRI.
+ * The radios and DUs carried a `<CHANGE-ME-ecpri-vlan>` placeholder, so
+ * nothing reconciled the two ends either.
+ */
+export const ORAN_FRONTHAUL_VLAN = 134
+export const ORAN_PTP_VLAN = 900
+export const ORAN_MGMT_VLAN = 999
+export const ORAN_PTP_DOMAIN = 24
+
+/** Physical Cell Identity range in 5G NR (TS 38.211): 0..1007. */
+const NR_PCI_MAX = 1008
+
+/**
+ * PCI for the nth radio. Consecutive assignment is deliberate: PCI mod 3 sets
+ * the SSB frequency-domain shift, so neighbouring cells — which are adjacent
+ * in this ordering — land on different shifts. The generated config still
+ * tells the operator to validate the plan against the real neighbour list;
+ * PCI collision/confusion is the classic 5G RAN outage.
+ */
+function oranPci(ruIdx: number): number {
+  return ruIdx % NR_PCI_MAX
+}
+
+/** The CU an O-DU homes to, round-robin over the CUs actually in the BOM. */
+function oranHomeCu(duIdx: number, allDevices: BOMDevice[]): { idx: number; hostname: string } {
+  const cus = allDevices.filter(d => d.subLayer === 'oran-cu')
+  if (!cus.length) return { idx: 0, hostname: '<CHANGE-ME-cu-hostname>' }
+  const i = duIdx % cus.length
+  return { idx: i, hostname: cus[i].hostname }
+}
+
+function oranCuConfig(dev: BOMDevice, idx: number, allDevices: BOMDevice[] = []): string {
+  // Tier-scoped (Z5): the id used to come from the global device index.
+  const cuIdx = roleIndex(dev, allDevices, idx)
+  const cuId = cuIdx + 1
+  const f1cIp = ipAdd('10.240.1.0', cuIdx + 1)
+  const f1uIp = ipAdd('10.240.2.0', cuIdx + 1)
   return `# ═══════════════════════════════════════════════════════════════
 # Device : ${dev.hostname}
 # Role   : O-RAN Centralized Unit (O-CU-CP + O-CU-UP)
@@ -5190,10 +5230,10 @@ cell-id <CHANGE-ME-nci>
 
 # ── F1 Interface (CU ↔ DU) ──────────────────────────────────────────────────
 f1-c:
-  local-address <CHANGE-ME-cu-f1c-ip>
+  local-address ${f1cIp}
   sctp-port 38472
 f1-u:
-  local-address <CHANGE-ME-cu-f1u-ip>
+  local-address ${f1uIp}
   gtp-u-port 2152
 
 # ── E1 Interface (CU-CP ↔ CU-UP) ───────────────────────────────────────────
@@ -5213,7 +5253,7 @@ ng-u:
 # ── PTP Timing (ITU-T G.8275.1 Telecom Profile) ─────────────────────────────
 ptp:
   profile g8275.1
-  domain 24
+  domain ${ORAN_PTP_DOMAIN}
   clock-class slave
   transport ethernet
   announce-interval -3
@@ -5251,8 +5291,17 @@ qos:
 `
 }
 
-function oranDuConfig(dev: BOMDevice, idx: number): string {
-  const duId = idx + 1
+function oranDuConfig(dev: BOMDevice, idx: number, allDevices: BOMDevice[] = []): string {
+  // Tier-scoped (Z5): with two CUs ahead of them in the BOM the DU ids used
+  // to start at 3, and every DU shared one <CHANGE-ME-du-f1c-ip> and pointed
+  // at one <CHANGE-ME-cu-f1c-ip> even though the design has two CUs.
+  const duIdx = roleIndex(dev, allDevices, idx)
+  const duId = duIdx + 1
+  const cu = oranHomeCu(duIdx, allDevices)
+  const duF1c = ipAdd('10.241.1.0', duIdx + 1)
+  const duF1u = ipAdd('10.241.2.0', duIdx + 1)
+  const cuF1c = ipAdd('10.240.1.0', cu.idx + 1)
+  const cuF1u = ipAdd('10.240.2.0', cu.idx + 1)
   return `# ═══════════════════════════════════════════════════════════════
 # Device : ${dev.hostname}
 # Role   : O-RAN Distributed Unit (O-DU)
@@ -5267,18 +5316,19 @@ plmn-id mcc <CHANGE-ME-mcc> mnc <CHANGE-ME-mnc>
 
 # ── F1 Interface (DU → CU) ──────────────────────────────────────────────────
 f1-c:
-  local-address <CHANGE-ME-du-f1c-ip>
-  cu-address <CHANGE-ME-cu-f1c-ip>
+  local-address ${duF1c}
+  cu-address ${cuF1c}            # ${cu.hostname}
   sctp-port 38472
 f1-u:
-  local-address <CHANGE-ME-du-f1u-ip>
-  cu-address <CHANGE-ME-cu-f1u-ip>
+  local-address ${duF1u}
+  cu-address ${cuF1u}            # ${cu.hostname}
   gtp-u-port 2152
 
 # ── eCPRI Fronthaul (DU ↔ RU — O-RAN 7.2x split) ───────────────────────────
 ecpri:
   transport ethernet
-  vlan-id <CHANGE-ME-ecpri-vlan>
+  vlan-id ${ORAN_FRONTHAUL_VLAN}
+  local-address ${ipAdd('10.242.0.0', duIdx + 1)}
   message-type iq-data
   # O-RAN 7.2x lower-layer split: RU handles RF + low-PHY (FFT/beamforming),
   # DU handles high-PHY + MAC + RLC
@@ -5292,7 +5342,7 @@ ecpri:
 # ── PTP Timing (ITU-T G.8275.1 Telecom Profile) ─────────────────────────────
 ptp:
   profile g8275.1
-  domain 24
+  domain ${ORAN_PTP_DOMAIN}
   clock-class slave
   transport ethernet
   sync-interval -4
@@ -5334,7 +5384,27 @@ management:
 `
 }
 
-function oranRuConfig(dev: BOMDevice, _idx: number): string {
+function oranRuConfig(dev: BOMDevice, idx: number, allDevices: BOMDevice[] = []): string {
+  // Every O-RU in the dumped design was byte-identical apart from its
+  // hostname: no ru-id, no cell identity and no PCI. PCI planning is the
+  // defining O-RU parameter and PCI collision is the classic 5G RAN outage.
+  const ruIdx = roleIndex(dev, allDevices, idx)
+  const ruId = ruIdx + 1
+  const pci = oranPci(ruIdx)
+  // PCI reuse across a large deployment is normal and unavoidable — the space
+  // is 1008 wide. Silent reuse is not: say so on the radio that is reusing.
+  const ruTotal = allDevices.filter(d => d.subLayer === 'oran-ru').length
+  const pciReused = ruTotal > NR_PCI_MAX
+    ? `\n# PCI REUSE: this design has ${ruTotal} radios in a 1008-wide PCI space.
+# This PCI repeats every ${NR_PCI_MAX} radios. Confirm the reusing cells are far
+# enough apart that neither appears in the other's neighbour list.`
+    : ''
+  const ruIp = ipAdd('10.242.128.0', ruIdx + 1)
+  const mgmtIp = ipAdd('10.243.0.0', ruIdx + 1)
+  // Each radio homes to a DU; sectors are grouped three to a DU, which is the
+  // ratio buildDeviceList sizes the DU tier with.
+  const dus = allDevices.filter(d => d.subLayer === 'oran-du')
+  const duHost = dus.length ? dus[Math.floor(ruIdx / 3) % dus.length].hostname : '<CHANGE-ME-du-hostname>'
   return `# ═══════════════════════════════════════════════════════════════
 # Device : ${dev.hostname}
 # Role   : O-RAN Radio Unit (O-RU)
@@ -5344,11 +5414,20 @@ function oranRuConfig(dev: BOMDevice, _idx: number): string {
 
 # ── System Identity ──────────────────────────────────────────────────────────
 hostname ${dev.hostname}
+ru-id ${ruId}
+# Physical Cell Identity — 0..1007 (TS 38.211). PCI mod 3 sets the SSB
+# frequency-domain shift, so adjacent radios are given adjacent PCIs and
+# therefore different shifts. VALIDATE this plan against the real neighbour
+# list before go-live: a PCI collision is a silent, hard-to-find outage.${pciReused}
+pci ${pci}
+cell-id <CHANGE-ME-nci-prefix>${String(ruId).padStart(3, '0')}
+served-by ${duHost}
 
 # ── eCPRI Fronthaul (RU → DU — O-RAN 7.2x split) ───────────────────────────
 ecpri:
   transport ethernet
-  vlan-id <CHANGE-ME-ecpri-vlan>
+  vlan-id ${ORAN_FRONTHAUL_VLAN}
+  local-address ${ruIp}
   du-mac <CHANGE-ME-du-mac-address>
   ru-mac <CHANGE-ME-ru-mac-address>
   # O-RAN 7.2x split: RU performs RF + low-PHY (FFT, iFFT, beamforming)
@@ -5359,7 +5438,7 @@ ecpri:
 # ── PTP Timing (G.8275.1 — slave to DU/switch) ──────────────────────────────
 ptp:
   profile g8275.1
-  domain 24
+  domain ${ORAN_PTP_DOMAIN}
   clock-class slave-only
   transport ethernet
   sync-interval -4
@@ -5384,7 +5463,7 @@ radio:
 
 # ── Management ───────────────────────────────────────────────────────────────
 management:
-  ip-address <CHANGE-ME-mgmt-ip>/24
+  ip-address ${mgmtIp}/24
   gateway <CHANGE-ME-mgmt-gw>
   o1-interface:
     ves-collector <CHANGE-ME-ves-collector-ip>:8443
@@ -5395,7 +5474,8 @@ management:
 `
 }
 
-function oranFronthaulConfig(dev: BOMDevice, idx: number): string {
+function oranFronthaulConfig(dev: BOMDevice, idx: number, allDevices: BOMDevice[] = []): string {
+  const fhIdx = roleIndex(dev, allDevices, idx)
   return `! ═══════════════════════════════════════════════════════════════
 ! Device : ${dev.hostname}
 ! Role   : O-RAN Fronthaul Switch (PTP Transparent-Clock)
@@ -5419,24 +5499,29 @@ ntp server <CHANGE-ME-ntp-secondary>
 ! jitter for eCPRI Class C7 (±65ns requirement).
 ptp mode transparent
 ptp profile g8275.1
-ptp domain 24
-ptp vlan ${idx + 100}
+ptp domain ${ORAN_PTP_DOMAIN}
+ptp vlan ${ORAN_FRONTHAUL_VLAN}
 !
 ! ── eCPRI Fronthaul VLANs ────────────────────────────────────────────────────
-vlan ${idx + 100}
-  name ECPRI-FRONTHAUL-${idx + 1}
+! Fronthaul is ONE broadcast domain across the site: every fronthaul switch,
+! every O-RU and every O-DU must agree on this VLAN. It used to be derived
+! from the switch's global device index, so the two switches at a site came
+! out as VLAN 134 and 135 and a radio homed to one could not reach a DU
+! behind the other.
+vlan ${ORAN_FRONTHAUL_VLAN}
+  name ECPRI-FRONTHAUL
 !
-vlan 900
+vlan ${ORAN_PTP_VLAN}
   name PTP-TIMING
 !
-vlan 999
+vlan ${ORAN_MGMT_VLAN}
   name MGMT-OOB
 !
 ! ── Downlink interfaces (to O-RUs) ──────────────────────────────────────────
 interface range Ethernet1/1-48
   description O-RU-DOWNLINK
   switchport mode trunk
-  switchport trunk allowed vlan ${idx + 100},900,999
+  switchport trunk allowed vlan ${ORAN_FRONTHAUL_VLAN},${ORAN_PTP_VLAN},${ORAN_MGMT_VLAN}
   spanning-tree port type edge trunk
   priority-flow-control mode on
   mtu 9216
@@ -5448,7 +5533,7 @@ interface range Ethernet1/1-48
 interface range Ethernet1/49-54
   description UPLINK-TO-DU-MIDHAUL
   switchport mode trunk
-  switchport trunk allowed vlan ${idx + 100},900,999
+  switchport trunk allowed vlan ${ORAN_FRONTHAUL_VLAN},${ORAN_PTP_VLAN},${ORAN_MGMT_VLAN}
   mtu 9216
   priority-flow-control mode on
   no shutdown
@@ -5476,8 +5561,8 @@ policy-map type queuing PM-FRONTHAUL-QUEUING
     bandwidth remaining percent 100
 !
 ! ── Management ───────────────────────────────────────────────────────────────
-interface Vlan999
-  ip address <CHANGE-ME-mgmt-ip>/24
+interface Vlan${ORAN_MGMT_VLAN}
+  ip address ${ipAdd('10.243.128.0', fhIdx + 1)}/24
   no shutdown
 !
 ip route 0.0.0.0/0 <CHANGE-ME-mgmt-gw>
@@ -5493,9 +5578,13 @@ ip access-list MGMT-ACL
 `
 }
 
-function oranMidhaulConfig(dev: BOMDevice, idx: number): string {
-  const routerId = `10.250.1.${idx + 1}`
-  const isisNet = `49.0001.0102.5001.${String(idx + 1).padStart(4, '0')}.00`
+function oranMidhaulConfig(dev: BOMDevice, idx: number, allDevices: BOMDevice[] = []): string {
+  // Tier-scoped (Z5): the router-id and NET came from the global device
+  // index, so in a 41-device design the two midhaul routers were numbered
+  // 37 and 38 rather than 1 and 2.
+  const mhIdx = roleIndex(dev, allDevices, idx)
+  const routerId = ipAdd('10.250.1.0', mhIdx + 1)
+  const isisNet = `49.0001.0102.5001.${String(mhIdx + 1).padStart(4, '0')}.00`
   return `! ═══════════════════════════════════════════════════════════════
 ! Device : ${dev.hostname}
 ! Role   : O-RAN Midhaul/Backhaul Router (PTP Boundary-Clock)
@@ -5508,7 +5597,7 @@ hostname ${dev.hostname}
 ! ── PTP — IEEE 1588 Boundary Clock (G.8275.1) ────────────────────────────────
 ! Midhaul routers operate as boundary-clocks, regenerating PTP timing for
 ! each segment. SyncE provides physical-layer frequency reference.
-ptp clock boundary domain 24
+ptp clock boundary domain ${ORAN_PTP_DOMAIN}
   clock-port GM-UPSTREAM master
     transport ethernet multicast
     announce interval -3
@@ -5711,7 +5800,7 @@ gnss:
 # ── PTP Configuration (ITU-T G.8275.1 Telecom Profile) ──────────────────────
 ptp:
   profile g8275.1
-  domain 24
+  domain ${ORAN_PTP_DOMAIN}
   clock-class grandmaster
   clock-accuracy 0x21            # ±100ns (GNSS-locked)
   time-source gps
@@ -5778,13 +5867,13 @@ function isOranSubLayer(subLayer: string): boolean {
   return subLayer.startsWith('oran-')
 }
 
-function oranConfig(dev: BOMDevice, idx: number): string {
+function oranConfig(dev: BOMDevice, idx: number, allDevices: BOMDevice[] = []): string {
   switch (dev.subLayer) {
-    case 'oran-cu':        return oranCuConfig(dev, idx)
-    case 'oran-du':        return oranDuConfig(dev, idx)
-    case 'oran-ru':        return oranRuConfig(dev, idx)
-    case 'oran-fronthaul': return oranFronthaulConfig(dev, idx)
-    case 'oran-midhaul':   return oranMidhaulConfig(dev, idx)
+    case 'oran-cu':        return oranCuConfig(dev, idx, allDevices)
+    case 'oran-du':        return oranDuConfig(dev, idx, allDevices)
+    case 'oran-ru':        return oranRuConfig(dev, idx, allDevices)
+    case 'oran-fronthaul': return oranFronthaulConfig(dev, idx, allDevices)
+    case 'oran-midhaul':   return oranMidhaulConfig(dev, idx, allDevices)
     case 'oran-core':      return oranCoreConfig(dev, idx)
     case 'oran-timing':    return oranTimingConfig(dev, idx)
     default:               return genericConfig(dev)
@@ -5803,7 +5892,7 @@ export function generateConfig(dev: BOMDevice, idx: number, useCase: UseCase | '
   const needsRoce = isGpu || ((v === 'Dell EMC' || v === 'NVIDIA') && useCase === 'dc')
 
   if (v === 'Palo Alto' && l === 'firewall')                        return paloAltoFirewallConfig(dev, idx)
-  if (isOranSubLayer(l))                                             return oranConfig(dev, idx)
+  if (isOranSubLayer(l))                                             return oranConfig(dev, idx, allDevices)
   if (v === 'Cisco'     && l === 'firewall')                         return isFtdModel(dev.model) ? ciscoFtdFirewallConfig(dev, idx, useCase, allDevices) : ciscoFirewallConfig(dev, idx)
   if (v === 'Cisco'     && l === 'sdwan-controller')                 return sdwanControllerConfig(dev, idx)
   if (v === 'Cisco'     && l === 'wan-edge' && isSdWanEdge(dev))     return sdwanEdgeConfig(dev, idx, allDevices)

--- a/frontend/src/test/e2e-journey.test.ts
+++ b/frontend/src/test/e2e-journey.test.ts
@@ -445,6 +445,63 @@ function assertDcimExportInvariants(j: Journey, p: ReturnType<typeof runPipeline
  *  emits an 'oversubscription' warning (H4). So at year 0 either the effective
  *  ratio honors the target, or the validator flagged the degradation — a
  *  SILENT breach means the two capacity views have drifted apart. */
+/**
+ * AD1, permanent: the O-RAN fronthaul is ONE broadcast domain. The VLAN used
+ * to be derived from each switch's GLOBAL device index, so the two fronthaul
+ * switches at a site came out as 134 and 135 — a radio homed to one could
+ * never reach a DU behind the other — while the radios and DUs carried a
+ * placeholder, so neither end reconciled the other. Radio identity is checked
+ * here too: 24 byte-identical radios with no PCI is not a radio plan.
+ */
+function assertOranFabricInvariants(j: Journey, p: ReturnType<typeof runPipeline>) {
+  if (j.useCase !== 'oran') return
+  const ctx = `oran/${j.scale}/${j.totalEndpoints}ep`
+  const cfg = (d: { id: string }) => p.configs[d.id] ?? ''
+  const of = (role: string) => p.devices.filter(d => d.subLayer === role)
+
+  // Scanning every config is O(devices x config length) and an 8192-radio
+  // design has ~10k of them, so sample: every switch and DU (few, and the
+  // switch is where the bug was), plus a STRIDED sample of the radios — a
+  // stride catches an index-derived value, which is the failure mode.
+  const stride = Math.max(1, Math.ceil(of('oran-ru').length / 64))
+  const sampled = [
+    ...of('oran-fronthaul'), ...of('oran-du'),
+    ...of('oran-ru').filter((_, i) => i % stride === 0),
+  ]
+  const vlans = new Set<string>()
+  for (const dev of sampled) {
+    for (const re of [/vlan-id (\d+)/g, /^vlan (\d+)$/gm, /ptp vlan (\d+)/g]) {
+      for (const m of cfg(dev).matchAll(re)) {
+        if (m[1] !== '900' && m[1] !== '999') vlans.add(m[1])
+      }
+    }
+  }
+  expect(vlans.size, `${ctx}: fronthaul split across VLANs ${[...vlans].join('/')}`).toBe(1)
+
+  const pcis = of('oran-ru').map(r => /^pci (\d+)$/m.exec(cfg(r))?.[1])
+  expect(pcis.every(x => x !== undefined), `${ctx}: a radio has no PCI`).toBe(true)
+  if (pcis.length <= 1008) {
+    expect(new Set(pcis).size, `${ctx}: PCI collision across ${pcis.length} radios`).toBe(pcis.length)
+  } else {
+    // The PCI space is 1008 wide, so a larger design MUST reuse. What is not
+    // allowed is reusing SILENTLY: the reuse has to be spaced as widely as the
+    // space permits, said on the radio, and raised at design time.
+    expect(new Set(pcis).size, `${ctx}: reuse is tighter than the PCI space allows`).toBe(1008)
+    const sample = cfg(of('oran-ru')[1008])
+    expect(sample, `${ctx}: a radio reuses a PCI without saying so`).toContain('PCI REUSE')
+    const warned = validateBOM(p.devices, { useCase: 'oran', totalEndpoints: j.totalEndpoints })
+      .some(i => /PCI space/.test(i.message))
+    expect(warned, `${ctx}: PCI reuse never reaches the operator`).toBe(true)
+  }
+
+  // Every DU must point at an address a CU in this BOM actually owns.
+  const cuAddrs = new Set(of('oran-cu').map(c => /^  local-address (\S+)$/m.exec(cfg(c))?.[1]))
+  for (const du of of('oran-du')) {
+    const home = /cu-address (\S+)/.exec(cfg(du))?.[1]
+    expect(cuAddrs.has(home), `${ctx}: ${du.hostname} homes to ${home}, which no CU owns`).toBe(true)
+  }
+}
+
 function assertCapacityPlanInvariants(j: Journey, p: ReturnType<typeof runPipeline>) {
   const ctx = `${j.useCase}/${j.totalEndpoints}ep/${j.bandwidthPerServer}/${j.oversubscription}:1`
   const plan = computeCapacityPlan(p.devices, j.totalEndpoints, 0.2, 5, {
@@ -528,6 +585,7 @@ describe('E2E journey — universal invariants across full matrix', () => {
           assertZTPPlanInvariants(j, p)
           assertDcimExportInvariants(j, p)
           assertCapacityPlanInvariants(j, p)
+          assertOranFabricInvariants(j, p)
         })
       }
     }
@@ -632,7 +690,10 @@ describe('E2E journey — tiny & extreme scale edges', () => {
           expect(d.hostname, `${useCase}@${endpoints}: non-alnum hostname ${d.hostname}`)
             .toMatch(/^EDG-[A-Z0-9-]+$/)
         }
-      })
+        // O-RAN at 8192 endpoints builds ~10k devices and generates a config
+        // for every one, so this edge scenario legitimately takes several
+        // seconds. It is a scale check, not a latency check.
+      }, 30_000)
     }
   }
 })

--- a/frontend/src/test/oran.test.ts
+++ b/frontend/src/test/oran.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from 'vitest'
-import { generateConfig } from '../lib/configgen'
+import {
+  generateConfig, generateAllConfigs,
+  ORAN_FRONTHAUL_VLAN, ORAN_PTP_VLAN, ORAN_MGMT_VLAN, ORAN_PTP_DOMAIN,
+} from '../lib/configgen'
 import { buildDeviceList, buildBOM } from '../lib/bom'
 import { PRODUCTS } from '../lib/products'
 import type { BOMDevice } from '@/types'
@@ -247,5 +250,122 @@ describe('G-A10 — Private 5G / O-RAN use case', () => {
         pwLines.forEach(l => expect(l).toContain('<CHANGE-ME'))
       })
     })
+  })
+})
+
+// ── AD1: fronthaul coherence + cell identity ─────────────────────────────────
+// A 5th-pass audit dumped a 41-device O-RAN design and reviewed the configs.
+// The fronthaul — the defining link of the architecture — was broken by
+// construction, and 24 radios were byte-identical apart from their hostname.
+describe('AD1 — O-RAN fabric coherence', () => {
+  const design = (endpoints = 24) => {
+    const devices = buildDeviceList({
+      useCase: 'oran', scale: 'medium', siteCode: 'AUD', totalEndpoints: endpoints,
+    })
+    const configs = generateAllConfigs(devices, 'oran')
+    return { devices, configs, byRole: (r: string) => devices.filter(d => d.subLayer === r) }
+  }
+  const cfgOf = (d: { devices: BOMDevice[]; configs: Record<string, string> }, dev: BOMDevice) =>
+    d.configs[dev.id] ?? ''
+
+  it('puts every device on ONE fronthaul VLAN', () => {
+    // Was `idx + 100` — the switch's GLOBAL device index — so the two
+    // fronthaul switches at one site came out as VLAN 134 and 135, and a
+    // radio homed to one could not reach a DU behind the other. The radios
+    // and DUs meanwhile carried a <CHANGE-ME-ecpri-vlan> placeholder, so
+    // nothing reconciled the two ends.
+    const d = design()
+    const seen = new Set<string>()
+    for (const cfg of Object.values(d.configs)) {
+      for (const re of [/vlan-id (\d+)/g, /^vlan (\d+)$/gm, /ptp vlan (\d+)/g]) {
+        for (const m of cfg.matchAll(re)) {
+          // PTP and mgmt VLANs are separate services, not fronthaul
+          if (m[1] !== String(ORAN_PTP_VLAN) && m[1] !== String(ORAN_MGMT_VLAN)) seen.add(m[1])
+        }
+      }
+    }
+    expect([...seen], 'the fronthaul is one broadcast domain').toEqual([String(ORAN_FRONTHAUL_VLAN)])
+  })
+
+  it('trunks the fronthaul VLAN on every fronthaul switch', () => {
+    const d = design()
+    const switches = d.byRole('oran-fronthaul')
+    expect(switches.length).toBeGreaterThan(1)
+    for (const sw of switches) {
+      const cfg = cfgOf(d, sw)
+      expect(cfg, sw.hostname).toContain(`switchport trunk allowed vlan ${ORAN_FRONTHAUL_VLAN},`)
+      expect(cfg, sw.hostname).toContain(`vlan ${ORAN_FRONTHAUL_VLAN}`)
+    }
+  })
+
+  it('gives every radio a distinct, in-range PCI', () => {
+    const d = design()
+    const rus = d.byRole('oran-ru')
+    expect(rus.length).toBe(24)
+    const pcis = rus.map(r => Number(/^pci (\d+)$/m.exec(cfgOf(d, r))?.[1]))
+    expect(pcis.every(n => Number.isInteger(n) && n >= 0 && n < 1008)).toBe(true)
+    expect(new Set(pcis).size, 'PCI collision — the classic 5G RAN outage').toBe(rus.length)
+    // PCI mod 3 sets the SSB shift, so neighbours must not share one.
+    for (let i = 1; i < pcis.length; i++) {
+      expect(pcis[i] % 3, `RU ${i} and ${i - 1} share an SSB shift`).not.toBe(pcis[i - 1] % 3)
+    }
+  })
+
+  it('no longer emits 24 identical radios', () => {
+    const d = design()
+    const bodies = d.byRole('oran-ru').map(r => cfgOf(d, r).replace(new RegExp(r.hostname, 'g'), ''))
+    expect(new Set(bodies).size, 'radios differ only by hostname').toBe(bodies.length)
+  })
+
+  it('homes each DU to a real CU at that CU own F1 address', () => {
+    const d = design()
+    const cus = d.byRole('oran-cu')
+    const dus = d.byRole('oran-du')
+    expect(cus.length).toBe(2)
+    const cuF1c = cus.map(c => /^  local-address (\S+)$/m.exec(cfgOf(d, c))?.[1])
+    const homed = dus.map(du => /cu-address (\S+)/.exec(cfgOf(d, du))?.[1])
+    for (const h of homed) expect(cuF1c, 'DU points at an address no CU owns').toContain(h)
+    // and the DUs are spread over the CUs rather than all piled on one
+    expect(new Set(homed).size).toBe(cus.length)
+  })
+
+  it('scopes gnb ids to their tier, not the whole BOM', () => {
+    // Two CUs precede the DUs in the BOM, so a global index started the DU
+    // ids at 3 and shifted them whenever the BOM composition changed.
+    const d = design()
+    const ids = (role: string, key: string) => d.byRole(role)
+      .map(x => Number(new RegExp(`^${key} (\\d+)$`, 'm').exec(cfgOf(d, x))?.[1]))
+      .sort((a, b) => a - b)
+    expect(ids('oran-cu', 'gnb-cu-id')).toEqual([1, 2])
+    expect(ids('oran-du', 'gnb-du-id')).toEqual([1, 2, 3, 4, 5, 6, 7, 8])
+  })
+
+  it('gives every radio and DU its own fronthaul address', () => {
+    const d = design()
+    const addrs = [...d.byRole('oran-ru'), ...d.byRole('oran-du')]
+      .map(x => /^  local-address (\S+)$/m.exec(cfgOf(d, x))?.[1])
+      .filter(Boolean)
+    expect(addrs.length).toBe(32)
+    expect(new Set(addrs).size, 'duplicate fronthaul address').toBe(addrs.length)
+    expect(addrs.some(a => a!.includes('CHANGE-ME'))).toBe(false)
+  })
+
+  it('agrees on one PTP domain fleet-wide', () => {
+    const d = design()
+    const domains = new Set(
+      Object.values(d.configs).flatMap(c => [...c.matchAll(/domain (\d+)/g)].map(m => m[1])))
+    expect([...domains]).toEqual([String(ORAN_PTP_DOMAIN)])
+  })
+
+  it('keeps every address inside a valid octet at scale', () => {
+    // The Z7 overflow class: 240 radios must not produce 10.242.128.256.
+    const d = design(240)
+    for (const [id, cfg] of Object.entries(d.configs)) {
+      for (const m of cfg.matchAll(/\b(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})\b/g)) {
+        for (const oct of m.slice(1)) {
+          expect(Number(oct), `${id}: invalid IP ${m[0]}`).toBeLessThanOrEqual(255)
+        }
+      }
+    }
   })
 })


### PR DESCRIPTION
## Where this came from

Groups X/Y/Z audited the DC, GPU and campus **configs**. Group AA audited the non-DC use cases' **BOM and cabling** but never the configs those designs generate. This is a 5th-pass audit that dumps WAN, multisite, multicloud, Aviatrix and O-RAN artifacts and reviews them as an architect would. The full finding set is recorded as tracker group **AD**; this PR closes **AD1**.

Both structural themes from the 3rd-pass audit recur in new places: **fix-parity** (the Z5 tier-scoped-identity fix never reached these generators) and **BOM↔config disagreement** (a switch hardcoding a VLAN the radios attached to it never learn).

## The critical one

`oranFronthaulConfig` set the eCPRI VLAN to `idx + 100` — the switch's **global device index**. In the dumped 41-device design the two fronthaul switches at one cell site came out as VLAN **134** and **135**:

```
AUD-OFH-A01:  vlan 134    switchport trunk allowed vlan 134,900,999
AUD-OFH-A02:  vlan 135    switchport trunk allowed vlan 135,900,999
```

A radio homed to one switch and its DU reached via the other are on different fronthaul VLANs. The defining link of the architecture could not carry traffic. And the radios and DUs both carried `<CHANGE-ME-ecpri-vlan>`, so nothing reconciled the two ends either.

Fronthaul is one broadcast domain, so the VLAN is now a fabric constant shared by the switch, the O-RU and the O-DU — as are the PTP and mgmt VLANs and the PTP domain, which six generators had hardcoded independently.

## Cell identity

All 24 O-RUs were byte-identical apart from the hostname — no `ru-id`, no cell identity, and **no PCI**. PCI planning is the defining O-RU parameter and a collision between cells that can see each other is the classic 5G RAN outage.

Each radio now carries a `ru-id`, a derived `cell-id`, the DU it is `served-by`, and a PCI assigned consecutively so neighbours differ mod 3 — which is what sets the SSB frequency-domain shift.

## Tier-scoped identity and real addressing

`gnb-cu-id`, `gnb-du-id` and the midhaul router-id / IS-IS NET all came from the global index, so DU ids started at 3 (two CUs preceded them) and the midhaul routers were numbered 37 and 38. Every DU shared one `<CHANGE-ME-du-f1c-ip>` and pointed at one `<CHANGE-ME-cu-f1c-ip>` although the design has two CUs.

Now tier-scoped via the existing `roleIndex`, with real per-device addresses via `ipAdd`, and each DU homed round-robin to an address a CU in the BOM actually owns.

## What the invariant then found

Past **1008 radios** the PCI space must wrap — that is 5G reality, not a generator bug. But it was wrapping silently, which is the worst outcome. Reuse is now stated on the reusing radio and raised by `validateBOM` at design time, and the invariant requires the reuse to be as widely spaced as the space allows.

## Verification

New permanent e2e invariant `assertOranFabricInvariants`: one fronthaul VLAN fleet-wide, unique in-range PCIs or explicit spaced reuse, every DU homed to an address a CU owns. Both the VLAN fix and the tier-scoping were revert-checked — reverting either trips the new tests.

9 new tests. 1387 frontend, 397 backend, tsc + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DiH1v2ufYHuupbP4xn6pPb

---
_Generated by [Claude Code](https://claude.ai/code/session_01DiH1v2ufYHuupbP4xn6pPb)_