### PR TITLE
feat: AH1 — icon system, typeface and tab-button redesign

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1294,6 +1294,23 @@ config-gen tests must keep passing; add new tests alongside).
 
 ---
 
+### AH. Visual design pass (user request, 2026-09-04)
+
+> "Improve layout and design like a top enterprise level application with
+> appealing text and font and image for router switches tab buttons."
+>
+> The single thing making the product read as a hobby project was **emoji as
+> iconography** — 14 in the sidebar, 8 on the use-case cards, more in the tab
+> bar and the policy gate. Emoji render differently on every OS, cannot
+> inherit colour, weight or theme, and sit at the wrong optical size next to
+> UI text.
+
+| # | Item | Status | Notes |
+|---|------|--------|-------|
+| AH1 | **Icon system, typeface and tab-button redesign** — (1) new `components/icons/index.tsx`: 30 hand-drawn SVG glyphs, no npm package (§21 rule 9). House style documented in the file header so a new icon matches: 24×24, stroke-based, `currentColor`, 1.5 width, round caps. Includes a **network-device set** — router, switch, spine, leaf, firewall, server, GPU, cloud, cloud-mesh, radio, sites — drawn to be told apart at 16px, where port dots vanish and only the link DIRECTION distinguishes a spine from a leaf. `deviceIcon(subLayer)` and `USE_CASE_ICONS` map BOM/wizard data onto them. (2) **Typeface**: Inter for UI and JetBrains Mono for the configs, CLI blocks and IP addresses that fill this product — a face where `0/O` and `1/l/I` cannot be confused. Both loaded `display=swap` behind a full native fallback. Added a type scale (tracking tightens as size rises), and `tabular-nums` globally so price and port columns line up. (3) **Tab buttons**: the Step 6 bar was a row of underlined words reading as prose; now a segmented control with icons, a solid active pill and a focus ring. (4) Device glyphs in the **BOM Model column**, so a reader can pick the spines out of a 200-row table without reading the Layer column. Icons inherit `currentColor`, so light mode needed no extra work. One test disambiguated two sidebar buttons by the emoji in their text; both sharing one accessible name was a real a11y defect, so the section toggle now names what it does | [x] | `components/icons/index.tsx` (new), `index.css`, `Sidebar.tsx`, `Step1UseCase.tsx`, `Step2Design.tsx`, `Step6Deploy.tsx`, `DemoLoader.tsx`, `NetBoxImportPanel.tsx`; 1456 tests, tsc + build green |
+
+---
+
 ---
 
 ## 23. Autonomous "Start Improving" Mode (2026-06-11 →)

--- a/frontend/src/components/DemoLoader.tsx
+++ b/frontend/src/components/DemoLoader.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { useAppStore } from '@/store/useAppStore'
 import { DEMO_TOPOLOGIES } from '@/data/demoTopologies'
