### PR TITLE
fix: AJ1 — SSH hardening on every fabric device, and a compliance control that checks them all

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1312,6 +1312,27 @@ config-gen tests must keep passing; add new tests alongside).
 |---|------|--------|-------|
 | AI1 | **The SNMP exporter inherited the gNMI filter, so it omitted exactly the devices it exists to cover** — `genSNMPExporterConfig` and `genSNMPPrometheusJob` both called `buildTelemetryTargets`, which drops anything without a gNMI server *and* every firewall. Measured before the fix: **every** design lost both firewalls from **both** configs (a Cisco DC monitored 12 of 14); an **Extreme Networks DC design monitored 0 of 14**, and a **Fortinet campus design 0 of 18** — with nothing in the UI saying so, so the fleet looked monitored. Split into `buildTelemetryTargets` (gNMI: excludes firewalls, whose NOSes expose management APIs rather than an OpenConfig server, and anything `speaksGnmi` rejects) and new `buildSnmpTargets` (every network element — SNMP is universal; only compute/host tiers are out of scope, and they are named). New `telemetryCoverage(devices)` → `{gnmi, snmpOnly, excluded, unmonitored}` drives a coverage line in the Monitoring tab's Observability Downloads card: how many stream, how many are SNMP-polled only and which NOSes those are, and a red chip if anything lands in **no** collector. 5 tests including a 5-vendor × 3-use-case sweep asserting `unmonitored` is empty everywhere; reverting the SNMP target list trips 1 | [x] | `lib/telemetry-gen.ts` `buildSnmpTargets`/`telemetryCoverage`/`SNMP_PORT`/`HOST_SUBLAYERS`, `Step6Deploy.tsx`; `telemetry-gen.test.ts` 29→34; 1501 tests, tsc + build green |
 
+### AJ. Management-plane SSH hardening (sourced 2026-09-07)
+
+> Found by measuring the compliance scanner per vendor rather than trusting its
+> score. Arista/NVIDIA/Dell/Extreme DC designs failed PCI-2.3 and FDRP-AC-17
+> ("SSH v2 only — no Telnet") where Cisco/Juniper/Nokia passed — the M4/AG5
+> "one vendor set over" signature. Reading the generated configs showed the
+> **score was the least of it**.
+>
+> Per-device, on a DC design: **Cisco 4 of 14** devices have any SSH hardening;
+> **Arista, NVIDIA and Dell EMC 0 of 14**. The NX-OS *spine* emits
+> `ssh version 2` and the *leaf* emits nothing; Arista's spine has
+> `management ssh` and its leaf nothing; Cumulus and OS10 have none at either
+> role. Campus is fine (16–18 of 18), so this is specifically the fabric.
+>
+> And the scanner hid it: the control uses `hasInConfigs` (**any one** device),
+> so a Cisco DC with 4 of 14 hardened reported **PASS** on "SSH v2 only".
+
+| # | Item | Status | Notes |
+|---|------|--------|-------|
+| AJ1 | **The fabric had no SSH hardening, and the scanner said it did** — two coupled defects, so fixed together. (a) **Real config gap**: the NX-OS *spine* emitted `ssh version 2` and the *leaf* emitted **nothing**; Arista's spine had `management ssh` and its leaf nothing; NVIDIA Cumulus and Dell OS10 had none at either role. Per-device on a DC design: **Cisco 4 of 14**, **Arista / NVIDIA / Dell EMC 0 of 14** (campus was fine, so the gap was specifically the fabric — the "fix landed on one role, one vendor" signature). New shared `sshHardeningBlock(family)` — one block per CLI family rather than five inline copies, since a duplicated management plane is what drifted in the first place — wired into all five generators, with Telnet stated **explicitly** (`no feature telnet` / `no management telnet` / `no ip telnet server enable`) rather than left to the platform default: an auditor reads the config, not the default, and the explicit line is what stops a later change re-enabling it. Now 14/14 on every vendor × use case. (b) **The scanner hid it**: PCI-2.3 and FDRP-AC-17 used `hasInConfigs` (**any one** device), so a Cisco DC with 4 of 14 hardened reported a clean **PASS** on "SSH v2 only — no Telnet". New `everyDeviceHas()` — `pass` only at full coverage, `warn` with the count and the first offenders named, `fail` at zero. And `RE_SSH_V2` was Cisco/Juniper/Nokia-only (M3/M4/AG5 signature again), missing Arista `management ssh`, Extreme `enable ssh2`, Cumulus NVUE, Dell `ip ssh server` and the FTD `configure ssh-access-list` (Firepower has no `ip ssh version 2` — the access-list *is* the control). The compliance score was vendor-dependent (Cisco/Juniper/Nokia 60, Arista/NVIDIA/Extreme 53, Dell 50); it is now identical across vendors, and honestly so. 8 tests incl. a 7-vendor × 3-use-case sweep and a partial-coverage case; reverting either half trips 5 and 1 | [x] | `lib/configgen.ts` `sshHardeningBlock`/`SshFamily` + nxos/arista spine+leaf, cumulus, dellos10; `lib/compliance-scan.ts` `everyDeviceHas`/`RE_SSH_V2`; `configgen.test.ts` 250→254, `compliance-scan.test.ts` 29→33; 1509 tests, tsc + build green |
+
 ### AH. Visual design pass (user request, 2026-09-04)
 
 > "Improve layout and design like a top enterprise level application with

