### PR TITLE
fix: AG — the lab export produced isolated, unconfigured devices

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1267,6 +1267,25 @@ config-gen tests must keep passing; add new tests alongside).
 
 ---
 
+### AG. Lab-export fidelity (sourced 2026-08-27)
+
+> N1 exports a containerlab topology so a user can "spin up a faithful
+> replica of their design with one command" — a stated differentiator. It was
+> audited the way a user would experience it: build a real DC design, export,
+> and read what you would actually be given.
+>
+> **A 20-device design exported 20 nodes, ZERO links and ZERO startup
+> configs** — twenty isolated, unconfigured switches. Three independent
+> causes, and 19 passing tests over the top of them because the test helper
+> fabricated a `CableLink` shape `buildCabling` never produces.
+
+| # | Item | Status | Notes |
+|---|------|--------|-------|
+| AG1 | **The containerlab export produced isolated, unconfigured devices** — three independent causes. (1) **Zero links**: `generateLinks` read `cable.fromDevice` as a hostname, but `buildCabling` puts a human summary there (`"16x leaf"`), so the node lookup missed on every cable and `continue` fired every time. (2) **Zero startup configs**: nodes were matched with `configs[node.hostname]` while `generateAllConfigs` keys its output by **BOM id**, so no node ever found its config — `ClabNode` now carries `deviceId`. (3) **The UI downloaded only the YAML**, so even once fixed the topology pointed at `configs/*.cfg` files nothing wrote; new `containerlabBundle()` emits one runnable shell script that writes the tree (heredocs, no zip dependency — §21 rule 9) and runs `clab deploy`. Links now come from `expandCablePlan` rather than a third expansion, so the lab and the cable schedule describe the same wiring. New tests drive a **real** BOM: links > 0, link count == cables billed, every node configured, every referenced file written, no self-links, no interface used twice | [x] | `lib/containerlab.ts`, `Step4NetworkDesign.tsx`; `containerlab.test.ts` 19→26 |
+| AG2 | **`expandCablePlan` emitted a full mesh and ignored `quantity`** — found while fixing AG1 and the more serious of the two, because this function also feeds the **NetBox DCIM export** (F2/F3), the customer's source of truth. A 20-device DC billing **74** cable runs exported **280**: firewall→leaf meshed every firewall to every leaf (28) instead of the two border leaves Z3 wires (4), and the same-layer peer-link meshed all 14 leaves against each other (196) instead of 7 pairs × 2 members (14). Spine-leaf matched only by coincidence — `4 spines × 14 leaves` happened to equal `14 leaves × 4 uplinks`, and would over-count as soon as `uplinks < spineCount` (the Y2 staggered case). Now the count is exactly `link.quantity`, and pair ORDER matches how the fabric is really wired: spine-leaf staggered as `closFabricLinks` assigns uplinks, same-layer runs between consecutive HA pair members, everything else in cross-product order. The I5 e2e invariant compared the CSV against the expanded plan — self-consistent, so it never caught this; the new tests compare against the **BOM** | [x] | `lib/netbox-dcim.ts` `candidatePairs`/`expandCablePlan`; 1436 tests, tsc + build green |
+
+---
+
 ---
 
 ## 23. Autonomous "Start Improving" Mode (2026-06-11 →)

--- a/frontend/src/lib/containerlab.ts
+++ b/frontend/src/lib/containerlab.ts
@@ -6,6 +6,7 @@
  */
 
 import type { BOMDevice, CableLink } from '@/types'
+import { expandCablePlan } from '@/lib/netbox-dcim'
 
 // ── Vendor → container image mapping ──────────────────────────────────────────
 
@@ -55,6 +56,9 @@ export interface ClabNode {
   kind: string
   image: string
   hostname: string
+  /** BOM device id — `generateAllConfigs` keys its output by this, not by
+   *  hostname, so without it no node ever found its startup config (AG1). */
+  deviceId: string
   startupConfig?: string
 }
 
