### PR TITLE
fix: AI1 — SNMP exporter no longer inherits the gNMI target filter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1294,6 +1294,24 @@ config-gen tests must keep passing; add new tests alongside).
 
 ---
 
+### AI. Monitoring coverage (sourced 2026-09-07)
+
+> Found while sweeping for more AG5–AG10-class silent gaps. The Monitoring tab
+> hands the operator a gnmic collector config and an SNMP exporter config, and
+> both are built from **one** target list that filters out anything without a
+> gNMI server *and* every firewall. So the SNMP exporter — the universal
+> fallback, which exists precisely for boxes that cannot stream — excludes
+> exactly the devices it should cover.
+>
+> Measured on generated designs: **every** design loses both firewalls from
+> both configs (a Cisco DC monitors 12 of 14). An Extreme Networks DC design
+> monitors **0 of 14**. A Fortinet campus design monitors **0 of 18**. Nothing
+> in the UI says so, so the fleet looks monitored.
+
+| # | Item | Status | Notes |
+|---|------|--------|-------|
+| AI1 | **The SNMP exporter inherited the gNMI filter, so it omitted exactly the devices it exists to cover** — `genSNMPExporterConfig` and `genSNMPPrometheusJob` both called `buildTelemetryTargets`, which drops anything without a gNMI server *and* every firewall. Measured before the fix: **every** design lost both firewalls from **both** configs (a Cisco DC monitored 12 of 14); an **Extreme Networks DC design monitored 0 of 14**, and a **Fortinet campus design 0 of 18** — with nothing in the UI saying so, so the fleet looked monitored. Split into `buildTelemetryTargets` (gNMI: excludes firewalls, whose NOSes expose management APIs rather than an OpenConfig server, and anything `speaksGnmi` rejects) and new `buildSnmpTargets` (every network element — SNMP is universal; only compute/host tiers are out of scope, and they are named). New `telemetryCoverage(devices)` → `{gnmi, snmpOnly, excluded, unmonitored}` drives a coverage line in the Monitoring tab's Observability Downloads card: how many stream, how many are SNMP-polled only and which NOSes those are, and a red chip if anything lands in **no** collector. 5 tests including a 5-vendor × 3-use-case sweep asserting `unmonitored` is empty everywhere; reverting the SNMP target list trips 1 | [x] | `lib/telemetry-gen.ts` `buildSnmpTargets`/`telemetryCoverage`/`SNMP_PORT`/`HOST_SUBLAYERS`, `Step6Deploy.tsx`; `telemetry-gen.test.ts` 29→34; 1501 tests, tsc + build green |
+
 ### AH. Visual design pass (user request, 2026-09-04)
 
 > "Improve layout and design like a top enterprise level application with

--- a/frontend/src/lib/telemetry-gen.ts
+++ b/frontend/src/lib/telemetry-gen.ts
@@ -99,31 +99,107 @@ export interface TelemetryTarget {
   role:     string
 }
 