+import { IconDeploy } from '@/components/icons'
 
 const USE_CASE_COLORS: Record<string, string> = {
   dc:         'bg-blue-500/20 text-blue-300 border-blue-500/30',
@@ -45,7 +46,7 @@ export function DemoLoader() {
             : 'bg-white/5 border-white/10 text-gray-400 hover:border-blue-500/30 hover:text-blue-300'
           }`}
       >
-        <span className="text-base">{active ? active.icon : '🚀'}</span>
+        {active ? <span className="text-base">{active.icon}</span> : <IconDeploy size={17} className="shrink-0" />}
         <span className="flex-1 text-left truncate">
           {active ? active.label : 'Load Demo Topology'}
         </span>

--- a/frontend/src/components/NetBoxImportPanel.tsx
+++ b/frontend/src/components/NetBoxImportPanel.tsx
@@ -3,6 +3,7 @@ import { Card } from '@/components/ui/Card'
 import { Button } from '@/components/ui/Button'
 import { useToast } from '@/components/ui/Toast'
 import { useAppStore } from '@/store/useAppStore'
+import { IconLink } from '@/components/icons'
 import {
   fetchNetBoxInventory, summarizeInventory, inventoryToStorePatch, SAMPLE_INVENTORY,
   type NetBoxInventory, type NetBoxImportPreview,
@@ -76,7 +77,11 @@ export function NetBoxImportPanel() {
   return (
     <Card>
       <h3 className="text-sm font-semibold text-gray-300 mb-1">
-        🔗 Import from NetBox / Nautobot <span className="text-gray-500 font-normal">(optional)</span>
+        <span className="inline-flex items-center gap-2">
+          <IconLink size={17} className="text-gray-400" />
+          Import from NetBox / Nautobot
+          <span className="text-gray-500 font-normal">(optional)</span>
+        </span>
       </h3>
       <p className="text-xs text-gray-500 mb-3">
         Connect to your NetBox or Nautobot instance to pre-fill organisation name, sites,

--- a/frontend/src/components/icons/index.tsx
+++ b/frontend/src/components/icons/index.tsx
@@ -1,0 +1,385 @@
+/**
+ * Icon set — hand-drawn SVG, no dependency.
+ *
+ * The UI used emoji for every nav item, use-case card and tab (🎯 📋 🛒 🚀 …).
+ * Emoji render differently on every OS, cannot inherit colour or weight, and
+ * read as a toy next to the rest of the product. §21 rule 9 forbids new UI
+ * packages, so these are drawn here.
+ *
+ * House style, so a new icon looks like the others:
+ *   · 24×24 viewBox, geometry on a 2px grid
+ *   · stroke-based, `currentColor`, 1.5 width, round cap and join
+ *   · no fills except where a solid mass reads better (status dots)
+ *   · optical weight even — a glyph should not be darker than its neighbours
+ */
+import type { SVGProps } from 'react'
+
+export interface IconProps extends SVGProps<SVGSVGElement> {
+  /** Pixel size for both axes. Defaults to 1em so it tracks font-size. */
+  size?: number | string
+}
+
+function Svg({ size = '1em', children, ...rest }: IconProps) {
+  return (
+    <svg
+      width={size} height={size} viewBox="0 0 24 24" fill="none"
+      stroke="currentColor" strokeWidth={1.5}
+      strokeLinecap="round" strokeLinejoin="round"
+      aria-hidden="true" focusable="false"
+      {...rest}
+    >
+      {children}
+    </svg>
+  )
+}
+
+// ── Network devices ─────────────────────────────────────────────────────────
+// Drawn to be told apart at 16px: a router pushes traffic outward, a switch
+// fans ports downward, a spine sits above and a leaf below.
+
+/** Router — chassis with traffic leaving in four directions. */
+export const IconRouter = (p: IconProps) => (
+  <Svg {...p}>
+    <rect x="2.5" y="9" width="19" height="9" rx="2" />
+    <path d="M6 13.5h.01M9.5 13.5h.01M13 13.5h.01" />
+    <path d="M16 6.5 19 3.5M19 3.5h-3M19 3.5v3" />
+    <path d="M19.5 6.5 16.5 3.5M16.5 3.5h3M16.5 3.5v3" opacity=".45" />
+    <path d="M18 18v2.5M6 18v2.5" opacity=".45" />
+  </Svg>
+)
+
+/** Switch — chassis over a row of access ports. */
+export const IconSwitch = (p: IconProps) => (
+  <Svg {...p}>
+    <rect x="2.5" y="6" width="19" height="8" rx="2" />
+    <path d="M6 10h.01M9 10h.01M12 10h.01" />
+    <path d="M17.5 10h2" opacity=".6" />
+    <path d="M6 14v3.5M10 14v3.5M14 14v3.5M18 14v3.5" />
+    <path d="M4.5 17.5h15" opacity=".45" />
+  </Svg>
+)
+
+/** Spine — aggregation switch, links fanning down to the leaves. */
+export const IconSpine = (p: IconProps) => (
+  <Svg {...p}>
+    <rect x="3.5" y="3" width="17" height="6" rx="1.75" />
+    <path d="M7 6h1.5M11.25 6h1.5" opacity=".8" />
+    <path d="M7.5 9.5 4.5 15.5M12 9.5v6M16.5 9.5l3 6" />
+    <path d="M2.5 18.5h4M10 18.5h4M17.5 18.5h4" />
+  </Svg>
+)
+
+/** Leaf — top-of-rack switch with uplinks rising to the spine. */
+export const IconLeaf = (p: IconProps) => (
+  <Svg {...p}>
+    <path d="M7.5 8.5 5 3M12 8.5v-6M16.5 8.5 19 3" />
+    <rect x="3.5" y="9" width="17" height="6" rx="1.75" />
+    <path d="M7 12h1.5M11.25 12h1.5" opacity=".8" />
+    <path d="M6.5 15.5v4M12 15.5v4M17.5 15.5v4" />
+  </Svg>
+)
+
+/** Firewall — brick coursing behind a shield. */
+export const IconFirewall = (p: IconProps) => (
+  <Svg {...p}>
+    <path d="M3 6h18M3 10.5h18M3 15h18" />
+    <path d="M8 6v4.5M16 6v4.5M5.5 10.5V15M12 10.5V15M18.5 10.5V15" opacity=".55" />
+    <path d="M12 8.5 16.5 10v3.6c0 2.4-1.9 4.3-4.5 5.4-2.6-1.1-4.5-3-4.5-5.4V10Z"
+          fill="currentColor" fillOpacity=".14" />
+  </Svg>
+)
+
+/** Server / compute — stacked rack units. */
+export const IconServer = (p: IconProps) => (
+  <Svg {...p}>
+    <rect x="3" y="4" width="18" height="6" rx="1.75" />
+    <rect x="3" y="14" width="18" height="6" rx="1.75" />
+    <path d="M6.5 7h.01M6.5 17h.01" />
+    <path d="M15 7h3M15 17h3" opacity=".55" />
+  </Svg>
+)
+
+/** Cloud gateway. */
+export const IconCloud = (p: IconProps) => (
+  <Svg {...p}>
+    <path d="M7 18.5a4 4 0 0 1-.6-7.96 5.2 5.2 0 0 1 10 -1.2A3.9 3.9 0 0 1 17.5 18.5Z" />
+  </Svg>
+)
+
+/** Radio unit / antenna — O-RAN and wireless. */
+export const IconRadio = (p: IconProps) => (
+  <Svg {...p}>
+    <path d="M12 12.5v8M9 20.5h6" />
+    <circle cx="12" cy="10" r="1.75" />
+    <path d="M8.4 6.4a5 5 0 0 0 0 7.2M15.6 6.4a5 5 0 0 1 0 7.2" />
+    <path d="M5.9 3.9a8.5 8.5 0 0 0 0 12.2M18.1 3.9a8.5 8.5 0 0 1 0 12.2" opacity=".5" />
+  </Svg>
+)
+
+/** WAN edge — globe with a routed path across it. */
+export const IconGlobe = (p: IconProps) => (
+  <Svg {...p}>
+    <circle cx="12" cy="12" r="9" />
+    <path d="M3.2 9.5h17.6M3.2 14.5h17.6" opacity=".6" />
+    <path d="M12 3a15 15 0 0 1 0 18A15 15 0 0 1 12 3Z" />
+  </Svg>
+)
+
+/** Multi-site — two sites joined by a link. */
+export const IconSites = (p: IconProps) => (
+  <Svg {...p}>
+    <rect x="2.5" y="6" width="7" height="12" rx="1.5" />
+    <rect x="14.5" y="6" width="7" height="12" rx="1.5" />
+    <path d="M9.5 12h5" />
+    <path d="M5 9.5h2M5 13h2M17 9.5h2M17 13h2" opacity=".55" />
+  </Svg>
+)
+
+/** Campus building. */
+export const IconBuilding = (p: IconProps) => (
+  <Svg {...p}>
+    <path d="M4 21V5.5A1.5 1.5 0 0 1 5.5 4h7A1.5 1.5 0 0 1 14 5.5V21" />
+    <path d="M14 10h4.5A1.5 1.5 0 0 1 20 11.5V21" />
+    <path d="M2.5 21h19" />
+    <path d="M7 8h.01M11 8h.01M7 12h.01M11 12h.01M7 16h.01M11 16h.01M17 14h.01M17 17.5h.01" />
+  </Svg>
+)
+
+/** GPU / accelerator — die with pins. */
+export const IconGpu = (p: IconProps) => (
+  <Svg {...p}>
+    <rect x="5" y="5" width="14" height="14" rx="2.25" />
+    <rect x="9.25" y="9.25" width="5.5" height="5.5" rx="1"
+          fill="currentColor" fillOpacity=".16" />
+    <path d="M9.5 2.75V5M14.5 2.75V5M9.5 19v2.25M14.5 19v2.25" />
+    <path d="M2.75 9.5H5M2.75 14.5H5M19 9.5h2.25M19 14.5h2.25" />
+  </Svg>
+)
+
+// ── Wizard / navigation ─────────────────────────────────────────────────────
+
+export const IconTarget = (p: IconProps) => (
+  <Svg {...p}>
+    <circle cx="12" cy="12" r="8.5" /><circle cx="12" cy="12" r="4.5" />
+    <circle cx="12" cy="12" r="1" fill="currentColor" />
+  </Svg>
+)
+
+export const IconClipboard = (p: IconProps) => (
+  <Svg {...p}>
+    <path d="M9 4.5H7A1.5 1.5 0 0 0 5.5 6v13A1.5 1.5 0 0 0 7 20.5h10a1.5 1.5 0 0 0 1.5-1.5V6A1.5 1.5 0 0 0 17 4.5h-2" />
+    <rect x="9" y="2.5" width="6" height="4" rx="1.25" />
+    <path d="M8.75 11h6.5M8.75 15h4.5" opacity=".7" />
+  </Svg>
+)
+
+export const IconCatalog = (p: IconProps) => (
+  <Svg {...p}>
+    <rect x="3" y="4" width="18" height="16" rx="2" />
+    <path d="M3 9h18" />
+    <path d="M6.5 13h5M6.5 16.5h8" opacity=".7" />
+    <path d="M16.5 12.5h1.5v4h-1.5z" opacity=".55" />
+  </Svg>
+)
+
+export const IconBlueprint = (p: IconProps) => (
+  <Svg {...p}>
+    <rect x="2.5" y="4.5" width="19" height="15" rx="2" />
+    <path d="M2.5 9h19" opacity=".5" />
+    <circle cx="8" cy="14" r="2" /><circle cx="16.5" cy="12" r="1.5" />
+    <path d="M10 14h4.9M8 12V11" />
+  </Svg>
+)
+
+export const IconCog = (p: IconProps) => (
+  <Svg {...p}>
+    <circle cx="12" cy="12" r="7.25" />
+    <circle cx="12" cy="12" r="2.75" />
+    <path d="M12 2.75v2M12 19.25v2M21.25 12h-2M4.75 12h-2M18.55 5.45l-1.4 1.4M6.85 17.15l-1.4 1.4M18.55 18.55l-1.4-1.4M6.85 6.85l-1.4-1.4" />
+  </Svg>
+)
+
+export const IconDeploy = (p: IconProps) => (
+  <Svg {...p}>
+    <path d="M12 2.5c2.6 2.2 4 5.2 4 8.7v4.3H8v-4.3c0-3.5 1.4-6.5 4-8.7Z" />
+    <circle cx="12" cy="9.5" r="1.75" />
+    <path d="M8 12.5 5.5 15v3l2.5-1.6M16 12.5 18.5 15v3L16 16.4" />
+    <path d="M10.5 18.5 12 21.5l1.5-3" fill="currentColor" fillOpacity=".18" />
+  </Svg>
+)
+
+export const IconSatellite = (p: IconProps) => (
+  <Svg {...p}>
+    <path d="M4.5 19.5 10 14" />
+    <path d="M3 21c1.6-1.1 2.6-2.4 3-3.9L8.9 20c-1.5.4-2.8 1.4-3.9 3Z" fill="currentColor" fillOpacity=".14" />
+    <path d="M12.5 11.5 9 8l3.5-3.5L16 8Z" />
+    <path d="M14.5 15.5A7 7 0 0 0 8.5 9.5" opacity=".55" />
+    <path d="M18.5 18.5A11 11 0 0 0 5.5 5.5" opacity=".4" />
+  </Svg>
+)
+
+export const IconCheckShield = (p: IconProps) => (
+  <Svg {...p}>
+    <path d="M12 2.75 19.5 5.5v6c0 4.2-3.1 7.6-7.5 9.75C7.6 19.1 4.5 15.7 4.5 11.5v-6Z" />
+    <path d="m8.75 11.75 2.4 2.4 4.1-4.6" />
+  </Svg>
+)
+
+export const IconTerminal = (p: IconProps) => (
+  <Svg {...p}>
+    <rect x="2.5" y="4" width="19" height="16" rx="2" />
+    <path d="m6.5 9.5 3 2.5-3 2.5M12.5 15h5" />
+  </Svg>
+)
+
+export const IconChart = (p: IconProps) => (
+  <Svg {...p}>
+    <path d="M3.5 3.5v17h17" />
+    <path d="M7.5 15.5v2M11.5 11v6.5M15.5 13v4.5M19.5 7.5v10" />
+    <path d="m7 10.5 4.5-4 3.5 3 4.5-5" opacity=".55" />
+  </Svg>
+)
+
+export const IconWrench = (p: IconProps) => (
+  <Svg {...p}>
+    <path d="M15.2 3.4a5.5 5.5 0 0 0-6.6 7L3.4 15.6a2 2 0 0 0 2.8 2.8l5.2-5.2a5.5 5.5 0 0 0 7-6.6l-3 3-2.6-2.6Z" />
+    <path d="M6 17h.01" />
+  </Svg>
+)
+
+export const IconStethoscope = (p: IconProps) => (
+  <Svg {...p}>
+    <path d="M6 3v5a4 4 0 0 0 8 0V3" />
+    <path d="M6 3H4.5M14 3h1.5" />
+    <path d="M10 12v2.5a5 5 0 0 0 5 5 4 4 0 0 0 4-4v-1.2" />
+    <circle cx="19" cy="13" r="2" />
+  </Svg>
+)
+
+export const IconBug = (p: IconProps) => (
+  <Svg {...p}>
+    <rect x="7" y="7" width="10" height="12.5" rx="5"
+          fill="currentColor" fillOpacity=".12" />
+    <path d="M9 7a3 3 0 0 1 6 0" />
+    <path d="M12 10.5v6" opacity=".7" />
+    <path d="M7 11H3.5M7 15.5H3.5M17 11h3.5M17 15.5h3.5" />
+    <path d="M9 4 10.75 6M15 4 13.25 6" />
+  </Svg>
+)
+
+export const IconSearch = (p: IconProps) => (
+  <Svg {...p}><circle cx="11" cy="11" r="6.5" /><path d="m16 16 4.5 4.5" /></Svg>
+)
+
+export const IconSave = (p: IconProps) => (
+  <Svg {...p}>
+    <path d="M4.5 4.5h11L19.5 8.5v11a1 1 0 0 1-1 1h-14a1 1 0 0 1-1-1v-14a1 1 0 0 1 1-1Z" />
+    <path d="M8 4.5v5h7v-5M8 20.5v-6h8v6" opacity=".7" />
+  </Svg>
+)
+
+export const IconScroll = (p: IconProps) => (
+  <Svg {...p}>
+    <rect x="4.5" y="3.5" width="15" height="17" rx="2" />
+    <path d="M8 8h8M8 12h8M8 16h5" opacity=".75" />
+  </Svg>
+)
+
+export const IconExport = (p: IconProps) => (
+  <Svg {...p}>
+    <path d="M12 15.5V3.5M12 3.5 8 7.5M12 3.5l4 4" />
+    <path d="M4 14v5a1.5 1.5 0 0 0 1.5 1.5h13A1.5 1.5 0 0 0 20 19v-5" />
+  </Svg>
+)
+
+export const IconLink = (p: IconProps) => (
+  <Svg {...p}>
+    <path d="M10 13.5a4 4 0 0 0 5.7 0l3-3a4 4 0 0 0-5.7-5.7l-1.7 1.7" />
+    <path d="M14 10.5a4 4 0 0 0-5.7 0l-3 3a4 4 0 0 0 5.7 5.7l1.7-1.7" />
+  </Svg>
+)
+
+export const IconApproval = (p: IconProps) => (
+  <Svg {...p}>
+    <rect x="3.5" y="4.5" width="17" height="15" rx="2" />
+    <path d="m8 12.5 2.6 2.6L16.5 9" />
+  </Svg>
+)
+
+export const IconPlug = (p: IconProps) => (
+  <Svg {...p}>
+    <path d="M9 2.5v5M15 2.5v5" />
+    <path d="M6.5 7.5h11v3a5.5 5.5 0 0 1-11 0Z" />
+    <path d="M12 16v5.5" />
+  </Svg>
+)
+
+export const IconUser = (p: IconProps) => (
+  <Svg {...p}>
+    <circle cx="12" cy="8" r="3.75" />
+    <path d="M4.5 20.5a7.5 7.5 0 0 1 15 0" />
+  </Svg>
+)
+
+export const IconSpark = (p: IconProps) => (
+  <Svg {...p}>
+    <path d="M12 3 13.6 8.4 19 10l-5.4 1.6L12 17l-1.6-5.4L5 10l5.4-1.6Z" />
+    <path d="M18.5 3.5v3M20 5h-3" opacity=".7" />
+  </Svg>
+)
+
+/** Satisfied condition. Solid so it reads as a state, not an action. */
+export const IconCheckCircle = (p: IconProps) => (
+  <Svg {...p}>
+    <circle cx="12" cy="12" r="9" fill="currentColor" fillOpacity=".14" />
+    <path d="m8.25 12.25 2.6 2.6 5-5.4" />
+  </Svg>
+)
+
+/** Unsatisfied condition needing attention. */
+export const IconWarnTriangle = (p: IconProps) => (
+  <Svg {...p}>
+    <path d="M12 3.75 21 19.5H3Z" fill="currentColor" fillOpacity=".14" />
+    <path d="M12 9.75v4M12 16.75h.01" />
+  </Svg>
+)
+
+/** Cloud overlay mesh — Aviatrix, as distinct from a plain cloud gateway. */
+export const IconCloudMesh = (p: IconProps) => (
+  <Svg {...p}>
+    <path d="M6.75 12.5a3.25 3.25 0 0 1 .5-6.46 4.4 4.4 0 0 1 8.4-1A3.3 3.3 0 0 1 17 12.5Z" opacity=".85" />
+    <circle cx="6" cy="18.5" r="2" /><circle cx="12" cy="18.5" r="2" /><circle cx="18" cy="18.5" r="2" />
+    <path d="M8 18.5h2M14 18.5h2M12 16.5v-2" />
+  </Svg>
+)
+
+// ── Lookup helpers ──────────────────────────────────────────────────────────
+
+type IconCmp = (p: IconProps) => React.ReactElement
+
+/** BOM sub-layer → device glyph. The point of an icon here is that a reader
+ *  can pick the spines out of a 200-row table without reading the column. */
+const DEVICE_ICONS: Record<string, IconCmp> = {
+  spine: IconSpine, 'gpu-spine': IconSpine, 'super-spine': IconSpine,
+  leaf: IconLeaf, 'gpu-tor': IconLeaf, tor: IconLeaf,
+  access: IconSwitch, distribution: IconSwitch, core: IconSwitch,
+  'wan-edge': IconRouter, 'oran-midhaul': IconRouter, router: IconRouter,
+  firewall: IconFirewall,
+  'gpu-compute': IconGpu, 'oran-cu': IconServer, 'oran-du': IconServer,
+  'oran-core': IconServer, server: IconServer,
+  'oran-ru': IconRadio, 'oran-timing': IconRadio,
+  'oran-fronthaul': IconSwitch,
+  'cloud-gw': IconCloud, 'cloud-transit': IconCloud,
+  'sdwan-controller': IconGlobe,
+}
+
+export function deviceIcon(subLayer: string): IconCmp {
+  return DEVICE_ICONS[subLayer] ?? IconSwitch
+}
+
+/** Use-case → glyph, for the Step 1 cards. */
+export const USE_CASE_ICONS: Record<string, IconCmp> = {
+  campus: IconBuilding, dc: IconServer, gpu: IconGpu, wan: IconGlobe,
+  multisite: IconSites, multicloud: IconCloud, aviatrix: IconCloudMesh,
+  oran: IconRadio,
+}

--- a/frontend/src/components/wizard/Sidebar.tsx
+++ b/frontend/src/components/wizard/Sidebar.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import * as Icons from '@/components/icons'
 import { cn } from '@/lib/utils'
 import { useAppStore } from '@/store/useAppStore'
 import { useAuthStore } from '@/store/useAuthStore'
@@ -24,27 +25,27 @@ interface SidebarProps {
 }
 
 const DESIGN_STEPS = [
-  { step: 1, label: 'Use Case',      icon: '🎯' },
-  { step: 2, label: 'Requirements',  icon: '📋' },
+  { step: 1, label: 'Use Case',      Icon: Icons.IconTarget },
+  { step: 2, label: 'Requirements',  Icon: Icons.IconClipboard },
 ]
 const CONFIG_STEPS = [
-  { step: 3, label: 'Products & BOM',  icon: '🛒' },
-  { step: 4, label: 'Network Design',  icon: '📐' },
-  { step: 5, label: 'Config Gen',      icon: '⚙️' },
+  { step: 3, label: 'Products & BOM',  Icon: Icons.IconCatalog },
+  { step: 4, label: 'Network Design',  Icon: Icons.IconBlueprint },
+  { step: 5, label: 'Config Gen',      Icon: Icons.IconCog },
 ]
 const DEPLOY_STEPS = [
-  { step: 6, label: 'Deploy & Validate', icon: '🚀' },
+  { step: 6, label: 'Deploy & Validate', Icon: Icons.IconDeploy },
 ]
 
 const DEPLOY_SUB_ITEMS = [
-  { tab: 'deploy',   icon: '🚀', label: 'Deploy Pipeline'  },
-  { tab: 'ztp',      icon: '📡', label: 'ZTP Provisioning' },
-  { tab: 'checks',   icon: '✅', label: 'Pre/Post Checks'  },
-  { tab: 'netconf',  icon: '🖧', label: 'NETCONF'          },
-  { tab: 'monitor',  icon: '📊', label: 'Monitoring'       },
-  { tab: 'day2ops',  icon: '⚙️', label: 'Day-2 Ops'       },
-  { tab: 'troubleshoot', icon: '🩺', label: 'Troubleshoot' },
-  { tab: 'batfish',  icon: '🦟', label: 'Batfish Validate' },
+  { tab: 'deploy',       Icon: Icons.IconDeploy,       label: 'Deploy Pipeline'  },
+  { tab: 'ztp',          Icon: Icons.IconSatellite,    label: 'ZTP Provisioning' },
+  { tab: 'checks',       Icon: Icons.IconCheckShield,  label: 'Pre/Post Checks'  },
+  { tab: 'netconf',      Icon: Icons.IconTerminal,     label: 'NETCONF'          },
+  { tab: 'monitor',      Icon: Icons.IconChart,        label: 'Monitoring'       },
+  { tab: 'day2ops',      Icon: Icons.IconWrench,       label: 'Day-2 Ops'        },
+  { tab: 'troubleshoot', Icon: Icons.IconStethoscope,  label: 'Troubleshoot'     },
+  { tab: 'batfish',      Icon: Icons.IconBug,          label: 'Batfish Validate' },
 ]
 
 export function Sidebar({ onGoHome, onShowTroubleshooting, showTroubleshooting, onNavigate, mobileOpen = false, onMobileClose }: SidebarProps) {
@@ -218,7 +219,7 @@ export function Sidebar({ onGoHome, onShowTroubleshooting, showTroubleshooting, 
           {DESIGN_STEPS.map(s => (
             <button key={s.step} onClick={() => closeAndNav(s.step)} className={itemCls(s.step)}
               aria-current={step === s.step ? 'step' : undefined}>
-              <span className="text-base" aria-hidden="true">{s.icon}</span>
+              <s.Icon size={18} className="shrink-0" />
               <span>{s.label}</span>
               {s.step < step && <span className="ml-auto text-xs text-green-500" aria-label="completed">✓</span>}
             </button>
@@ -231,7 +232,7 @@ export function Sidebar({ onGoHome, onShowTroubleshooting, showTroubleshooting, 
           {CONFIG_STEPS.map(s => (
             <button key={s.step} onClick={() => closeAndNav(s.step)} className={itemCls(s.step)}
               aria-current={step === s.step ? 'step' : undefined}>
-              <span className="text-base" aria-hidden="true">{s.icon}</span>
+              <s.Icon size={18} className="shrink-0" />
               <span>{s.label}</span>
               {s.step < step && <span className="ml-auto text-xs text-green-500" aria-label="completed">✓</span>}
             </button>
@@ -242,6 +243,10 @@ export function Sidebar({ onGoHome, onShowTroubleshooting, showTroubleshooting, 
         <nav aria-label="Deploy & Validate" className="px-3 mb-1 mt-3">
           <button onClick={() => setDeployOpen(o => !o)}
             aria-expanded={deployOpen}
+            /* The step button below carries the same visible words, so without
+               a distinct accessible name a screen reader announces two
+               identical "Deploy & Validate" buttons that do different things. */
+            aria-label={`${deployOpen ? 'Collapse' : 'Expand'} Deploy & Validate section`}
             className="flex items-center justify-between w-full text-xs font-bold text-gray-500 uppercase tracking-widest px-3 mb-2 cursor-pointer hover:text-gray-300">
             <span>Deploy & Validate</span>
             <span className={cn('transition-transform', deployOpen ? 'rotate-90' : '')} aria-hidden="true">{deployOpen ? '▼' : '▶'}</span>
@@ -252,7 +257,7 @@ export function Sidebar({ onGoHome, onShowTroubleshooting, showTroubleshooting, 
               {DEPLOY_STEPS.map(s => (
                 <button key={s.step} onClick={() => { onNavigate?.(); setStep(6); setActiveDeployTab('deploy'); onClose?.() }}
                   className={itemCls(s.step)}>
-                  <span className="text-base">{s.icon}</span>
+                  <s.Icon size={18} className="shrink-0" />
                   <span>{s.label}</span>
                   {s.step < step && <span className="ml-auto text-xs text-green-500">✓</span>}
                 </button>
@@ -272,7 +277,7 @@ export function Sidebar({ onGoHome, onShowTroubleshooting, showTroubleshooting, 
                         : 'text-gray-500 hover:bg-white/5 hover:text-gray-300',
                     )}
                   >
-                    <span aria-hidden="true">{sub.icon}</span>
+                    <sub.Icon size={16} className="shrink-0" />
                     <span>{sub.label}</span>
                   </button>
                 ))}
@@ -289,35 +294,35 @@ export function Sidebar({ onGoHome, onShowTroubleshooting, showTroubleshooting, 
               showTroubleshooting
                 ? 'bg-orange-600/20 border border-orange-500/30 text-orange-300 font-semibold'
                 : 'text-gray-400 hover:bg-white/5 hover:text-gray-200')}>
-            <span className="text-base">🔬</span>
+            <Icons.IconSearch size={18} className="shrink-0" />
             <span>Troubleshooting Engine</span>
           </button>
           <button onClick={() => setShowMyDesigns(true)}
             className="flex items-center gap-2.5 w-full px-3 py-2 rounded-lg text-sm transition-colors cursor-pointer text-gray-400 hover:bg-white/5 hover:text-gray-200">
-            <span className="text-base">💾</span>
+            <Icons.IconSave size={18} className="shrink-0" />
             <span>My Designs</span>
           </button>
           {gated('designs:write') && (
             <button onClick={() => setShowConfigPolicy(true)}
               className="flex items-center gap-2.5 w-full px-3 py-2 rounded-lg text-sm transition-colors cursor-pointer text-gray-400 hover:bg-white/5 hover:text-gray-200">
-              <span className="text-base">📜</span>
+              <Icons.IconScroll size={18} className="shrink-0" />
               <span>Config Policy</span>
             </button>
           )}
           <button onClick={() => setShowExport(true)}
             className="flex items-center gap-2.5 w-full px-3 py-2 rounded-lg text-sm transition-colors cursor-pointer text-gray-400 hover:bg-white/5 hover:text-gray-200">
-            <span className="text-base">📤</span>
+            <Icons.IconExport size={18} className="shrink-0" />
             <span>Export</span>
           </button>
           <button onClick={handleShare}
             className="flex items-center gap-2.5 w-full px-3 py-2 rounded-lg text-sm transition-colors cursor-pointer text-gray-400 hover:bg-white/5 hover:text-gray-200">
-            <span className="text-base">🔗</span>
+            <Icons.IconLink size={18} className="shrink-0" />
             <span>{shareCopied ? 'Copied!' : 'Share Design'}</span>
           </button>
           {gated('designs:write') && (
             <button onClick={() => setShowPolicyRules(true)}
               className="flex items-center gap-2.5 w-full px-3 py-2 rounded-lg text-sm transition-colors cursor-pointer text-gray-400 hover:bg-white/5 hover:text-gray-200">
-              <span className="text-base">📋</span>
+              <Icons.IconClipboard size={18} className="shrink-0" />
               <span>Policy Rules</span>
             </button>
           )}
@@ -330,14 +335,14 @@ export function Sidebar({ onGoHome, onShowTroubleshooting, showTroubleshooting, 
             {gated('approvals:read') && (
               <button onClick={() => setShowApprovals(true)}
                 className="flex items-center gap-2.5 w-full px-3 py-2 rounded-lg text-sm transition-colors cursor-pointer text-gray-400 hover:bg-white/5 hover:text-gray-200">
-                <span className="text-base">✅</span>
+                <Icons.IconApproval size={18} className="shrink-0" />
                 <span>Approvals</span>
               </button>
             )}
             {gated('org:admin') && (
               <button onClick={() => setShowIntegrations(true)}
                 className="flex items-center gap-2.5 w-full px-3 py-2 rounded-lg text-sm transition-colors cursor-pointer text-gray-400 hover:bg-white/5 hover:text-gray-200">
-                <span className="text-base">🔌</span>
+                <Icons.IconPlug size={18} className="shrink-0" />
                 <span>Integrations</span>
               </button>
             )}
@@ -365,7 +370,7 @@ export function Sidebar({ onGoHome, onShowTroubleshooting, showTroubleshooting, 
             <button key={s.step} onClick={() => nav(s.step)} title={s.label}
               className={cn('w-8 h-8 rounded-lg text-base flex items-center justify-center cursor-pointer',
                 step === s.step ? 'bg-blue-600/30 text-blue-300' : 'text-gray-500 hover:text-gray-300')}>
-              {s.icon}
+              <s.Icon size={18} />
             </button>
           ))}
           <div className="mt-auto">

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,14 +1,57 @@
 @import "tailwindcss";
 
+/* ── Typeface ────────────────────────────────────────────────────────────────
+   Inter is the de-facto UI face for this class of tool: it was drawn for
+   screen UI at small sizes, its digits line up in tables, and it has the
+   weight range a type scale needs. Loaded with `display=swap` and a full
+   native fallback, so an offline or blocked load renders in the previous
+   system stack rather than a blank page.
+
+   JetBrains Mono carries every device config, CLI block and IP address in the
+   product — those need a face where 0/O and 1/l/I cannot be confused.
+──────────────────────────────────────────────────────────────────────────── */
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap');
+
+@theme {
+  --font-sans: 'Inter', system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+  --font-mono: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
+}
+
 *, *::before, *::after {
   box-sizing: border-box;
 }
 
 body {
   margin: 0;
-  font-family: system-ui, -apple-system, sans-serif;
+  font-family: var(--font-sans);
   -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  /* Inter's own spacing is tuned for display sizes; UI text wants it tighter. */
+  letter-spacing: -0.011em;
+  /* Tabular figures so a column of prices and port counts lines up. */
+  font-variant-numeric: tabular-nums;
 }
+
+/* ── Type scale ──────────────────────────────────────────────────────────────
+   Headings were the same family, weight and tracking as body copy, so a page
+   read as one undifferentiated block. Tightening tracking as size goes up is
+   what makes large text look set rather than scaled.
+──────────────────────────────────────────────────────────────────────────── */
+h1, h2, h3, h4 {
+  font-weight: 600;
+  letter-spacing: -0.022em;
+  line-height: 1.2;
+}
+h1 { letter-spacing: -0.03em; }
+
+code, pre, kbd, samp {
+  font-family: var(--font-mono);
+  font-variant-ligatures: none;
+  letter-spacing: 0;
+}
+
+/* Numeric cells in a data table: fixed-width digits, never proportional. */
+.tabular { font-variant-numeric: tabular-nums; }
 
 #root {
   min-height: 100vh;

--- a/frontend/src/pages/Step1UseCase.tsx
+++ b/frontend/src/pages/Step1UseCase.tsx
@@ -6,17 +6,18 @@ import { Button } from '@/components/ui/Button'
 import { Card } from '@/components/ui/Card'
 import { NetBoxImportPanel } from '@/components/NetBoxImportPanel'
 import { cn } from '@/lib/utils'
+import { USE_CASE_ICONS, IconServer, IconSpark } from '@/components/icons'
 import type { UseCase, OrgSize, BudgetTier } from '@/types'
 
-const USE_CASES: Array<{ id: UseCase; label: string; icon: string; desc: string }> = [
-  { id: 'campus',     icon: '🏢', label: 'Campus',       desc: 'Access/dist/core with PoE, QoS, SDA' },
-  { id: 'dc',         icon: '🖥️',  label: 'Data Centre',  desc: 'Spine-leaf with VXLAN/EVPN BGP' },
-  { id: 'gpu',        icon: '🤖', label: 'GPU Cluster',   desc: 'AI/ML fabric with RoCE & PFC/ECN' },
-  { id: 'wan',        icon: '🌐', label: 'WAN / SD-WAN',  desc: 'Edge routers and SD-WAN gateways' },
-  { id: 'multisite',  icon: '🔗', label: 'Multi-Site',    desc: 'Spine-leaf with WAN interconnect' },
-  { id: 'multicloud', icon: '☁️',  label: 'Multi-Cloud',   desc: 'Cloud transit and spoke gateways' },
-  { id: 'aviatrix',   icon: '🚀', label: 'Aviatrix',      desc: 'Cloud-native Aviatrix overlay mesh' },
-  { id: 'oran',       icon: '📡', label: 'Private 5G',    desc: 'O-RAN with eCPRI fronthaul & PTP timing' },
+const USE_CASES: Array<{ id: UseCase; label: string; desc: string }> = [
+  { id: 'campus',     label: 'Campus',       desc: 'Access/dist/core with PoE, QoS, SDA' },
+  { id: 'dc',         label: 'Data Centre',  desc: 'Spine-leaf with VXLAN/EVPN BGP' },
+  { id: 'gpu',        label: 'GPU Cluster',  desc: 'AI/ML fabric with RoCE & PFC/ECN' },
+  { id: 'wan',        label: 'WAN / SD-WAN', desc: 'Edge routers and SD-WAN gateways' },
+  { id: 'multisite',  label: 'Multi-Site',   desc: 'Spine-leaf with WAN interconnect' },
+  { id: 'multicloud', label: 'Multi-Cloud',  desc: 'Cloud transit and spoke gateways' },
+  { id: 'aviatrix',   label: 'Aviatrix',     desc: 'Cloud-native Aviatrix overlay mesh' },
+  { id: 'oran',       label: 'Private 5G',   desc: 'O-RAN with eCPRI fronthaul & PTP timing' },
 ]
 
 const VENDORS = ['Cisco', 'Arista', 'Juniper', 'NVIDIA', 'Dell EMC', 'HPE Aruba', 'Fortinet', 'Palo Alto', 'Extreme Networks']
@@ -109,7 +110,9 @@ export function Step1UseCase({ onBack }: Props) {
             disabled={!description.trim() || intentParse.isPending || !isLive}
             size="sm"
           >
-            {intentParse.isPending ? 'Parsing…' : '✨ Parse with AI'}
+            {intentParse.isPending ? 'Parsing…' : (
+              <span className="inline-flex items-center gap-1.5"><IconSpark size={15} />Parse with AI</span>
+            )}
           </Button>
           {!isLive && (
             <span className="text-xs text-gray-500">Requires live backend (see Backend Mode toggle)</span>
@@ -152,12 +155,12 @@ export function Step1UseCase({ onBack }: Props) {
               <div className="absolute top-0 left-0 w-full h-0.5 bg-gradient-to-r from-blue-400 via-blue-500 to-blue-600" />
             )}
             <div className={cn(
-              'text-2xl mb-3 w-10 h-10 flex items-center justify-center rounded-lg transition-colors',
+              'mb-3 w-11 h-11 flex items-center justify-center rounded-xl border transition-colors',
               useCase === uc.id
-                ? 'bg-blue-500/20'
-                : 'bg-white/5 group-hover:bg-white/10',
+                ? 'bg-blue-500/15 border-blue-400/40 text-blue-300'
+                : 'bg-white/5 border-white/10 text-gray-400 group-hover:bg-white/10 group-hover:text-gray-200',
             )}>
-              {uc.icon}
+              {(() => { const I = USE_CASE_ICONS[uc.id] ?? IconServer; return <I size={22} /> })()}
             </div>
             <div className={cn(
               'text-sm font-semibold tracking-tight',

--- a/frontend/src/pages/Step2Design.tsx
+++ b/frontend/src/pages/Step2Design.tsx
@@ -11,6 +11,7 @@ import type { BOMSummaryRow } from '@/lib/bom'
 import { Button } from '@/components/ui/Button'
 import { Card } from '@/components/ui/Card'
 import { cn, formatUSD, downloadCSV } from '@/lib/utils'
+import { deviceIcon } from '@/components/icons'
 import { HLDTopologyDiagram } from '@/components/HLDTopologyDiagram'
 import type { CableLink, OpticsEntry } from '@/types'
 
@@ -316,12 +317,23 @@ export function Step2Design() {
     helper.accessor('vendor',   { header: 'Vendor',  cell: i => <span className="text-gray-300">{i.getValue()}</span> }),
     helper.accessor('model',    {
       header: 'Model',
-      cell: i => (
-        <div>
-          <div className="font-medium text-gray-100">{i.getValue()}</div>
-          <div className="text-xs text-gray-500">{i.row.original.detail}</div>
-        </div>
-      ),
+      // The glyph is the point of this cell: it lets a reader pick the spines
+      // out of a 200-row BOM without reading the Layer column.
+      cell: i => {
+        const Glyph = deviceIcon(i.row.original.subLayer)
+        return (
+          <div className="flex items-center gap-3">
+            <span className="shrink-0 w-9 h-9 rounded-lg bg-blue-500/[0.08] border border-blue-400/20
+                             flex items-center justify-center text-blue-300/90">
+              <Glyph size={20} />
+            </span>
+            <div className="min-w-0">
+              <div className="font-medium text-gray-100 truncate">{i.getValue()}</div>
+              <div className="text-xs text-gray-500 truncate">{i.row.original.detail}</div>
+            </div>
+          </div>
+        )
+      },
     }),
     helper.accessor('subLayer', { header: 'Layer',   cell: i => <code className="text-xs text-blue-400">{i.getValue()}</code> }),
     helper.accessor('speed',    { header: 'Speed' }),

--- a/frontend/src/pages/Step6Deploy.tsx
+++ b/frontend/src/pages/Step6Deploy.tsx
@@ -1,4 +1,9 @@
 import React, { useState, useRef, useMemo, useEffect } from 'react'
+import {
+  IconDeploy, IconSatellite, IconCheckShield, IconChart,
+  IconTerminal, IconWrench, IconBug, IconCheckCircle, IconWarnTriangle,
+  type IconProps,
+} from '@/components/icons'
 import { useTopologySummary, useTopologyDevices } from '@/hooks/useTopology'
 import { useRunZTP } from '@/hooks/useZTP'
 import { useRunChecks } from '@/hooks/useChecks'
@@ -2906,14 +2911,14 @@ export function Step6Deploy() {
   const [postResults, setPostResults] = useState<CheckResult[]>([])
 
   // ── Tab bar ───────────────────────────────────────────────────────────────
-  const tabs: Array<{ id: Tab; label: string }> = [
-    { id: 'deploy',  label: 'Deploy Pipeline' },
-    { id: 'ztp',     label: 'ZTP Provisioning' },
-    { id: 'checks',  label: 'Pre / Post Checks' },
-    { id: 'monitor', label: 'Monitoring' },
-    { id: 'netconf', label: 'NETCONF' },
-    { id: 'day2ops', label: 'Day-2 Ops' },
-    { id: 'batfish', label: 'Batfish' },
+  const tabs: Array<{ id: Tab; label: string; Icon: (p: IconProps) => React.ReactElement }> = [
+    { id: 'deploy',  label: 'Deploy Pipeline',   Icon: IconDeploy },
+    { id: 'ztp',     label: 'ZTP Provisioning',  Icon: IconSatellite },
+    { id: 'checks',  label: 'Pre / Post Checks', Icon: IconCheckShield },
+    { id: 'monitor', label: 'Monitoring',        Icon: IconChart },
+    { id: 'netconf', label: 'NETCONF',           Icon: IconTerminal },
+    { id: 'day2ops', label: 'Day-2 Ops',         Icon: IconWrench },
+    { id: 'batfish', label: 'Batfish',           Icon: IconBug },
   ]
 
   return (
@@ -2924,7 +2929,10 @@ export function Step6Deploy() {
       </div>
 
       {/* Tab bar */}
-      <div className="flex gap-0 border-b border-white/10" role="tablist" aria-label="Deploy & Validate sections">
+      <div
+        className="flex gap-1 p-1 rounded-xl bg-white/[0.03] border border-white/10 overflow-x-auto"
+        role="tablist" aria-label="Deploy & Validate sections"
+      >
         {tabs.map(t => (
           <button
             key={t.id}
@@ -2943,12 +2951,21 @@ export function Step6Deploy() {
               if (e.key === 'End') { e.preventDefault(); setTab(tabs[tabs.length - 1].id) }
             }}
             className={cn(
-              'px-5 py-2.5 text-sm font-medium border-b-2 -mb-px transition-colors cursor-pointer',
+              'group flex items-center gap-2 px-3.5 py-2 rounded-lg whitespace-nowrap',
+              'text-[13px] font-medium tracking-[-0.01em] transition-all duration-150 cursor-pointer',
+              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/60',
               tab === t.id
-                ? 'border-blue-500 text-blue-400'
-                : 'border-transparent text-gray-500 hover:text-gray-300',
+                ? 'bg-blue-600 text-white shadow-sm shadow-blue-900/40'
+                : 'text-gray-400 hover:text-gray-100 hover:bg-white/[0.07]',
             )}
           >
+            <t.Icon
+              size={16}
+              className={cn(
+                'shrink-0 transition-opacity',
+                tab === t.id ? 'opacity-100' : 'opacity-70 group-hover:opacity-100',
+              )}
+            />
             {t.label}
           </button>
         ))}
@@ -2967,17 +2984,24 @@ export function Step6Deploy() {
                   policyApproved
                     ? 'bg-green-500/15 border-green-500/40 text-green-300'
                     : 'bg-yellow-500/15 border-yellow-500/40 text-yellow-300')}>
-                  {policyApproved ? '🔒 LOCKED & APPROVED' : '⚠ PENDING APPROVAL'}
+                  <span className="inline-flex items-center gap-1.5">
+                    {policyApproved
+                      ? <IconCheckShield size={14} />
+                      : <IconWarnTriangle size={14} />}
+                    {policyApproved ? 'LOCKED & APPROVED' : 'PENDING APPROVAL'}
+                  </span>
                 </span>
               </div>
               <div className="space-y-1.5 text-xs">
                 <div className="flex items-center gap-2">
-                  <span className="text-green-400">✅</span>
+                  <IconCheckCircle size={16} className="text-green-400 shrink-0" />
                   <span className="text-gray-300">Change window: Business hours (Mon–Fri 06:00–22:00)</span>
                 </div>
                 <div className="flex items-center gap-2">
                   <span className={customPolicyRules ? 'text-green-400' : 'text-yellow-400'}>
-                    {customPolicyRules ? '✅' : '⚠️'}
+                    {customPolicyRules
+                      ? <IconCheckCircle size={16} className="text-green-400 shrink-0" />
+                      : <IconWarnTriangle size={16} className="text-amber-400 shrink-0" />}
                   </span>
                   <span className="text-gray-300">
                     {customPolicyRules ? 'Custom policy rules loaded' : 'Peer review: Required (0 of 1 approver confirmed)'}
@@ -2985,7 +3009,9 @@ export function Step6Deploy() {
                 </div>
                 <div className="flex items-center gap-2">
                   <span className={simDevices.length > 3 ? 'text-yellow-400' : 'text-green-400'}>
-                    {simDevices.length > 3 ? '⚠️' : '✅'}
+                    {simDevices.length > 3
+                      ? <IconWarnTriangle size={16} className="text-amber-400 shrink-0" />
+                      : <IconCheckCircle size={16} className="text-green-400 shrink-0" />}
                   </span>
                   <span className="text-gray-300">
                     Blast radius: {Math.max(simDevices.length, storeDevices.length)} device(s)
@@ -2993,7 +3019,7 @@ export function Step6Deploy() {
                   </span>
                 </div>
                 <div className="flex items-center gap-2">
-                  <span className="text-green-400">✅</span>
+                  <IconCheckCircle size={16} className="text-green-400 shrink-0" />
                   <span className="text-gray-300">Rollback plan: Platform-native checkpoint strategy configured</span>
                 </div>
               </div>
@@ -3047,7 +3073,9 @@ export function Step6Deploy() {
             )}
 
             <Button onClick={handleStartDeploy} disabled={isDeploying || (!deployDone && !policyApproved)}>
-              {isDeploying ? '⏳ Deploying…' : '🚀 Start Deploy'}
+              {isDeploying ? 'Deploying…' : (
+                <span className="inline-flex items-center gap-2"><IconDeploy size={16} />Start Deploy</span>
+              )}
             </Button>
             {!deployDone && !policyApproved && !isDeploying && (
               <span className="text-xs text-yellow-400 italic">Approve policy gate to enable deployment</span>

--- a/frontend/src/test/sidebar-nav.test.tsx
+++ b/frontend/src/test/sidebar-nav.test.tsx
@@ -24,13 +24,19 @@ function renderSidebar(overrides: Partial<Parameters<typeof Sidebar>[0]> = {}) {
   return { onNavigate, onShowTroubleshooting, onGoHome }
 }
 
-/** Click the button whose label text node matches `label` exactly. */
-function clickButtonByLabel(label: string, requireIcon?: string) {
+/** Click the button whose label text node matches `label` exactly.
+ *
+ *  This used to disambiguate the step button from the section toggle by the
+ *  emoji in its text. Nav icons are SVG now, so there is no text to match —
+ *  and the two buttons sharing one accessible name was a real a11y defect,
+ *  not just a testing inconvenience. The toggle now names what it does, so
+ *  filtering it out by accessible name is both stabler and truer. */
+function clickButtonByLabel(label: string) {
   const nodes = screen.getAllByText(label)
-  const btns = nodes.map(n => n.closest('button')).filter(Boolean) as HTMLButtonElement[]
-  const btn = requireIcon ? btns.find(b => b.textContent?.includes(requireIcon)) : btns[0]
-  if (!btn) throw new Error(`No button for label "${label}"`)
-  fireEvent.click(btn)
+  const btns = (nodes.map(n => n.closest('button')).filter(Boolean) as HTMLButtonElement[])
+    .filter(b => !/Collapse|Expand/i.test(b.getAttribute('aria-label') ?? ''))
+  if (!btns.length) throw new Error(`No button for label "${label}"`)
+  fireEvent.click(btns[0])
 }
 
 describe('Sidebar navigation — single-click exit from overlays', () => {
@@ -50,7 +56,7 @@ describe('Sidebar navigation — single-click exit from overlays', () => {
 
   it('clicking the Deploy & Validate step header navigates to step 6 + deploy tab in one click', () => {
     const { onNavigate } = renderSidebar()
-    clickButtonByLabel('Deploy & Validate', '🚀') // the step button, not the group toggle
+    clickButtonByLabel('Deploy & Validate') // the step button, not the section toggle
     expect(onNavigate).toHaveBeenCalledTimes(1)
     expect(useAppStore.getState().step).toBe(6)
     expect(useAppStore.getState().activeDeployTab).toBe('deploy')


### PR DESCRIPTION
> "Improve layout and design like a top enterprise level application with appealing text and font and image for router switches tab buttons."

The single thing making the product read as a hobby project was **emoji as iconography** — 14 in the sidebar, 8 on the use-case cards, more in the tab bar and the policy gate. Emoji render differently on every OS, can't inherit colour, weight or theme, and sit at the wrong optical size next to UI text.

## 1. A real icon set

New `components/icons/index.tsx` — **30 hand-drawn SVG glyphs, no npm package** (§21 rule 9 forbids new UI dependencies). The house style is documented in the file header so the next icon added matches: 24×24, stroke-based, `currentColor`, 1.5 width, round caps.

It includes a proper **network-device set** — router, switch, spine, leaf, firewall, server, GPU, cloud, cloud-mesh, radio, sites — drawn specifically for 16px, where port dots vanish and only the *direction of the links* tells a spine from a leaf. I redrew the gear (it read as a sun), the rocket (a lightbulb) and the chip after seeing them rendered at size.

## 2. Device images in the BOM

`deviceIcon(subLayer)` puts the right glyph in the **Model column**, so a reader can pick the spines out of a 200-row table without reading the Layer column.

## 3. Typography

**Inter** for UI, **JetBrains Mono** for the configs, CLI blocks and IP addresses that fill this product — a face where `0/O` and `1/l/I` can't be confused. Both load `display=swap` behind a full native fallback, so a blocked font renders in the previous stack rather than nothing.

Plus a type scale that tightens tracking as size rises, and `tabular-nums` globally so price and port columns line up.

## 4. Tab buttons

The Step 6 bar was a row of underlined words that read as prose. It's now a segmented control with icons, a solid active pill and a focus ring.

## Verified visually

I ran the app and screenshotted each surface rather than guessing — that's how I caught the sun-shaped gear and the lightbulb-shaped rocket. Icons inherit `currentColor`, so **light mode needed no extra work**.

## One test change worth flagging

A sidebar test told two buttons apart by the emoji in their text. Both carrying the same accessible name was a **real a11y defect** — a screen reader announced two identical "Deploy & Validate" buttons doing different things — so the section toggle now names what it does, and the test filters on that.

1456 tests, tsc + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DiH1v2ufYHuupbP4xn6pPb

---
_Generated by [Claude Code](https://claude.ai/code/session_01DiH1v2ufYHuupbP4xn6pPb)_