@@ -68,6 +72,7 @@ function expandDevices(devices: BOMDevice[]): ClabNode[] {
         kind: resolveImage(dev).kind,
         image: resolveImage(dev).image,
         hostname: dev.hostname,
+        deviceId: dev.id,
       })
     } else {
       for (let i = 1; i <= dev.count; i++) {
@@ -79,6 +84,7 @@ function expandDevices(devices: BOMDevice[]): ClabNode[] {
           kind: resolveImage(dev).kind,
           image: resolveImage(dev).image,
           hostname,
+          deviceId: dev.id,
         })
       }
     }
@@ -106,34 +112,40 @@ function interfacePrefix(kind: string): string {
   }
 }
 
+/**
+ * Concrete node-to-node links.
+ *
+ * This used to read `cable.fromDevice` as a hostname. It is not: `buildCabling`
+ * sets it to a human summary like "16x leaf", so the node lookup missed on
+ * every cable and the topology came out with ZERO links — twenty isolated
+ * switches. The 19 tests over this passed because the test helper built a
+ * CableLink with a hostname in that field, a shape the BOM never produces.
+ *
+ * The aggregate plan is expanded by `expandCablePlan`, which already does
+ * exactly this for the NetBox DCIM export (F2). Reusing it keeps the lab and
+ * the cable schedule describing the same physical wiring — writing a third
+ * expansion is how they would drift.
+ */
 function generateLinks(
   nodes: ClabNode[],
+  devices: BOMDevice[],
   cabling: CableLink[],
 ): ClabLink[] {
   const links: ClabLink[] = []
-  const nodeMap = new Map(nodes.map(n => [n.hostname, n]))
+  const byHostname = new Map(nodes.map(n => [n.hostname, n]))
   const portCounters = new Map<string, number>()
 
-  function nextPort(nodeName: string, kind: string): string {
-    const count = portCounters.get(nodeName) ?? 1
-    portCounters.set(nodeName, count + 1)
-    const prefix = interfacePrefix(kind)
-    return `${prefix}${count}`
+  function nextPort(node: ClabNode): string {
+    const count = portCounters.get(node.name) ?? 1
+    portCounters.set(node.name, count + 1)
+    return `${interfacePrefix(node.kind)}${count}`
   }
 
-  for (const cable of cabling) {
-    const fromNode = nodeMap.get(cable.fromDevice)
-    const toNode = nodeMap.get(cable.toDevice)
-    if (!fromNode || !toNode) continue
-
-    for (let i = 0; i < cable.quantity; i++) {
-      const fromPort = nextPort(fromNode.name, fromNode.kind)
-      const toPort = nextPort(toNode.name, toNode.kind)
-      links.push({
-        a: `${fromNode.name}:${fromPort}`,
-        b: `${toNode.name}:${toPort}`,
-      })
-    }
+  for (const run of expandCablePlan(devices, cabling)) {
+    const a = byHostname.get(run.a.device)
+    const b = byHostname.get(run.b.device)
+    if (!a || !b) continue
+    links.push({ a: `${a.name}:${nextPort(a)}`, b: `${b.name}:${nextPort(b)}` })
   }
 
   return links
@@ -160,12 +172,14 @@ export function buildContainerlabTopology(
   const nodes = expandDevices(devices)
 
   for (const node of nodes) {
-    if (configs[node.hostname]) {
+    // Keyed by BOM id — the hostname lookup this used to do never matched, so
+    // every lab booted bare devices with none of the generated config (AG1).
+    if (configs[node.deviceId]) {
       node.startupConfig = `configs/${node.hostname}.cfg`
     }
   }
 
-  const links = generateLinks(nodes, cabling)
+  const links = generateLinks(nodes, devices, cabling)
   return { name: sanitizeName(name), nodes, links }
 }
 
@@ -208,7 +222,7 @@ export function generateStartupConfigs(
 ): { filename: string; content: string }[] {
   const files: { filename: string; content: string }[] = []
   for (const node of topo.nodes) {
-    const cfg = configs[node.hostname]
+    const cfg = configs[node.deviceId]
     if (cfg) {
       files.push({
         filename: `configs/${node.hostname}.cfg`,
@@ -217,6 +231,51 @@ export function generateStartupConfigs(
     }
   }
   return files
+}
+
+/**
+ * A single self-contained file that stands up the whole lab.
+ *
+ * The topology references `configs/<host>.cfg` for every node, but the UI only
+ * ever downloaded the YAML — so the lab pointed at config files that were
+ * never written, and the user got bare devices even once the wiring was fixed
+ * (AG1). Browsers cannot hand over a directory and this project takes no new
+ * dependencies for a zip, so the bundle is a shell script that writes the
+ * tree and deploys it.
+ */
+export function containerlabBundle(
+  topo: ContainerlabTopology,
+  configs: Record<string, string>,
+): string {
+  const files = generateStartupConfigs(topo, configs)
+  // A heredoc delimiter that cannot appear inside a device config.
+  const EOF = 'NETDESIGN_EOF'
+  const write = (path: string, body: string) => [
+    `mkdir -p "$(dirname '${path}')"`,
+    `cat > '${path}' <<'${EOF}'`,
+    body.replace(/\r/g, ''),
+    EOF,
+    '',
+  ].join('\n')
+
+  return [
+    '#!/usr/bin/env bash',
+    '# Generated by NetDesign AI — containerlab lab bundle',
+    '#',
+    `# Writes ${topo.name}.clab.yml plus ${files.length} startup config(s), then deploys.`,
+    '#   chmod +x this file and run it from an empty directory.',
+    'set -euo pipefail',
+    '',
+    write(`${topo.name}.clab.yml`, topologyToYAML(topo)),
+    ...files.map(f => write(f.filename, f.content)),
+    `echo "Wrote ${topo.name}.clab.yml and ${files.length} config file(s)."`,
+    'if command -v clab >/dev/null 2>&1; then',
+    `  clab deploy -t "${topo.name}.clab.yml"`,
+    'else',
+    '  echo "containerlab not found — install it, then: clab deploy -t ' + topo.name + '.clab.yml"',
+    'fi',
+    '',
+  ].join('\n')
 }
 
 export function containerlabReadme(topo: ContainerlabTopology): string {

--- a/frontend/src/lib/netbox-dcim.ts
+++ b/frontend/src/lib/netbox-dcim.ts
@@ -79,6 +79,57 @@ export interface DcimCable {
  * endpoints). Interface names are allocated sequentially per device as the
  * cabling is walked (deterministic given the same device/cabling order).
  */
+/**
+ * Expand the aggregate cable plan into concrete device-to-device runs.
+ *
+ * This used to emit a full `fromDevs x toDevs` mesh and ignore `quantity`
+ * entirely, so a 20-device DC design whose BOM billed **74** runs exported
+ * **280**: every leaf cabled to every other leaf and to itself (196 runs for
+ * a 14-member peer-link tier), and every firewall cabled to every leaf rather
+ * than to the two border leaves Z3 actually wires. A customer importing that
+ * into NetBox received a fabricated cable plant nearly four times the real
+ * size — in the artifact whose purpose is to be the source of truth (AG2).
+ *
+ * The count is now exactly `link.quantity`, always. Pair ORDER is chosen to
+ * match how the fabric is really wired so the endpoints are meaningful too:
+ * spine-leaf is staggered the way `closFabricLinks` assigns uplinks, a
+ * same-layer peer-link runs between consecutive HA pair members, and anything
+ * else walks the cross-product in order.
+ */
+function candidatePairs(
+  link: CableLink, fromDevs: BOMDevice[], toDevs: BOMDevice[],
+): Array<[BOMDevice, BOMDevice]> {
+  const pairs: Array<[BOMDevice, BOMDevice]> = []
+
+  // Same-layer runs are HA peer-links: A01<->A02, B01<->B02, ...
+  if (link.fromLayer === link.toLayer) {
+    for (let i = 0; i + 1 < fromDevs.length; i += 2) pairs.push([fromDevs[i], fromDevs[i + 1]])
+    return pairs
+  }
+
+  const isSpineLeaf =
+    (link.fromLayer === 'spine' && link.toLayer === 'leaf') ||
+    (link.fromLayer === 'leaf' && link.toLayer === 'spine')
+  if (isSpineLeaf) {
+    const leaves = link.fromLayer === 'leaf' ? fromDevs : toDevs
+    const spines = link.fromLayer === 'leaf' ? toDevs : fromDevs
+    const uplinks = Math.max(1, leaves[0]?.uplinks ?? 1)
+    // Staggered round-robin, matching configgen's closFabricLinks: leaf i's
+    // k-th uplink lands on spine (i + k) % spineCount, so no spine goes dark.
+    for (let i = 0; i < leaves.length; i++) {
+      for (let k = 0; k < uplinks; k++) {
+        const spine = spines[(i + k) % spines.length]
+        if (!spine) continue
+        pairs.push(link.fromLayer === 'leaf' ? [leaves[i], spine] : [spine, leaves[i]])
+      }
+    }
+    return pairs
+  }
+
+  for (const fd of fromDevs) for (const td of toDevs) pairs.push([fd, td])
+  return pairs
+}
+
 export function expandCablePlan(devices: BOMDevice[], cabling: CableLink[]): DcimCable[] {
   const cables: DcimCable[] = []
   const portCounter = new Map<string, number>()
@@ -87,37 +138,37 @@ export function expandCablePlan(devices: BOMDevice[], cabling: CableLink[]): Dci
     portCounter.set(device, n)
     return `Ethernet1/${n}`
   }
+  const push = (a: string, b: string, link: CableLink) => cables.push({
+    a: { device: a, iface: nextIface(a) },
+    b: { device: b, iface: nextIface(b) },
+    cableType: link.cableType, medium: link.medium, speed: link.speed, lengthM: link.lengthM,
+  })
 
   for (const link of cabling) {
     const fromDevs = devices.filter(d => d.subLayer === link.fromLayer)
     const toDevs   = devices.filter(d => d.subLayer === link.toLayer)
+    const qty = Math.max(0, link.quantity)
 
     if (fromDevs.length === 0 || toDevs.length === 0) {
       // Fall back to the aggregate labels when the layer isn't in the BOM.
       const a = link.fromDevice || link.fromLayer
       const b = link.toDevice || link.toLayer
-      cables.push({
-        a: { device: a, iface: nextIface(a) },
-        b: { device: b, iface: nextIface(b) },
-        cableType: link.cableType, medium: link.medium, speed: link.speed, lengthM: link.lengthM,
-      })
+      for (let i = 0; i < qty; i++) push(a, b, link)
       continue
     }
 
-    for (const fd of fromDevs) {
-      for (const td of toDevs) {
-        const a = fd.hostname || fd.model
-        const b = td.hostname || td.model
-        cables.push({
-          a: { device: a, iface: nextIface(a) },
-          b: { device: b, iface: nextIface(b) },
-          cableType: link.cableType, medium: link.medium, speed: link.speed, lengthM: link.lengthM,
-        })
-      }
+    const pairs = candidatePairs(link, fromDevs, toDevs)
+    if (!pairs.length) continue
+    // Exactly `quantity` runs: the plan and the schedule must agree on how
+    // many cables a contractor is being asked to pull.
+    for (let i = 0; i < qty; i++) {
+      const [fd, td] = pairs[i % pairs.length]
+      push(fd.hostname || fd.model, td.hostname || td.model, link)
     }
   }
   return cables
 }
+
 
 // ── Rack layout structural types (F3) ─────────────────────────────────────────
 // Structurally compatible with RackElevation's RackAssignment/RackSlot so the

--- a/frontend/src/pages/Step4NetworkDesign.tsx
+++ b/frontend/src/pages/Step4NetworkDesign.tsx
@@ -13,7 +13,7 @@ import { buildNetBoxDcimExport } from '@/lib/netbox-dcim'
 import { downloadDesignJSON, downloadDesignMarkdown, validateDesignImport, applyDesignImport, serializeDesign } from '@/lib/design-export'
 import { diffDesigns, diffToMarkdown, type DesignDiff } from '@/lib/design-diff'
 import { computeCapacityPlan } from '@/lib/capacity-planning'
-import { buildContainerlabTopology, topologyToYAML } from '@/lib/containerlab'
+import { buildContainerlabTopology, containerlabBundle } from '@/lib/containerlab'
 import { buildCloudTerraform, cloudTerraformFilename } from '@/lib/cloud-terraform'
 import { buildDrawio, drawioFilename } from '@/lib/drawio-export'
 import type { DesignExport } from '@/lib/design-export'
@@ -1841,18 +1841,22 @@ export function Step4NetworkDesign() {
                     state.configs,
                     `${siteCode || useCase || 'lab'}`,
                   )
-                  const yaml = topologyToYAML(topo)
-                  const blob = new Blob([yaml], { type: 'text/yaml' })
+                  // The topology references configs/<host>.cfg for every node.
+                  // Downloading the YAML alone left those files unwritten, so
+                  // the lab booted bare devices (AG1) — ship the bundle that
+                  // writes the whole tree and deploys it.
+                  const script = containerlabBundle(topo, state.configs)
+                  const blob = new Blob([script], { type: 'text/x-shellscript' })
                   const url = URL.createObjectURL(blob)
                   const a = document.createElement('a')
                   a.href = url
-                  a.download = `${topo.name}.clab.yml`
+                  a.download = `${topo.name}-lab.sh`
                   a.click()
                   URL.revokeObjectURL(url)
                 }}
                 className="flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg border border-orange-500/40 bg-orange-600/20 text-orange-300 text-sm font-medium hover:bg-orange-600/30 transition-colors cursor-pointer"
               >
-                Containerlab (.yml)
+                Containerlab lab (.sh)
               </button>
 
               <button

--- a/frontend/src/test/containerlab.test.ts
+++ b/frontend/src/test/containerlab.test.ts
@@ -4,7 +4,10 @@ import {
   topologyToYAML,
   generateStartupConfigs,
   containerlabReadme,
+  containerlabBundle,
 } from '@/lib/containerlab'
+import { buildDeviceList, buildCabling } from '@/lib/bom'
+import { generateAllConfigs } from '@/lib/configgen'
 import type { BOMDevice, CableLink } from '@/types'
 
 const leaf = (hostname: string, vendor = 'Cisco', count = 1): BOMDevice => ({
@@ -249,5 +252,101 @@ describe('containerlab', () => {
       expect(yaml).toContain('kind: cisco_n9kv')
       expect(yaml).toContain('kind: crpd')
     })
+  })
+})
+
+// ── AG1: the export must reproduce the design, not just name it ──────────────
+// Audited the way a user experiences it — build a real design, export, read
+// what you get. A 20-device DC produced 20 nodes, ZERO links and ZERO startup
+// configs: twenty isolated, unconfigured switches. Every test in this file
+// passed over the top of that, because the helper above builds a CableLink
+// with a HOSTNAME in `fromDevice`, and `buildCabling` puts a summary string
+// like "16x leaf" there.
+describe('AG1 — a real design round-trips into a usable lab', () => {
+  const real = () => {
+    const state = {
+      useCase: 'dc' as const, scale: 'medium' as const, siteCode: 'AG1',
+      totalEndpoints: 512, oversubscription: 3, bandwidthPerServer: '25G',
+    }
+    const devices = buildDeviceList(state)
+    const cabling = buildCabling(devices, {
+      'spine-leaf': 100, 'dist-access': 50, 'core-dist': 200, 'wan-edge': 5000,
+    })
+    const configs = generateAllConfigs(devices, 'dc')
+    return {
+      devices, cabling, configs,
+      topo: buildContainerlabTopology(devices, cabling, configs, 'AG1'),
+    }
+  }
+
+  it('wires the nodes together', () => {
+    const { topo } = real()
+    expect(topo.nodes.length).toBeGreaterThan(10)
+    expect(topo.links.length, 'a lab with no links is isolated devices').toBeGreaterThan(0)
+  })
+
+  it('emits exactly as many links as the BOM bills cables', () => {
+    // The lab and the cable schedule must describe the same wiring.
+    const { cabling, topo } = real()
+    const billed = cabling.reduce((n, c) => n + c.quantity, 0)
+    expect(topo.links.length).toBe(billed)
+  })
+
+  it('gives every node its generated startup config', () => {
+    // `generateAllConfigs` keys by BOM id; this looked up by hostname, so the
+    // match never happened and every device booted bare.
+    const { topo, configs } = real()
+    const withConfig = topo.nodes.filter(n => n.startupConfig)
+    expect(withConfig.length).toBe(topo.nodes.filter(n => configs[n.deviceId]).length)
+    expect(withConfig.length).toBe(topo.nodes.length)
+  })
+
+  it('writes the config files the topology references', () => {
+    const { topo, configs } = real()
+    const files = generateStartupConfigs(topo, configs)
+    const referenced = topo.nodes.map(n => n.startupConfig).filter(Boolean)
+    expect(files.length).toBe(referenced.length)
+    for (const path of referenced) {
+      expect(files.some(f => f.filename === path), `${path} referenced but not written`).toBe(true)
+    }
+    for (const f of files) expect(f.content.length).toBeGreaterThan(100)
+  })
+
+  it('bundles the topology and every config into one runnable script', () => {
+    const { topo, configs } = real()
+    const sh = containerlabBundle(topo, configs)
+    expect(sh.startsWith('#!/usr/bin/env bash')).toBe(true)
+    expect(sh).toContain(`${topo.name}.clab.yml`)
+    expect(sh).toContain('clab deploy')
+    // Every referenced config is written by the script, not just named.
+    for (const node of topo.nodes) {
+      if (!node.startupConfig) continue
+      expect(sh, `${node.startupConfig} is referenced but never written`)
+        .toContain(`cat > '${node.startupConfig}'`)
+    }
+    // The heredoc delimiter must not occur inside any payload, or the script
+    // terminates early and writes a truncated config.
+    const delim = 'NETDESIGN_EOF'
+    const opens = (sh.match(new RegExp(`<<'${delim}'`, 'g')) ?? []).length
+    const closes = (sh.match(new RegExp(`^${delim}$`, 'gm')) ?? []).length
+    expect(closes).toBe(opens)
+  })
+
+  it('never links a node to itself', () => {
+    const { topo } = real()
+    for (const l of topo.links) {
+      expect(l.a.split(':')[0], `self-link on ${l.a}`).not.toBe(l.b.split(':')[0])
+    }
+  })
+
+  it('uses each container interface at most once', () => {
+    const { topo } = real()
+    const seen = new Set<string>()
+    for (const l of topo.links) {
+      for (const ep of [l.a, l.b]) {
+        expect(seen.has(ep), `${ep} used twice`).toBe(false)
+        seen.add(ep)
+      }
+    }
   })
 })

--- a/frontend/src/test/netbox-dcim.test.ts
+++ b/frontend/src/test/netbox-dcim.test.ts
@@ -54,9 +54,12 @@ describe('expandCablePlan', () => {
   })
 
   it('falls back to aggregate labels when a layer is absent from the BOM', () => {
+    // Still `quantity` runs, not one: expanding a plan that says four cables
+    // into a single row is the same under-count the main path used to
+    // over-count (AG2). Only the endpoint NAMES fall back here.
     const orphan: CableLink[] = [{ ...cabling[0], fromLayer: 'core', toLayer: 'nowhere', fromDevice: 'CORE-01', toDevice: 'EDGE-01' }]
     const cables = expandCablePlan(devices, orphan)
-    expect(cables.length).toBe(1)
+    expect(cables.length).toBe(orphan[0].quantity)
     expect(cables[0].a.device).toBe('CORE-01')
     expect(cables[0].b.device).toBe('EDGE-01')
   })


### PR DESCRIPTION
N1 exports a containerlab topology so a user can "spin up a faithful replica of their design with one command" — a stated differentiator. Audited the way a user experiences it: build a real DC design, export, read what you'd actually be given.

```
BOM devices: 20   node count: 20
BOM cable runs: 74   links: 0
node cl-spine-a01 {"name":…,"kind":"cisco_n9kv","image":…}     <- no startupConfig
```

**Twenty isolated, unconfigured switches.** Nineteen tests passed over the top of it, because the test helper builds a `CableLink` with a hostname in `fromDevice` — a shape `buildCabling` never produces.

## AG1 — three independent causes

1. **Zero links.** `generateLinks` read `cable.fromDevice` as a hostname. It's a human summary like `"16x leaf"`, so the node lookup missed on every cable and `continue` fired each time.
2. **Zero startup configs.** Nodes were matched with `configs[node.hostname]`, but `generateAllConfigs` keys by **BOM id**. `ClabNode` now carries `deviceId`.
3. **The UI downloaded only the YAML.** Even once fixed, the topology referenced `configs/*.cfg` files nothing ever wrote. New `containerlabBundle()` emits one runnable shell script that writes the whole tree via heredocs and runs `clab deploy` — no zip dependency (§21 rule 9).

Links now come from `expandCablePlan` rather than a third expansion, so the lab and the cable schedule describe the same wiring.

## AG2 — the more serious one, found on the way

`expandCablePlan` emitted a full `fromDevs × toDevs` mesh and **ignored `quantity` entirely**. It also feeds the **NetBox DCIM export** — the customer's source of truth.

| adjacency | BOM bills | exported |
|---|---|---|
| spine → leaf | 56 | 56 (coincidence) |
| firewall → leaf | 4 (two border leaves, per Z3) | **28** |
| leaf ↔ leaf peer-link | 14 (7 pairs × 2) | **196** |
| **total** | **74** | **280** |

Every leaf cabled to every other leaf *and to itself*. The spine-leaf match was luck — `4 spines × 14 leaves` happened to equal `14 leaves × 4 uplinks`, and would over-count as soon as `uplinks < spineCount`, which is the Y2 staggered case.

The count is now exactly `link.quantity`, and pair *order* matches how the fabric is really wired: spine-leaf staggered as `closFabricLinks` assigns uplinks, same-layer runs between consecutive HA pair members, everything else in cross-product order.

**Why the existing invariant missed it:** I5 asserts "cable-CSV rows == expanded plan count" — self-consistent, so it can never catch an expansion that is uniformly wrong. The new tests compare against the **BOM**.

## Tests

7 new, all driven from a real `buildDeviceList` + `buildCabling` + `generateAllConfigs` rather than fixtures: links > 0, link count == cables billed, every node configured, every referenced file written, no self-links, no interface used twice, heredoc delimiters balanced. Reverting the config keying trips 2; reverting the quantity cap trips 7.

1436 frontend tests, 407 backend, tsc + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DiH1v2ufYHuupbP4xn6pPb

---
_Generated by [Claude Code](https://claude.ai/code/session_01DiH1v2ufYHuupbP4xn6pPb)_