-/** Expand BOM devices (capped at 4 instances each) into per-device gNMI targets. */
-export function buildTelemetryTargets(devices: BOMDevice[]): TelemetryTarget[] {
+/** Compute/host tiers — not network elements, so out of scope for both collectors. */
+const HOST_SUBLAYERS = new Set(['gpu-compute'])
+
+/** SNMP is universal: every network element has an agent, firewalls included. */
+export const SNMP_PORT = 161
+
+function expand(
+  devices: BOMDevice[],
+  pick: (dev: BOMDevice) => { os: string; port: number } | null,
+): TelemetryTarget[] {
   const targets: TelemetryTarget[] = []
   let octet = 11
   for (const dev of devices) {
-    if (dev.subLayer === 'firewall' || dev.subLayer === 'gpu-compute') continue
-    const os = deviceOS(dev)
-    // Excluded rather than mislabelled: a target the collector cannot speak
-    // to is worse than an absent one, because it looks monitored (AG6).
-    if (!speaksGnmi(os)) continue
-    const port = GNMI_PORT[os]
+    if (HOST_SUBLAYERS.has(dev.subLayer)) continue
+    const hit = pick(dev)
+    if (!hit) continue
     const count = Math.min(dev.count, 4)
     for (let i = 1; i <= count; i++) {
       targets.push({
         name:     `${dev.hostname}-${String(i).padStart(2, '0')}`,
         hostname: dev.hostname,
         mgmtIp:   `10.0.0.${octet}`,
-        port,
-        os,
+        port:     hit.port,
+        os:       hit.os,
         role:     dev.subLayer,
       })
       octet++
     }
   }
   return targets
+}
+
+/**
+ * Per-device gNMI targets (BOM rows expanded, capped at 4 instances each).
+ *
+ * Firewalls are excluded: the catalogue's firewall NOSes (PAN-OS, FortiOS,
+ * Cisco FTD) expose management APIs rather than an OpenConfig gNMI server, so
+ * a gnmic target for one would never connect. They are picked up by SNMP —
+ * see `buildSnmpTargets`.
+ */
+export function buildTelemetryTargets(devices: BOMDevice[]): TelemetryTarget[] {
+  return expand(devices, dev => {
+    if (dev.subLayer === 'firewall') return null
+    const os = deviceOS(dev)
+    // Excluded rather than mislabelled: a target the collector cannot speak
+    // to is worse than an absent one, because it looks monitored (AG6).
+    if (!speaksGnmi(os)) return null
+    return { os, port: GNMI_PORT[os] }
+  })
+}
+
+/**
+ * Per-device SNMP targets — AI1.
+ *
+ * This used to reuse `buildTelemetryTargets`, so the SNMP exporter config
+ * inherited the gNMI filter AND the firewall exclusion: the universal
+ * fallback, which exists precisely for boxes that cannot stream, omitted
+ * exactly the devices it should cover. Measured before the fix, EVERY design
+ * lost both firewalls from both configs; an Extreme Networks DC design
+ * monitored 0 of 14 devices, and a Fortinet campus design 0 of 18 — with
+ * nothing in the UI saying so, so the fleet looked monitored.
+ */
+export function buildSnmpTargets(devices: BOMDevice[]): TelemetryTarget[] {
+  return expand(devices, dev => ({ os: deviceOS(dev), port: SNMP_PORT }))
+}
+
+export interface TelemetryCoverage {
+  /** Devices streaming to the gnmic collector. */
+  gnmi: TelemetryTarget[]
+  /** Devices reachable only by SNMP polling (no gNMI server). */
+  snmpOnly: TelemetryTarget[]
+  /** Hostnames deliberately out of scope (compute/host tiers). */
+  excluded: string[]
+  /** Hostnames in NEITHER collector — must always be empty; a bug if not. */
+  unmonitored: string[]
+}
+
+/**
+ * How each device in a design is actually monitored, so the UI can say it.
+ * `unmonitored` is the invariant that matters: a device in no collector looks
+ * monitored to an operator reading a dashboard.
+ */
+export function telemetryCoverage(devices: BOMDevice[]): TelemetryCoverage {
+  const gnmi = buildTelemetryTargets(devices)
+  const snmp = buildSnmpTargets(devices)
+  const gnmiHosts = new Set(gnmi.map(t => t.hostname))
+  const snmpHosts = new Set(snmp.map(t => t.hostname))
+  const excluded: string[] = []
+  const unmonitored: string[] = []
+  for (const dev of devices) {
+    if (HOST_SUBLAYERS.has(dev.subLayer)) { excluded.push(dev.hostname); continue }
+    if (!gnmiHosts.has(dev.hostname) && !snmpHosts.has(dev.hostname)) {
+      unmonitored.push(dev.hostname)
+    }
+  }
+  return {
+    gnmi,
+    snmpOnly: snmp.filter(t => !gnmiHosts.has(t.hostname)),
+    excluded,
+    unmonitored,
+  }
 }
 
 // ══════════════════════════════════════════════════════════════════════════
@@ -594,7 +670,7 @@ const SNMP_MODULES: Array<{ name: string; walk: string[]; lookups?: string[]; co
 ]
 
 export function genSNMPExporterConfig(devices: BOMDevice[]): string {
-  const targets = buildTelemetryTargets(devices)
+  const targets = buildSnmpTargets(devices)
   const deviceList = targets.map(t => `#   ${t.hostname} (${t.os}) — ${t.mgmtIp}:161`)
   const lines: string[] = [
     '# ═══════════════════════════════════════════════════════════════',
@@ -649,7 +725,7 @@ export function genSNMPExporterConfig(devices: BOMDevice[]): string {
 }
 
 export function genSNMPPrometheusJob(devices: BOMDevice[]): string {
-  const targets = buildTelemetryTargets(devices)
+  const targets = buildSnmpTargets(devices)
   const targetIps = targets.map(t => `        - ${t.mgmtIp}  # ${t.hostname}`)
 
   const lines: string[] = [

--- a/frontend/src/pages/Step6Deploy.tsx
+++ b/frontend/src/pages/Step6Deploy.tsx
@@ -20,7 +20,7 @@ import { useBackendMode } from '@/components/BackendToggle'
 import { TopologyDiagram } from '@/components/TopologyDiagram'
 import { formatUptime } from '@/lib/utils'
 import { cn } from '@/lib/utils'
-import { genGNMICCollectorConfig, genTelegrafGNMIConfig, genPrometheusAlertRules, genGrafanaDashboardJSON, genSNMPExporterConfig, genSNMPPrometheusJob } from '@/lib/telemetry-gen'
+import { genGNMICCollectorConfig, genTelegrafGNMIConfig, genPrometheusAlertRules, genGrafanaDashboardJSON, genSNMPExporterConfig, genSNMPPrometheusJob, telemetryCoverage } from '@/lib/telemetry-gen'
 import { useTroubleshoot } from '@/hooks/useTroubleshoot'
 import { runComplianceScan, exportComplianceReport } from '@/lib/compliance-scan'
 import type { ComplianceScanResult } from '@/lib/compliance-scan'
@@ -2741,6 +2741,8 @@ export function Step6Deploy() {
   // and default the selector to a platform the fleet actually has rather than
   // a hardcoded 'nxos'.
   const tsCoverage = useMemo(() => troubleshootCoverage(storeDevices), [storeDevices])
+  // AI1 — how the generated collector configs actually cover this fleet.
+  const telCoverage = useMemo(() => telemetryCoverage(storeDevices), [storeDevices])
   const [tsPlatform, setTsPlatform] = useState<string>(tsCoverage.suggested)
   const tsPlatformPinned = useRef(false)
   useEffect(() => {
@@ -4551,6 +4553,33 @@ export function Step6Deploy() {
               SNMP exporter config, Logstash Grok patterns, NetFlow/sFlow, gNMI collector configs,
               Prometheus alert rules, and Grafana dashboard — all derived from your BOM device list.
             </p>
+
+            {/* AI1 — say how each device is covered. Streaming telemetry and SNMP
+                polling reach different parts of the fleet, and a device in
+                neither looks monitored to anyone reading a dashboard. */}
+            {(telCoverage.gnmi.length > 0 || telCoverage.snmpOnly.length > 0) && (
+              <div className="mb-4 flex flex-wrap items-center gap-2 text-[11px]">
+                <span className="text-gray-500">Coverage:</span>
+                <span className="px-2 py-0.5 rounded bg-emerald-500/15 text-emerald-300 font-semibold tabular-nums">
+                  {new Set(telCoverage.gnmi.map(t => t.hostname)).size} streaming (gNMI)
+                </span>
+                <span className="px-2 py-0.5 rounded bg-blue-500/15 text-blue-300 font-semibold tabular-nums">
+                  {new Set(telCoverage.snmpOnly.map(t => t.hostname)).size} SNMP-polled only
+                </span>
+                {telCoverage.snmpOnly.length > 0 && (
+                  <span className="text-gray-500">
+                    — no gNMI server on {[...new Set(telCoverage.snmpOnly.map(t => t.os))].join(', ')};
+                    they are in <code className="text-gray-400">snmp.yml</code>, not{' '}
+                    <code className="text-gray-400">gnmic.yml</code>
+                  </span>
+                )}
+                {telCoverage.unmonitored.length > 0 && (
+                  <span className="px-2 py-0.5 rounded bg-red-500/15 text-red-300 font-semibold">
+                    {telCoverage.unmonitored.length} in NO collector: {telCoverage.unmonitored.slice(0, 4).join(', ')}
+                  </span>
+                )}
+              </div>
+            )}
             <div className="flex flex-wrap gap-3">
               <Button variant="secondary" size="sm"
                 onClick={() => { downloadBlob('snmp.yml', genSNMPExporterConfig(storeDevices)); showToast('snmp.yml downloaded', 'success') }}>

--- a/frontend/src/test/telemetry-gen.test.ts
+++ b/frontend/src/test/telemetry-gen.test.ts
@@ -7,6 +7,8 @@ import {
   genGrafanaDashboardJSON,
   genSNMPExporterConfig,
   genSNMPPrometheusJob,
+  buildSnmpTargets,
+  telemetryCoverage,
   GNMI_PORT,
   speaksGnmi,
 } from '@/lib/telemetry-gen'
@@ -332,5 +334,57 @@ describe('AG6 — telemetry targets name the real NOS', () => {
     for (const vendor of ['Fortinet', 'Palo Alto', 'Extreme Networks']) {
       for (const t of build(vendor).targets) expect(speaksGnmi(t.os)).toBe(true)
     }
+  })
+})
+
+
+// ── AI1: SNMP must not inherit the gNMI filter ───────────────────────────────
+describe('telemetry coverage (AI1)', () => {
+  it('puts every network device in at least one collector', () => {
+    // Before the fix, genSNMPExporterConfig reused buildTelemetryTargets, so
+    // the universal fallback inherited the gNMI filter AND the firewall
+    // exclusion. EVERY design lost both firewalls from both configs; an
+    // Extreme DC design monitored 0 of 14 devices.
+    for (const prefs of [['Cisco'], ['Palo Alto'], ['Fortinet'], ['Extreme Networks'], ['Nokia']]) {
+      for (const uc of ['dc', 'campus', 'gpu'] as const) {
+        const devices = buildDeviceList({ useCase: uc, scale: 'medium', siteCode: 'T', vendorPrefs: prefs })
+        const cov = telemetryCoverage(devices)
+        expect(cov.unmonitored, `${prefs[0]}/${uc}`).toEqual([])
+      }
+    }
+  })
+
+  it('includes firewalls in the SNMP exporter config', () => {
+    const devices = buildDeviceList({ useCase: 'dc', scale: 'medium', siteCode: 'T' })
+    const fw = devices.filter(d => d.subLayer === 'firewall')
+    expect(fw.length, 'guard: the fixture must contain firewalls').toBeGreaterThan(0)
+    const snmp = genSNMPExporterConfig(devices)
+    for (const d of fw) expect(snmp).toContain(d.hostname)
+  })
+
+  it('keeps firewalls OUT of the gNMI collector', () => {
+    // PAN-OS / FortiOS / FTD expose management APIs, not an OpenConfig gNMI
+    // server — a gnmic target for one would never connect.
+    const devices = buildDeviceList({ useCase: 'dc', scale: 'medium', siteCode: 'T' })
+    const gnmi = genGNMICCollectorConfig(devices)
+    for (const d of devices.filter(x => x.subLayer === 'firewall')) {
+      expect(gnmi).not.toContain(d.hostname)
+    }
+  })
+
+  it('gives every SNMP target port 161 and every gNMI target its real port', () => {
+    const devices = buildDeviceList({ useCase: 'dc', scale: 'medium', siteCode: 'T' })
+    for (const t of buildSnmpTargets(devices)) expect(t.port).toBe(161)
+    for (const t of buildTelemetryTargets(devices)) expect(t.port).toBe(GNMI_PORT[t.os])
+  })
+
+  it('reports an all-SNMP fleet as SNMP-only rather than as covered', () => {
+    // Extreme EXOS has no gNMI server at all — the operator must be able to
+    // see that nothing in this design streams.
+    const devices = buildDeviceList({ useCase: 'campus', scale: 'medium', siteCode: 'T', vendorPrefs: ['Extreme Networks'] })
+    const cov = telemetryCoverage(devices)
+    expect(cov.gnmi).toEqual([])
+    expect(cov.snmpOnly.length).toBeGreaterThan(0)
+    expect(cov.unmonitored).toEqual([])
   })
 })


### PR DESCRIPTION
## The bug

`genSNMPExporterConfig` and `genSNMPPrometheusJob` both called `buildTelemetryTargets`, which drops anything without a gNMI server **and** every firewall. So the universal fallback — the thing that exists precisely for boxes that cannot stream — omitted exactly the devices it should cover.

Measured on generated designs, **before**:

| Design | In gNMI | In SNMP | **In neither** |
|---|---|---|---|
| Cisco DC | 12 | 12 | **2** (both firewalls) |
| Cisco campus | 16 | 16 | **2** (both firewalls) |
| Palo Alto DC | 12 | 12 | **2** |
| Fortinet campus | 0 | 0 | **18 of 18** |
| Extreme Networks DC | 0 | 0 | **14 of 14** |

Nothing in the UI said so, so the fleet looked monitored — the same failure class as AG6 ("a target the collector cannot speak to is worse than an absent one, because it looks monitored"), one level up.

**After**: `unmonitored` is empty for every vendor × use case tested.

## The change

- `buildTelemetryTargets` keeps the gNMI rules — firewalls stay out, because the catalogue's firewall NOSes (PAN-OS, FortiOS, Cisco FTD) expose management APIs rather than an OpenConfig gNMI server, so a gnmic target for one would never connect.
- New `buildSnmpTargets` covers every network element. SNMP is universal; only compute/host tiers are out of scope, and they are named rather than silently dropped.
- New `telemetryCoverage(devices)` → `{gnmi, snmpOnly, excluded, unmonitored}` drives a coverage line in the Monitoring tab's Observability Downloads card: how many stream, how many are SNMP-polled only and which NOSes those are, and a red chip if anything lands in **no** collector.

## Tests

5 new (`telemetry-gen.test.ts` 29→34), including a 5-vendor × 3-use-case sweep asserting `unmonitored` is empty everywhere, and a guard that the firewall fixture actually contains firewalls so the assertion cannot pass vacuously.

Reverting the SNMP target list trips 1. 1501 tests pass · `tsc --noEmit` clean · `npm run build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DiH1v2ufYHuupbP4xn6pPb

---
_Generated by [Claude Code](https://claude.ai/code/session_01DiH1v2ufYHuupbP4xn6pPb)_