--- a/frontend/src/lib/compliance-scan.ts
+++ b/frontend/src/lib/compliance-scan.ts
@@ -34,7 +34,13 @@ type ControlChecker = (state: AppState, configs: Record<string, string>, devices
 //                 Juniper `protocol-version v2`, Nokia `ssh-server`
 //   Syslog:       Cisco `logging host`, Juniper `syslog`, Nokia `logging {` / `remote-server`
 //   NTP:          Cisco/Juniper `ntp server`, Nokia `ntp {`
-const RE_SSH_V2 = /transport\s+input\s+ssh|ssh\s+version\s+2|protocol-version\s+v2|ssh-server/i
+// AJ1 — widened again, and for the same reason M3/M4/AG5 kept recurring: the
+// detector knew Cisco/Juniper/Nokia spellings only, so Arista `management ssh`,
+// Extreme `enable ssh2`, Cumulus NVUE `ssh-server state enabled`, Dell OS10
+// `ip ssh server` and the FTD `configure ssh-access-list` (Firepower has no
+// `ip ssh version 2` — SSH is on and the access-list is the control) were all
+// read as "no SSH", producing false PCI-2.3 / FDRP-AC-17 failures.
+const RE_SSH_V2 = /transport\s+input\s+ssh|ssh\s+version\s+2|protocol-version\s+v2|ssh-server|enable\s+ssh2|management\s+ssh|ip\s+ssh\s+server|configure\s+ssh-access-list/i
 const RE_SYSLOG = /logging\s+(?:server|host|remote)|syslog|remote-server|logging\s*\{/i
 const RE_NTP = /ntp\s+server|ntp\s+source|ntp\s*\{/i
 
@@ -45,6 +51,37 @@ function hasInConfigs(configs: Record<string, string>, pattern: RegExp): boolean
 function allConfigsHave(configs: Record<string, string>, pattern: RegExp): boolean {
   const vals = Object.values(configs)
   return vals.length > 0 && vals.every(c => pattern.test(c))
+}
+
+/**
+ * Per-device coverage of a control — AJ1.
+ *
+ * `hasInConfigs` asks whether ANY ONE device matches, which is the wrong
+ * question for a control phrased "on all devices". Measured before this
+ * existed: a Cisco DC design with SSH hardening on 4 of 14 devices reported a
+ * clean PASS on PCI-2.3 "SSH v2 only — no Telnet". A compliance report that
+ * says compliant while 10 of 14 devices are not is worse than no report.
+ *
+ * Returns a control fragment: `pass` only at full coverage, `warn` when some
+ * devices are covered (with the count and the first few offenders named, so
+ * the gap is actionable), `fail` at zero, `na` with no configs.
+ */
+function everyDeviceHas(
+  configs: Record<string, string>,
+  pattern: RegExp,
+  labels: { pass: string; partial: string; fail: string },
+): { status: ComplianceStatus; detail: string } {
+  const entries = Object.entries(configs)
+  if (entries.length === 0) return { status: 'na', detail: 'No configs generated yet' }
+  const missing = entries.filter(([, cfg]) => !pattern.test(cfg)).map(([host]) => host)
+  const covered = entries.length - missing.length
+  if (missing.length === 0) return { status: 'pass', detail: labels.pass }
+  const named = missing.slice(0, 3).join(', ')
+  const more = missing.length > 3 ? ` +${missing.length - 3} more` : ''
+  const where = ` — ${covered}/${entries.length} devices; missing on ${named}${more}`
+  return covered === 0
+    ? { status: 'fail', detail: labels.fail + where }
+    : { status: 'warn', detail: labels.partial + where }
 }
 
 const PCI_CONTROLS: ControlChecker[] = [
@@ -67,11 +104,11 @@ const PCI_CONTROLS: ControlChecker[] = [
   (_state, configs) => ({
     id: 'PCI-2.3', framework: 'PCI', category: 'Encryption',
     requirement: 'SSH v2 only — no Telnet',
-    ...hasInConfigs(configs, RE_SSH_V2)
-      ? { status: 'pass', detail: 'SSH v2 enforced in device configs' }
-      : Object.values(configs).length === 0
-        ? { status: 'na', detail: 'No configs generated yet' }
-        : { status: 'fail', detail: 'SSH v2 enforcement not found in configs' },
+    ...everyDeviceHas(configs, RE_SSH_V2, {
+      pass:    'SSH v2 enforced on every device',
+      partial: 'SSH v2 not enforced on every device',
+      fail:    'SSH v2 enforcement not found in configs',
+    }),
   }),
   (_state, configs) => ({
     id: 'PCI-6.1', framework: 'PCI', category: 'Logging',
@@ -212,11 +249,11 @@ const FEDRAMP_CONTROLS: ControlChecker[] = [
   (_state, configs) => ({
     id: 'FDRP-AC-17', framework: 'FedRAMP', category: 'Remote Access',
     requirement: 'Remote access via encrypted channel only',
-    ...hasInConfigs(configs, RE_SSH_V2)
-      ? { status: 'pass', detail: 'SSH v2 only for remote management' }
-      : Object.values(configs).length === 0
-        ? { status: 'na', detail: 'No configs generated yet' }
-        : { status: 'fail', detail: 'Ensure SSH v2 only for all remote access' },
+    ...everyDeviceHas(configs, RE_SSH_V2, {
+      pass:    'SSH v2 only for remote management on every device',
+      partial: 'Encrypted remote access not enforced on every device',
+      fail:    'Ensure SSH v2 only for all remote access',
+    }),
   }),
   (_state) => ({
     id: 'FDRP-CM-6', framework: 'FedRAMP', category: 'Configuration',

--- a/frontend/src/lib/configgen.ts
+++ b/frontend/src/lib/configgen.ts
@@ -17,6 +17,67 @@ import { applyPolicies } from '@/lib/policies'
 // ── Shared helpers ─────────────────────────────────────────────────────────────
 
 /** Single management block used exactly once per config. */
+/**
+ * Management-plane SSH hardening — AJ1.
+ *
+ * Measured on generated DC designs before this existed: only 4 of 14 Cisco
+ * devices had ANY ssh statement, and Arista / NVIDIA / Dell EMC had 0 of 14.
+ * The NX-OS spine emitted `ssh version 2` while the leaf emitted nothing, and
+ * the same spine/leaf split existed on Arista — the "fix landed on one role /
+ * one vendor" signature this codebase keeps paying for. Campus was fine, so
+ * the gap was specifically the fabric.
+ *
+ * One helper per CLI family rather than five inline copies: a duplicated
+ * management plane is exactly what drifted in the first place.
+ *
+ * Telnet is stated EXPLICITLY rather than left to the platform default. On
+ * NX-OS and OS10 the daemon is off unless a feature is enabled, but an
+ * auditor reads the config, not the default — and `no feature telnet` is
+ * also what stops someone re-enabling it in a later change.
+ */
+export type SshFamily = 'nxos' | 'eos' | 'nvue' | 'dellos10'
+
+export function sshHardeningBlock(family: SshFamily, srcIface = ''): string {
+  switch (family) {
+    case 'nxos':
+      return `! ── SSH / REMOTE ACCESS (AJ1) ───────────────────────────────────────────────
+no feature telnet
+feature ssh
+ssh version 2
+ssh key rsa 2048 force
+ip ssh source-interface ${srcIface || 'mgmt0'}
+line vty
+  exec-timeout 10
+  session-limit 4
+!`
+    case 'eos':
+      return `! ── SSH / REMOTE ACCESS (AJ1) ───────────────────────────────────────────────
+no management telnet
+management ssh
+  idle-timeout 10
+  authentication mode password
+  no shutdown
+  vrf MGMT
+    no shutdown
+!`
+    case 'nvue':
+      return `# ── SSH / REMOTE ACCESS (AJ1) ───────────────────────────────────────────────
+nv set system ssh-server state enabled
+nv set system ssh-server permit-root-login no
+nv set system ssh-server password-authentication yes
+nv set system ssh-server vrf mgmt
+#`
+    case 'dellos10':
+      return `! ── SSH / REMOTE ACCESS (AJ1) ───────────────────────────────────────────────
+no ip telnet server enable
+ip ssh server enable
+ip ssh server version 2
+ip ssh server vrf management
+ip ssh server login-grace-time 60
+!`
+  }
+}
+
 function mgmtBlock(hostname: string, mgmtVlan = 10): string {
   return `
 ! ── MANAGEMENT ──────────────────────────────────────────────────────────────────
@@ -226,9 +287,7 @@ ntp source-interface mgmt0
 logging server <CHANGE-ME-syslog-ip> 6 use-vrf management
 logging source-interface mgmt0
 !
-ssh version 2
-ip ssh source-interface mgmt0
-!
+${sshHardeningBlock('nxos')}
 ! ── MANAGEMENT VRF ───────────────────────────────────────────────────────────
 vrf context management
   ip route 0.0.0.0/0 <CHANGE-ME-oob-gateway>
@@ -946,6 +1005,7 @@ ntp source-interface mgmt0
 !
 logging server <CHANGE-ME-syslog-ip> 6 use-vrf management
 !
+${sshHardeningBlock('nxos')}
 ! ── MANAGEMENT VRF ───────────────────────────────────────────────────────────
 vrf context management
   ip route 0.0.0.0/0 <CHANGE-ME-oob-gateway>
@@ -1528,10 +1588,7 @@ ntp source vrf MGMT Management1
 logging vrf MGMT host <CHANGE-ME-syslog-ip>
 logging vrf MGMT source-interface Management1
 !
-management ssh
-  idle-timeout 10
-  authentication mode password
-!
+${sshHardeningBlock('eos')}
 ! ── MANAGEMENT INTERFACE (OOB, dedicated VRF) ───────────────────────────────
 vrf instance MGMT
 !
@@ -1714,6 +1771,7 @@ ntp source vrf MGMT Management1
 logging vrf MGMT host <CHANGE-ME-syslog-ip>
 logging vrf MGMT source-interface Management1
 !
+${sshHardeningBlock('eos')}
 ! ── MANAGEMENT INTERFACE (OOB, dedicated VRF) ───────────────────────────────
 vrf instance MGMT
 !
@@ -3688,6 +3746,7 @@ snmp-server host <CHANGE-ME-nms-ip> traps version 3 priv netmon
 ! ── Syslog ──────────────────────────────────────────────────────────────────
 logging server <CHANGE-ME-syslog-ip>
 !
+${sshHardeningBlock('dellos10')}
 ! ── LLDP ────────────────────────────────────────────────────────────────────
 lldp enable
 !
@@ -3947,6 +4006,7 @@ nv set service syslog mgmt server <CHANGE-ME-syslog-ip> port 514
 nv set service snmp-server enable on
 nv set service snmp-server username netmon auth-sha <CHANGE-ME-snmp-auth-pass> encrypt-aes <CHANGE-ME-snmp-priv-pass>
 
+${sshHardeningBlock('nvue')}
 # ── LOOPBACK / FABRIC PORTS (jumbo MTU for RoCE/VXLAN payloads) ──────────────
 nv set interface lo ip address ${lo0ip}/32
 nv set interface swp1-${ports} link mtu 9216

--- a/frontend/src/test/compliance-scan.test.ts
+++ b/frontend/src/test/compliance-scan.test.ts
@@ -277,3 +277,82 @@ describe('exportComplianceReport', () => {
     })
   })
 })
+
+
+// ── AJ1: the SSH control is per-device, and vendor-aware ─────────────────────
+describe('SSH controls are per-device (AJ1)', () => {
+  const SSH_CONTROLS = ['PCI-2.3', 'FDRP-AC-17']
+
+  function scan(vendor: string, useCase: 'dc' | 'campus' = 'dc') {
+    const devices = buildDeviceList({ useCase, scale: 'medium', siteCode: 'T', vendorPrefs: [vendor] })
+    const configs = generateAllConfigs(devices, useCase)
+    return runComplianceScan({
+      ...BASE_STATE,
+      useCase, devices, configs, vendorPrefs: [vendor],
+      compliance: ['PCI', 'FedRAMP'] as never,
+    } as never)
+  }
+
+  it('passes for every vendor now that the configs actually comply', () => {
+    // Before AJ1 these FAILED for Arista, NVIDIA, Dell EMC and Extreme while
+    // Cisco/Juniper/Nokia passed — the M3/M4/AG5 "one vendor set over"
+    // signature, distorting the score by vendor (53 vs 60).
+    for (const v of ['Cisco', 'Arista', 'Juniper', 'Nokia', 'NVIDIA', 'Dell EMC', 'Extreme Networks']) {
+      const r = scan(v)
+      for (const id of SSH_CONTROLS) {
+        const c = r.controls.find(x => x.id === id)
+        expect(c, `${v} ${id} missing`).toBeTruthy()
+        expect(c!.status, `${v} ${id}: ${c!.detail}`).toBe('pass')
+      }
+    }
+  })
+
+  it('does NOT report a pass when only some devices are hardened', () => {
+    // The control used `hasInConfigs` (any ONE device), so a Cisco DC design
+    // with SSH on 4 of 14 devices reported a clean PASS on "SSH v2 only".
+    // A report that says compliant while 10 of 14 devices are not is worse
+    // than no report.
+    const devices = buildDeviceList({ useCase: 'dc', scale: 'medium', siteCode: 'T' })
+    const configs = generateAllConfigs(devices, 'dc')
+    const hosts = Object.keys(configs)
+    expect(hosts.length, 'guard: no configs generated').toBeGreaterThan(3)
+    // Strip SSH from all but one device.
+    const holed: Record<string, string> = {}
+    hosts.forEach((h, i) => {
+      holed[h] = i === 0 ? configs[h] : configs[h].replace(/ssh/gi, 'xxx')
+    })
+    const r = runComplianceScan({
+      ...BASE_STATE, useCase: 'dc', devices, configs: holed,
+      compliance: ['PCI', 'FedRAMP'] as never,
+    } as never)
+    for (const id of SSH_CONTROLS) {
+      const c = r.controls.find(x => x.id === id)!
+      expect(c.status, `${id} must not pass on partial coverage`).not.toBe('pass')
+      // and it must be actionable — name the count and an offender
+      expect(c.detail).toMatch(/1\/\d+ devices/)
+      expect(c.detail).toMatch(/missing on /)
+    }
+  })
+
+  it('fails outright when no device is hardened', () => {
+    const devices = buildDeviceList({ useCase: 'dc', scale: 'medium', siteCode: 'T' })
+    const configs = generateAllConfigs(devices, 'dc')
+    const stripped = Object.fromEntries(
+      Object.entries(configs).map(([h, c]) => [h, c.replace(/ssh/gi, 'xxx')]),
+    )
+    const r = runComplianceScan({
+      ...BASE_STATE, useCase: 'dc', devices, configs: stripped,
+      compliance: ['PCI', 'FedRAMP'] as never,
+    } as never)
+    for (const id of SSH_CONTROLS) {
+      expect(r.controls.find(x => x.id === id)!.status).toBe('fail')
+    }
+  })
+
+  it('the score no longer depends on which vendor was chosen', () => {
+    const scores = ['Cisco', 'Arista', 'Juniper', 'Nokia', 'NVIDIA', 'Extreme Networks']
+      .map(v => scan(v).score)
+    // Before AJ1: Cisco/Juniper/Nokia 60, Arista/NVIDIA/Extreme 53.
+    expect(new Set(scores).size, `scores: ${scores.join(',')}`).toBe(1)
+  })
+})

--- a/frontend/src/test/configgen.test.ts
+++ b/frontend/src/test/configgen.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { generateConfig, generateAllConfigs, isFtdModel } from '@/lib/configgen'
+import { buildDeviceList } from '@/lib/bom'
 import type { BOMDevice } from '@/types'
 
 function makeDevice(overrides: Partial<BOMDevice> = {}): BOMDevice {
@@ -2344,5 +2345,67 @@ describe('Final Z5b remainders (J3-3 / J3-8 / N3-4)', () => {
       makeDevice({ id: 'l1', hostname: 'H-LEAF-A01', vendor: 'NVIDIA', subLayer: 'leaf', role: 'leaf', ports: 64, uplinks: 8 }),
     ] as BOMDevice[], 'campus')
     expect(dc['l1'] ?? '').not.toMatch(/mlnx_qos/)
+  })
+})
+
+
+// ── AJ1: management-plane SSH hardening on every fabric device ───────────────
+describe('SSH management-plane hardening (AJ1)', () => {
+  const RE_SSH = /transport\s+input\s+ssh|ssh\s+version\s+2|protocol-version\s+v2|ssh-server|enable\s+ssh2|management\s+ssh|ip\s+ssh\s+server|configure\s+ssh-access-list/i
+
+  it('every device in every vendor x use-case design has SSH hardening', () => {
+    // Measured before this landed: Cisco DC had it on 4 of 14 devices, and
+    // Arista / NVIDIA / Dell EMC on 0 of 14 — the NX-OS spine emitted
+    // `ssh version 2` while the leaf emitted nothing, and Arista had the same
+    // spine/leaf split. Campus was fine, so the gap was specifically the fabric.
+    const vendors = ['Cisco', 'Arista', 'Juniper', 'Nokia', 'NVIDIA', 'Dell EMC', 'Extreme Networks']
+    for (const vendor of vendors) {
+      for (const uc of ['dc', 'campus', 'gpu'] as const) {
+        const devices = buildDeviceList({ useCase: uc, scale: 'medium', siteCode: 'T', vendorPrefs: [vendor] })
+        const configs = generateAllConfigs(devices, uc)
+        const missing = devices.filter(d => !RE_SSH.test(configs[d.id] ?? ''))
+        expect(missing.map(d => `${d.hostname}(${d.vendor})`), `${vendor}/${uc}`).toEqual([])
+      }
+    }
+  })
+
+  it('states Telnet explicitly rather than relying on a platform default', () => {
+    // An auditor reads the config, not the default — and the explicit line is
+    // also what stops a later change quietly re-enabling it.
+    const cases: Array<[string, RegExp]> = [
+      ['Cisco', /no feature telnet/],
+      ['Arista', /no management telnet/],
+      ['Dell EMC', /no ip telnet server enable/],
+      ['Extreme Networks', /disable telnet/],
+    ]
+    for (const [vendor, re] of cases) {
+      const devices = buildDeviceList({ useCase: 'dc', scale: 'medium', siteCode: 'T', vendorPrefs: [vendor] })
+      const configs = generateAllConfigs(devices, 'dc')
+      const fabric = devices.filter(d => d.subLayer === 'spine' || d.subLayer === 'leaf')
+      expect(fabric.length, `guard: ${vendor} produced no fabric devices`).toBeGreaterThan(0)
+      for (const d of fabric) expect(configs[d.id], `${vendor} ${d.hostname}`).toMatch(re)
+    }
+  })
+
+  it('emits one shared block per CLI family rather than five inline copies', () => {
+    // The gap existed because the management plane was written out per
+    // generator and the copies drifted. Spine and leaf must now agree.
+    for (const vendor of ['Cisco', 'Arista', 'NVIDIA', 'Dell EMC']) {
+      const devices = buildDeviceList({ useCase: 'dc', scale: 'medium', siteCode: 'T', vendorPrefs: [vendor] })
+      const configs = generateAllConfigs(devices, 'dc')
+      const spine = devices.find(d => d.subLayer === 'spine')!
+      const leaf = devices.find(d => d.subLayer === 'leaf')!
+      const grab = (cfg: string) => (cfg.match(/SSH \/ REMOTE ACCESS[\s\S]*?\n[!#]\n/) ?? [''])[0]
+      expect(grab(configs[spine.id]), vendor).toBe(grab(configs[leaf.id]))
+      expect(grab(configs[spine.id]).length, `${vendor}: no shared block found`).toBeGreaterThan(0)
+    }
+  })
+
+  it('keeps every credential a placeholder', () => {
+    const devices = buildDeviceList({ useCase: 'dc', scale: 'medium', siteCode: 'T' })
+    const configs = generateAllConfigs(devices, 'dc')
+    for (const cfg of Object.values(configs)) {
+      expect(cfg).not.toMatch(/password\s+(?!<CHANGE-ME)[A-Za-z0-9!@#$%]{6,}/)
+    }
   })
 })


### PR DESCRIPTION
Two coupled defects, found by measuring the compliance scanner **per vendor** instead of trusting its score. Arista/NVIDIA/Dell/Extreme failed PCI-2.3 where Cisco/Juniper/Nokia passed — the familiar "one vendor set over" signature. Reading the generated configs showed the score was the least of it.

## (a) The fabric genuinely had no SSH hardening

| | spine | leaf |
|---|---|---|
| NX-OS | `ssh version 2` | **nothing** |
| Arista EOS | `management ssh` | **nothing** |
| NVIDIA Cumulus | **nothing** | **nothing** |
| Dell OS10 | **nothing** | **nothing** |

Per device on a DC design: **Cisco 4 of 14**, **Arista / NVIDIA / Dell EMC 0 of 14**. Campus was fine (16–18 of 18), so the gap was specifically the fabric — the same "the fix landed on one role, one vendor" pattern that produced X1, Y1 and Z1.

New shared `sshHardeningBlock(family)` covering nxos / eos / nvue / dellos10, wired into all five generators. **One block per CLI family, not five inline copies** — a duplicated management plane is precisely what drifted here in the first place.

Telnet is now stated **explicitly** (`no feature telnet`, `no management telnet`, `no ip telnet server enable`) rather than left to the platform default. On NX-OS and OS10 the daemon is off unless a feature is enabled, but an auditor reads the config, not the default — and the explicit line is also what stops a later change quietly re-enabling it.

After: **14/14 on every vendor × use case.**

## (b) The scanner was hiding it

`PCI-2.3` and `FDRP-AC-17` used `hasInConfigs` — **any one** device. So a Cisco DC design with SSH on 4 of 14 devices reported a clean **PASS** on *"SSH v2 only — no Telnet"*. A compliance report that says compliant while 10 of 14 devices are not is worse than no report.

New `everyDeviceHas()`: `pass` only at full coverage, `warn` with the count and the first offenders named so the gap is actionable, `fail` at zero.

`RE_SSH_V2` was also Cisco/Juniper/Nokia-only (M3/M4/AG5 again), missing Arista `management ssh`, Extreme `enable ssh2`, Cumulus NVUE, Dell `ip ssh server`, and the FTD `configure ssh-access-list` — Firepower has no `ip ssh version 2`, the access-list *is* the control, so the fix is to teach the detector rather than invent CLI for the device.

**Score before:** Cisco/Juniper/Nokia 60, Arista/NVIDIA/Extreme 53, Dell 50 — i.e. it measured which vendor you picked. **After:** identical across all seven, and honestly so.

## Tests

8 new, including a 7-vendor × 3-use-case sweep asserting every device is hardened, a partial-coverage case asserting the control does *not* pass, and a check that spine and leaf emit the *same* block so the two cannot drift apart again. Reverting the config half trips 5; reverting the scanner half trips 1.

1509 frontend / 456 backend tests pass · `tsc --noEmit` clean · `npm run build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DiH1v2ufYHuupbP4xn6pPb

---
_Generated by [Claude Code](https://claude.ai/code/session_01DiH1v2ufYHuupbP4xn6pPb)_